### PR TITLE
MockSoql API Revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Mocking queries by passing the records to be returned (as shown above) should wo
 ```java
 public class MySimulator implements MockSoql.Simulator {
   // This implementation generates a List<Opportunity> with random values
-  public Object simulateQuery() {
+  public Object simulateQuery(Soql queryToMock) {
     Integer numOpps = Integer.valueOf(Math.random() * 200);
     List<Opportunity> opps = new List<Opportunity>();
     for (Integer i = 0; i < numOpps; i++) {

--- a/README.md
+++ b/README.md
@@ -126,22 +126,46 @@ List<User> users = soql?.query();
 ```
 
 In apex tests, you can mock all of your query operations by calling `DatabaseLayer.useMocks()`. This will automatically substitute real `Soql` objects with a `MockSoql` object.
-By default, `MockSoql` objects will return an empty list of results. You can inject mock results for each query set using the `setMock()` method:
+By default, `MockSoql` objects will return an empty list of results. You can inject mock results for each query set using the `setGlobalMock` and `setMock` methods:
 
 ```java
 DatabaseLayer.useMocks();
-Account account = new Account(Name = 'Test Account');
-MockSoql soql = DatabaseLayer.newQuery(Account.SObjectType);
-soql?.setMock(new List<Account>{ account });
-List<Account> results = (List<Account>) soql?.query();
+Account mockAccount = new Account(Name = 'Test Account');
+// Note: The setGlobalMock static method injects mock results for all queries
+// If you want to mock a specific query, use the setMock member method instead
+MockSoql.setGlobalMock()?.withResults(new List<Account>{ mockAccount });
+List<Account> results = (List<Account>) DatabaseLayer.newQuery(Account.SObjectType)?.query();
 Assert.areEqual(1, results?.size(), 'Wrong # of results');
 ```
 
-Mocking queries by passing the records to be returned (as shown above) should work for most use cases. If needed, you can implement your own custom logic by creating a class that implements the `MockSoql.Simulator` interface:
+You can also simulate query errors via the `withError()` method:
 
 ```java
+DatabaseLayer.useMocks();
+// Note: The setMock member method injects mock results for the specified queries
+// If you want to mock all queries w/out needing to assign a mock to each,
+// use the setGlobalMock static method instead
+MockSoql myQuery = DatabaseLayer.newQuery(Account.SObjectType);
+myQuery?.setMock()?.withError();
+
+try {
+  myQuery?.query();
+  Assert.fail('Did not throw an exception');
+} catch (System.QueryException error) {
+  // As expected
+}
+```
+
+Mocking queries by passing the records to be returned, or errors to be thrown (as shown above) should work for most use cases. If needed, you can implement your own custom logic via the `MockSoql.Simulator` interface:
+
+```java
+DatabaseLayer.useMocks();
+MockSoql.Simulator simulator = new MySimulator();
+MockSoql.setGlobalMock(simulator);
+List<Opportunity> opps = DatabaseLayer.Soql.newQuery(Opportunity.SObjectType)?.query();
+
 public class MySimulator implements MockSoql.Simulator {
-  // This implementation generates a List<Opportunity> with random values
+  // This implementation generates a List<Opportunity> w/random values
   public Object simulateQuery(Soql queryToMock) {
     Integer numOpps = Integer.valueOf(Math.random() * 200);
     List<Opportunity> opps = new List<Opportunity>();
@@ -152,30 +176,6 @@ public class MySimulator implements MockSoql.Simulator {
     }
     return opps;
   }
-}
-```
-
-You can pass that object to the `setMock()` method, as shown below:
-
-```java
-DatabaseLayer.useMocks();
-MockSoql.Simulator simulator = new MySimulator();
-MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Opportunity.SObjectType);
-soql?.setMock(simulator);
-List<Opportunity> opps = soql?.query();
-```
-
-You can also simulate query errors via the `setError()` method:
-
-```java
-DatabaseLayer.useMocks();
-MockSoql soql = DatabaseLayer.newQuery(Account.SObjectType);
-soql?.setError();
-try {
-  soql?.query();
-  Assert.fail('Did not throw an exception');
-} catch (Exception error) {
-  // As expected
 }
 ```
 

--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -60,15 +60,16 @@ List<Account> results = soql?.query();
 Assert.areEqual(0, results?.size(), 'Wrong # of resuls');
 ```
 
-For these queries to return actual results, developers must first inject logic via either the static [`setGlobalMock`](#the-setglobalmock-static-methods) method, or the member [`setMock`](#the-setmock-methods) method.
+For these queries to return actual results, developers must first inject logic via either the static [`setGlobalMock`](#the-setglobalmock-static-method) method, or the member [`setMock`](#the-setmock-method) method.
 
 Both methods have two overloads - one which accepts and returns a [`MockSoql.Simulator`](#the-mocksoqlsimulator-interface) object, and a 0-argument overlaod which returns a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object.
 
-#### The `setGlobalMock` Static Methods
+<details>
+  <summary><h4>The <code>setGlobalMock</code> Static Method</h4></summary>
 
-This method assigns "default" query logic to _all_ `Soql` objects. This allows developers to inject mocks for queries without the need to expose those queries as `@TestVisible`, class-level variables.
+This method assigns "default" query logic to _all_ `Soql` objects. This allows developers to inject mocks for queries without the need to expose those objects as `@TestVisible`, class-level variables.
 
-The 0-argument version of this method injects a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object, and returns that same object. You can use that object's `withResults` to inject a static `List<Object>`, or its `withError` method to inject a static `Exception` to be thrown.
+The 0-argument version of this method injects a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object, and returns that same object. You can use that object's `withResults` to inject a static `List<Object>` to be returned, or its `withError` method to inject a static `Exception` to be thrown.
 
 ```java
 DatabaseLayer.useMocks();
@@ -84,11 +85,16 @@ MockSoql.Simulator simulator = new MyCustomQueryLogic();
 MockSoql.setGlobalMock(simulator);
 ```
 
-#### The `setMock` Methods
+-   `MockSoql.Simulator static setGlobalMock(MockSoql.Simulator simulator)`
+-   `MockSoql.StaticResults static setGlobalMock()`
+</details>
+
+<details>
+  <summary><h4>The <code>setMock</code> Method</h4></summary>
 
 This method assigns query logic to a _specific_ `Soql` object, overriding any global defaults set via `MockSoql.setGlobalMock`. In a real-world scenario, queries in a production class **must** be exposed as public/`@TestVisible` variables to use this method.
 
-The 0-argument version of this method injects a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object, and returns that same object. You can use that object's `withResults` to inject a static `List<Object>`, or its `withError` method to inject a static `Exception` to be thrown.
+The 0-argument version of this method injects a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object, and returns that same object. You can use that object's `withResults` to inject a static `List<Object>` to be returned, or its `withError` method to inject a static `Exception` to be thrown.
 
 ```java
 DatabaseLayer.useMocks();
@@ -106,9 +112,15 @@ MockSoql queryToMock = (MockSoql) MyClass.SOME_QUERY;
 queryToMock?.setMock(simulator);
 ```
 
-#### The `MockSoql.Simulator` Interface
+-   `MockSoql.Simulator setMock(MockSoql.Simulator simulator)`
+-   `MockSoql.StaticResults setMock()`
 
-The `MockSoql.Simulator` interface defines custom logic for returning query results. Use this interface when you need more complex logic than what the [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) can provide.
+</details>
+
+<details> 
+  <summary><h4>The <code>MockSoql.Simulator</code> Interface</h4></summary>
+
+The `MockSoql.Simulator` interface defines custom logic for returning query results. Use this interface when you need more complex logic than what [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) can provide.
 
 The interface has one required method:
 
@@ -149,15 +161,18 @@ private class CustomQueryLogic implements MockSoql.Simulator {
 }
 ```
 
-#### The `MockSoql.StaticResults` Class
+</details>
+
+<details>
+  <summary><h4>The <code>MockSoql.StaticResults</code> Class</h4></summary>
 
 Not all testing scenarios require the creation of a custom `MockSoql.Simulator` object. Most simple use cases can be handled by using the included `MockSoql.StaticResults` object.
 
-This object cannot be directly constructed. Create an instance of this object by calling the 0-argument versions of the [`MockSoql.setGlobalMock`](#the-setglobalmock-static-methods) static method, or the [`setMock`](#the-setmock-methods) member method.
+This object cannot be directly constructed. Create an instance of this object by calling the 0-argument versions of the [`MockSoql.setGlobalMock`](#the-setglobalmock-static-method) static method, or the [`setMock`](#the-setmock-method) member method.
 
 This object implements `MockSoql.Simulator` interface, and includes methods which allow callers to inject a static list of results, or an exception to be thrown. Whenever the query runs, the injected results are returned.
 
-##### `withError`
+<h5><code>withError</code></h5>
 
 Injects an error to be thrown each time the query runs. Callers can provide a specific exception object, if desired. The 0-argument overload of this method will inject a generic `System.QueryException`.
 
@@ -173,7 +188,7 @@ System.Exception someOtherError = new System.CalloutException();
 MockSoql.setGlobalMock()?.withError(someOtherError);
 ```
 
-##### `withResults`
+<h5><code>withResults</code></h5>
 
 Injects a static list of results. This list will be returned each time the query runs.
 
@@ -186,7 +201,35 @@ Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.withId()?.t
 MockSoql.setGlobalMock()?.withResults(new List<Account>{ mockAccont });
 ```
 
-### Mocking Query Locators
+</details>
+
+### Special Considerations
+
+<details>
+  <summary><h4>Mocking Aggregate Queries</h4></summary>
+
+`MockSoql.AggregateResult` is a A constructable version of the `Soql.AggregateResult` class, which wraps the `Schema.AggregateResult` class and its methods. `Schema.AggregateResult` objects cannot be directly constructed, serialized, or otherwise mocked.
+
+You can use this object along in conjunction with existing mocking methods to inject these results in queries. For example:
+
+```java
+DatabaseLayer.useMocks();
+MockSoql.AggregateResult agg = new MockSoql.AggregateResult()?.addParameter('numRecords', 100);
+MockSoql?.setGlobalMock()?.withResults(new List<MockSoql.AggregateResult>{ agg });
+List<Soql.AggregateResult> results = soql?.aggregateQuery();
+```
+
+<h5>addParameter</h5>
+
+Adds a column to the current `AggregateResult`. These can be created with or without an _alias_. If an alias isn't provided, the column is assigned a default alias, ex. `expr0'`. This mirrors the behavior of the underlying `Schema.AggregateResult` object.
+
+-   `MockSoql.AggregateResult addParameter(String alias, Object value)`
+-   `MockSoql.AggregateResult addParameter(Object value)`
+
+</details>
+
+<details>
+  <summary><h4>Mocking Query Locators</h4></summary>
 
 The `Database.QueryLocator` object cannot be mocked in a traditional sense, since it manually constructed, or JSON-deserialized. The only way to create an object of this type is by directly interacting with the Salesforce database, via the `Database.getQueryLocator` method.
 
@@ -244,36 +287,6 @@ Developers can employ one of the following strategies to work around this:
 -   Have your unit tests call the batch's `start`, `execute`, and `finish` methods invidually.
 -   Amend the `start` method to return an [iterable object](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_iterable.htm) instead.
 -   Use `System.Queueable` jobs paired with a `System.Finalizer` instead of `Database.Batchable`.
-
-<details>
-  <summary><h4>The <code>MockSoql.AggregateResult</code> Class</h4></summary>
-
-A constructable version of the `Soql.AggregateResult` class, which wraps the `Schema.AggregateResult` class and its methods. `Schema.AggregateResult` objects cannot be directly constructed, serialized, or otherwise mocked.
-
-Use this object in conjunction with the `setMock` method, or the `MockSoql.Simulator` interface to inject results for aggregate queries. For example:
-
-```java
-DatabaseLayer.useMocks();
-String alias = 'numRecords';
-Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT, Account.Id)
-  ?.withAlias(alias);
-MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
-  ?.addSelect(count);
-MockSoql.AggregateResult agg = new MockSoql.AggregateResult()
-  ?.addParameter(alias, 100);
-soql?.setMock(new List<MockSoql.AggregateResult>{ agg });
-List<Soql.AggregateResult> results = soql?.aggregateQuery();
-Assert.areEqual(1, results?.size(), 'Wrong # of results');
-Assert.areEqual(100, results?.get(0)?.get(alias), 'Wrong count');
-```
-
-#### `addParameter`
-
-Adds a column to the current `AggregateResult`. These can be created with or without an _alias_. If an alias isn't provided, the column is assigned a default alias, ex. `expr0'`. This mirrors the behavior of the underlying `Schema.AggregateResult` object.
-
--   `MockSoql.AggregateResult addParameter(String alias, Object value)`
--   `MockSoql.AggregateResult addParameter(Object value)`
-
 </details>
 
 ---
@@ -427,6 +440,33 @@ Selects all fields from the specified entity by querying the schema for all avai
 Sets the logical operator (AND/OR) for combining HAVING conditions.
 
 -   `Soql.Builder setOuterHavingLogic(Soql.LogicType newLogicType)`
+
+#### `setQueryIdentifier`
+
+Assigns an identifier to the query. Callers can use this identifier to distinguish queries from one another, for example in mocks.
+
+-   `Soql setQueryIdentifier(String identifier)`
+
+```java
+// In MyClass.cls:
+Soql myQuery = (Soql) DatabaseLayer.Soql
+  ?.newQuery(Account.SObjectType)
+  ?.setQueryIdentifier('My Account Query');
+
+// In MyClassTest.cls:
+MockSoql.Simulator queryMock = new MyQueryMock();
+DatabaseLayer.useMocks().setGlobalMock(queryMock);
+
+private class MyQueryMock implements MockSoql.Simulator {
+  public List<Object> simulateQuery(Soql queryToMock) {
+    if (queryToMock?.identifier == 'My Account Query') {
+      // Do some mocking logic specific to this query
+    } else {
+      // Do some other mocking logic for other queries...
+    }
+  }
+}
+```
 
 #### `setRowLimit`
 

--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -60,23 +60,61 @@ List<Account> results = soql?.query();
 Assert.areEqual(0, results?.size(), 'Wrong # of resuls');
 ```
 
-Use the [`MockSoql.Simulator`](#the-mocksoqlsimulator-interface) interface in conjunction with the [`setGlobalMock`](#the-setglobalmock-static-method) static method, or the [`setMock`](#the-setmock-method) member method to enable your mock queries to return mock results, throw exceptions, and more.
+For these queries to return actual results, developers must first inject logic via either the static [`setGlobalMock`](#the-setglobalmock-static-methods) method, or the member [`setMock`](#the-setmock-methods) method.
 
-! TODO !
+Both methods have two overloads - one which accepts and returns a [`MockSoql.Simulator`](#the-mocksoqlsimulator-interface) object, and a 0-argument overlaod which returns a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object.
 
-### The `setGlobalMock` Static Method
+#### The `setGlobalMock` Static Methods
 
-### The `setMock` Method
+This method assigns "default" query logic to _all_ `Soql` objects. This allows developers to inject mocks for queries without the need to expose those queries as `@TestVisible`, class-level variables.
 
-### The `MockSoql.Simulator` Interface
+The 0-argument version of this method injects a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object, and returns that same object. You can use that object's `withResults` to inject a static `List<Object>`, or its `withError` method to inject a static `Exception` to be thrown.
 
-The `MockSoql.Simulator` interface defines logic for returning query results.
+```java
+DatabaseLayer.useMocks();
+List<Account> mockAccounts = SomeTestFactory.initAccounts();
+MockSoql.setGlobalMock()?.withResults(mockAccounts);
+```
+
+For more complex query logic, use the 1-argument version of this method, which accepts a [`MockSoql.Simulator`](#the-mocksoqlsimulator-interface) object. You can create your own custom query logic by creating a class which implements this interface, and then pass it to all `Soql` objects through this method:
+
+```java
+DatabaseLayer.useMocks();
+MockSoql.Simulator simulator = new MyCustomQueryLogic();
+MockSoql.setGlobalMock(simulator);
+```
+
+#### The `setMock` Methods
+
+This method assigns query logic to a _specific_ `Soql` object, overriding any global defaults set via `MockSoql.setGlobalMock`. In a real-world scenario, queries in a production class **must** be exposed as public/`@TestVisible` variables to use this method.
+
+The 0-argument version of this method injects a [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) object, and returns that same object. You can use that object's `withResults` to inject a static `List<Object>`, or its `withError` method to inject a static `Exception` to be thrown.
+
+```java
+DatabaseLayer.useMocks();
+List<Account> mockAccounts = SomeTestFactory.initAccounts();
+MockSoql queryToMock = (MockSoql) MyClass.SOME_QUERY;
+queryToMock?.setMock()?.withResults(mockAccounts);
+```
+
+For more complex query logic, use the 1-argument version of this method, which accepts a [`MockSoql.Simulator`](#the-mocksoqlsimulator-interface) object. You can create your own custom query logic by creating a class which implements this interface, and then pass it to a `Soql` object through this method:
+
+```java
+DatabaseLayer.useMocks();
+MockSoql.Simulator simulator = new MyCustomQueryLogic();
+MockSoql queryToMock = (MockSoql) MyClass.SOME_QUERY;
+queryToMock?.setMock(simulator);
+```
+
+#### The `MockSoql.Simulator` Interface
+
+The `MockSoql.Simulator` interface defines custom logic for returning query results. Use this interface when you need more complex logic than what the [`MockSoql.StaticResults`](#the-mocksoqlstaticresults-class) can provide.
 
 The interface has one required method:
 
 -   `List<Object> simulateQuery(Soql queryToMock)`
 
-Use the `Soql queryToMock` parameter to conditionally return results based on the details of the query. For example, you if the query is `FROM Task`, return a list of Tasks:
+Callers can conditionally return results based on the details of the provided `Soql` argument. For example, you if the query is `FROM Task`, return a list of Tasks:
 
 ```java
 private class CustomQueryLogic implements MockSoql.Simulator {
@@ -111,143 +149,41 @@ private class CustomQueryLogic implements MockSoql.Simulator {
 }
 ```
 
-### The `MockSoql.StaticResults` Class
+#### The `MockSoql.StaticResults` Class
 
 Not all testing scenarios require the creation of a custom `MockSoql.Simulator` object. Most simple use cases can be handled by using the included `MockSoql.StaticResults` object.
 
+This object cannot be directly constructed. Create an instance of this object by calling the 0-argument versions of the [`MockSoql.setGlobalMock`](#the-setglobalmock-static-methods) static method, or the [`setMock`](#the-setmock-methods) member method.
+
 This object implements `MockSoql.Simulator` interface, and includes methods which allow callers to inject a static list of results, or an exception to be thrown. Whenever the query runs, the injected results are returned.
 
-#### `withError`
+##### `withError`
 
 Injects an error to be thrown each time the query runs. Callers can provide a specific exception object, if desired. The 0-argument overload of this method will inject a generic `System.QueryException`.
 
 -   `MockSoql.StaticResults withError(System.Exception error)`
 -   `MockSoql.StaticResults withError()`
 
-#### `withResults`
+```java
+DatabaseLayer.useMocks();
+// Queries will always throw a System.QueryException:
+MockSoql.setGlobalMock()?.withError();
+// Queries will always throw some other exception type:
+System.Exception someOtherError = new System.CalloutException();
+MockSoql.setGlobalMock()?.withError(someOtherError);
+```
+
+##### `withResults`
 
 Injects a static list of results. This list will be returned each time the query runs.
 
 -   `MockSoql.StaticResults withResults(List<Object> results)`
 
----
-
-Each `MockSoql` object can be injected with static query results, logic that determines the query results, or an Exception. When the query runs, those results will be returned instead of what is actually in the Salesforce database.
-
-For this reason, it's best practice to store each Soql object in a `@TestVisible` class variable, that can be easily accessed by your test code if needed.
-
-#### Inject Static Results with the `setMock` Method
-
-The easiest way to simulate queries is to use the `setMock` method with a static `List<Object>`. The provided results will be returned each time the query runs:
-
 ```java
 DatabaseLayer.useMocks();
-Account mockAccount = new MockRecord(Account.SObjectType)?.withId()?.toSObject();
-MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
-soql.useMocks(new List<Account>{ mockAccount });
-List<Account> results = soql?.query();
-Assert.areEqual(1, results?.size(), 'Wrong # of results');
-```
-
-Most of the time, this will be a `List<SObject>`, but you can also pass a `List<MockSoql.AggregateResult>` or a custom list type for aggregate queries:
-
-```java
-public class MyCustomType {
-  public String state { get; set; }
-  public Integer numRecords { get; set; }
-}
-```
-
-```java
-DatabaseLayer.useMocks();
-MyCustomType mockResult = new MyCustomType();
-mockResult.state = 'CA';
-mockResult.numRecords = 123;
-Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT, Account.Id)
-  ?.withAlias('numRecords');
-MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
-  ?.addSelect(Account.BillingState, 'state')
-  ?.addSelect(count);
-soql.useMocks(new List<MyCustomType>{ mockResult });
-List<MyCustomType> results = (List<MyCustomType>) soql?.query(
-  List<MyCustomType>.class
-);
-```
-
-#### Inject Dynamic Results with the `setMock` Method
-
-Certain testing scenarios may require custom logic to determine the results returned by a query. For these scenarios, developers can leverage the `MockSoql.Simulator` interface with the `setMock` method.
-
-The `MockSoql.Simulator` interface has one required method, which returns a `List<Object>`. This method will be run each time the query is run.
-
-```java
-private class CustomTaskQueryLogic implements MockSoql.Simulator {
-  public List<Object> simulateQuery(Soql queryToMock) {
-    // For each inserted contact, return a Task
-    List<Task> results = new List<Task>();
-    List<Contact> contacts = (List<Contact>) MockDml.INSERTED.getRecords(
-      Contact.SObjectType
-    );
-    for (Contact contact : contacts) {
-      Task task = (Task) new MockRecord(Task.SObjectType)
-        ?.setField(Task.Subject, 'Introductory Call')
-        ?.setField(Task.WhatId, contact?.AccountId)
-        ?.setField(Task.WhoId, contact?.Id)
-        ?.withId()
-        ?.toSObject();
-      results?.add(task);
-    }
-    return results;
-  }
-}
-```
-
-```java
-// Establish Dml & Soql objects to be used
-DatabaseLayer.useMocks();
-MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Task.SObjectType)
-  ?.addSelect(Task.WhatId)
-  ?.addSelect(Task.WhoId);
-// Mock with a custom class that leverages MockDml.INSERTED to generate results
-soql?.setMock(new CustomTaskQueryLogic());
-// Mock insert an account + related contact
-Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.toSObject();
-DatabaseLayer.Dml.doInsert(mockAccount);
-Contact mockContact = (Contact) new MockRecord(Contact.SObjectType)
-  ?.setField(Contact.AccountId, mockAccount?.Id)
-  ?.toSObject();
-DatabaseLayer.Dml.doInsert(mockContact);
-
-Test.startTest();
-List<Task> tasks = soql?.query();
-Test.stopTest();
-
-// Expecting 1 task x each inserted Contact
-Assert.areEqual(1, tasks?.size(), 'Wrong # of tasks');
-Task firstTask = tasks?.get(0);
-Assert.areEqual(mockAccount?.Id, firstTask?.WhatId, 'Wrong WhatId');
-Assert.areEqual(mockContact?.Id, firstTask?.WhoId, 'Wrong WhoId');
-```
-
-#### Inject Exceptions with the `setError` Method
-
-Developers can simulate `Database.QueryException`s and other errors that may occur when running queries, by using the `setError` method:
-
-```java
-DatabaseLayer.useMocks();
-MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
-soql?.setError();
-soql?.query(); // ! System.QueryException
-```
-
-Callers can specify the exact exception to be thrown, if desired:
-
-```java
-DatabaseLayer.useMocks();
-System.NullPointerException npe = new System.NullPointerException();
-MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
-soql?.setError(npe);
-soql?.query(); // ! System.NullPointerException
+Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
+// Queries will always return the provided List<Object>
+MockSoql.setGlobalMock()?.withResults(new List<Account>{ mockAccont });
 ```
 
 ### Mocking Query Locators

--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -60,6 +60,78 @@ List<Account> results = soql?.query();
 Assert.areEqual(0, results?.size(), 'Wrong # of resuls');
 ```
 
+Use the [`MockSoql.Simulator`](#the-mocksoqlsimulator-interface) interface in conjunction with the [`setGlobalMock`](#the-setglobalmock-static-method) static method, or the [`setMock`](#the-setmock-method) member method to enable your mock queries to return mock results, throw exceptions, and more.
+
+! TODO !
+
+### The `setGlobalMock` Static Method
+
+### The `setMock` Method
+
+### The `MockSoql.Simulator` Interface
+
+The `MockSoql.Simulator` interface defines logic for returning query results.
+
+The interface has one required method:
+
+-   `List<Object> simulateQuery(Soql queryToMock)`
+
+Use the `Soql queryToMock` parameter to conditionally return results based on the details of the query. For example, you if the query is `FROM Task`, return a list of Tasks:
+
+```java
+private class CustomQueryLogic implements MockSoql.Simulator {
+  public List<Object> simulateQuery(Soql queryToMock) {
+    String fromSObjectName = queryToMock?.entity;
+    if (fromSObjectName == Task.SObjectType.toString()) {
+      return this.simulateTaskQuery();
+    } else if (fromSObjectName == Account.SObjectType.toString()) {
+      // You could imagine methods to simulate account queries here:
+    } else {
+      return new List<Object>();
+    }
+  }
+
+  private List<Task> simulateTaskQuery() {
+    // For each inserted contact, return a Task
+    List<Task> results = new List<Task>();
+    List<Contact> contacts = (List<Contact>) MockDml.INSERTED.getRecords(
+      Contact.SObjectType
+    );
+    for (Contact contact : contacts) {
+      Task task = (Task) new MockRecord(Task.SObjectType)
+        ?.setField(Task.Subject, 'Introductory Call')
+        ?.setField(Task.WhatId, contact?.AccountId)
+        ?.setField(Task.WhoId, contact?.Id)
+        ?.withId()
+        ?.toSObject();
+      results?.add(task);
+    }
+    return results;
+  }
+}
+```
+
+### The `MockSoql.StaticResults` Class
+
+Not all testing scenarios require the creation of a custom `MockSoql.Simulator` object. Most simple use cases can be handled by using the included `MockSoql.StaticResults` object.
+
+This object implements `MockSoql.Simulator` interface, and includes methods which allow callers to inject a static list of results, or an exception to be thrown. Whenever the query runs, the injected results are returned.
+
+#### `withError`
+
+Injects an error to be thrown each time the query runs. Callers can provide a specific exception object, if desired. The 0-argument overload of this method will inject a generic `System.QueryException`.
+
+-   `MockSoql.StaticResults withError(System.Exception error)`
+-   `MockSoql.StaticResults withError()`
+
+#### `withResults`
+
+Injects a static list of results. This list will be returned each time the query runs.
+
+-   `MockSoql.StaticResults withResults(List<Object> results)`
+
+---
+
 Each `MockSoql` object can be injected with static query results, logic that determines the query results, or an Exception. When the query runs, those results will be returned instead of what is actually in the Salesforce database.
 
 For this reason, it's best practice to store each Soql object in a `@TestVisible` class variable, that can be easily accessed by your test code if needed.

--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -110,7 +110,7 @@ The `MockSoql.Simulator` interface has one required method, which returns a `Lis
 
 ```java
 private class CustomTaskQueryLogic implements MockSoql.Simulator {
-  public List<Object> simulateQuery() {
+  public List<Object> simulateQuery(Soql queryToMock) {
     // For each inserted contact, return a Task
     List<Task> results = new List<Task>();
     List<Contact> contacts = (List<Contact>) MockDml.INSERTED.getRecords(

--- a/force-app/main/default/classes/MockSoql.cls
+++ b/force-app/main/default/classes/MockSoql.cls
@@ -3,33 +3,50 @@
 public class MockSoql extends Soql {
 	/**
 	 * This class mocks SOQL queries. By default, each query will return empty results.
-	 * Users can use the `setMock()` method to inject an object which will simulate the query & return results
+	 * Users can use the `setGlobalMock()` static method, and `setMock()` member method(s)
+	 * to inject a `MockSoql.Simulator` object which will simulate the query & return results
 	 **/
 	private static final String AGGREGATE_KEY_PREFIX = 'expr';
 	private static MockSoql.Simulator globalMock;
-
-	private MockSoql.Simulator simulator;
+	private MockSoql.Simulator currentMock;
 
 	public MockSoql(DatabaseLayer factory) {
 		super(factory);
 	}
 
+	// **** STATIC **** //
+	public static MockSoql.Simulator setGlobalMock(MockSoql.Simulator simulator) {
+		// This method assigns a simulator object, which will be run for all queries by default,
+		// unless a Soql object has a specific Simulator assigned to it
+		// Similar to using Test.setMock w/the System.HttpCalloutMock interface
+		MockSoql.globalMock = simulator;
+		return simulator;
+	}
+
+	// **** MEMBER **** //
 	public Soql setError(Exception error) {
+		// Call this method to inject the given Exception object
+		// to be thrown whenever the current query runs, instead of the global mock
 		MockSoql.Simulator simulator = new MockSoql.StaticResults(error);
 		return this.setMock(simulator);
 	}
 
 	public Soql setError() {
+		// Call this method to inject a generic System.QueryException
+		// to be thrown whenever the current query runs, instead of the global mock
 		return this.setError(new System.QueryException());
 	}
 
 	public Soql setMock(MockSoql.Simulator simulator) {
-		// Inject an Simulator object, which will return mock results when the query runs.
-		this.simulator = simulator;
+		// Call this method to inject an Simulator object
+		// to be run whenever the current query runs, instead of the global mock
+		this.currentMock = simulator;
 		return this;
 	}
 
 	public Soql setMock(List<Object> results) {
+		// Call this method to inject static List<Object>
+		// to be returned whenever the current query runs, instead of the global mock
 		MockSoql.Simulator simulator = new MockSoql.StaticResults(results);
 		return this.setMock(simulator);
 	}
@@ -55,17 +72,11 @@ public class MockSoql extends Soql {
 		return this.simulate() ?? returnType?.newInstance();
 	}
 
-	// **** STATIC **** //
-	public static MockSoql.Simulator setGlobalMock(MockSoql.Simulator simulator) {
-		MockSoql.globalMock = simulator;
-		return simulator;
-	}
-
 	// **** PRIVATE **** //
 	private MockSoql.Simulator getSimulator() {
 		// If the current query has a specific simulator assigned to it, return that simulator
 		// Else return the globally assigned simulator
-		return this.simulator ?? MockSoql.globalMock;
+		return this.currentMock ?? MockSoql.globalMock;
 	}
 
 	private Object simulate() {

--- a/force-app/main/default/classes/MockSoql.cls
+++ b/force-app/main/default/classes/MockSoql.cls
@@ -3,7 +3,7 @@
 public class MockSoql extends Soql {
 	/**
 	 * This class mocks SOQL queries. By default, each query will return empty results.
-	 * Users can use the `setGlobalMock()` static method, and `setMock()` member method(s)
+	 * Users can use the `setGlobalMock()` static method(s), and `setMock()` member method(s)
 	 * to inject a `MockSoql.Simulator` object which will simulate the query & return results
 	 **/
 	private static final String AGGREGATE_KEY_PREFIX = 'expr';
@@ -16,39 +16,31 @@ public class MockSoql extends Soql {
 
 	// **** STATIC **** //
 	public static MockSoql.Simulator setGlobalMock(MockSoql.Simulator simulator) {
-		// This method assigns a simulator object, which will be run for all queries by default,
+		// This method assigns the given simulator object to be run for all queries by default,
 		// unless a Soql object has a specific Simulator assigned to it
 		// Similar to using Test.setMock w/the System.HttpCalloutMock interface
 		MockSoql.globalMock = simulator;
 		return simulator;
 	}
 
+	public static MockSoql.StaticResults setGlobalMock() {
+		// This overload instantiates a new StaticResults object, and returns it as a concrete instance
+		// to allow for a more fluent interface + method chaining w/global mocks
+		return (MockSoql.StaticResults) MockSoql.setGlobalMock(new MockSoql.StaticResults());
+	}
+
 	// **** MEMBER **** //
-	public Soql setError(Exception error) {
-		// Call this method to inject the given Exception object
-		// to be thrown whenever the current query runs, instead of the global mock
-		MockSoql.Simulator simulator = new MockSoql.StaticResults(error);
-		return this.setMock(simulator);
-	}
-
-	public Soql setError() {
-		// Call this method to inject a generic System.QueryException
-		// to be thrown whenever the current query runs, instead of the global mock
-		return this.setError(new System.QueryException());
-	}
-
-	public Soql setMock(MockSoql.Simulator simulator) {
-		// Call this method to inject an Simulator object
+	public MockSoql.Simulator setMock(MockSoql.Simulator simulator) {
+		// Call this method to inject the given Simulator object
 		// to be run whenever the current query runs, instead of the global mock
 		this.currentMock = simulator;
-		return this;
+		return this.currentMock;
 	}
 
-	public Soql setMock(List<Object> results) {
-		// Call this method to inject static List<Object>
-		// to be returned whenever the current query runs, instead of the global mock
-		MockSoql.Simulator simulator = new MockSoql.StaticResults(results);
-		return this.setMock(simulator);
+	public MockSoql.StaticResults setMock() {
+		// Call this method to inject an return a concrete instance of a new StaticResults object
+		// to be run whenever the current query runs, instead of the global mock
+		return (MockSoql.StaticResults) this.setMock(new MockSoql.StaticResults());
 	}
 
 	// **** OVERRIDES **** //
@@ -194,12 +186,25 @@ public class MockSoql extends Soql {
 		private Exception error;
 		private List<Object> results;
 
-		public StaticResults(Exception error) {
-			this.error = error;
+		private StaticResults() {
+			// Callers have no need to ever reference the StaticResults object directly
+			// instead, use the StaticResults objects returned by the 0-arg setGlobalMock/setMock methods
 		}
 
-		public StaticResults(List<Object> results) {
+		public MockSoql.StaticResults withError(Exception error) {
+			// This method injects the given error to be thrown whenever the simulator is run
+			this.error = error;
+			return this;
+		}
+
+		public MockSoql.StaticResults withError() {
+			// This method injects a generic System.QueryException to be thrown whenever the simulator is run
+			return this.withError(new System.QueryException());
+		}
+
+		public MockSoql.StaticResults withResults(List<Object> results) {
 			this.results = results;
+			return this;
 		}
 
 		public List<Object> simulateQuery(Soql queryToMock) {

--- a/force-app/main/default/classes/MockSoql.cls
+++ b/force-app/main/default/classes/MockSoql.cls
@@ -6,6 +6,8 @@ public class MockSoql extends Soql {
 	 * Users can use the `setMock()` method to inject an object which will simulate the query & return results
 	 **/
 	private static final String AGGREGATE_KEY_PREFIX = 'expr';
+	private static MockSoql.Simulator globalMock;
+
 	private MockSoql.Simulator simulator;
 
 	public MockSoql(DatabaseLayer factory) {
@@ -53,11 +55,23 @@ public class MockSoql extends Soql {
 		return this.simulate() ?? returnType?.newInstance();
 	}
 
+	// **** STATIC **** //
+	public static MockSoql.Simulator setGlobalMock(MockSoql.Simulator simulator) {
+		MockSoql.globalMock = simulator;
+		return simulator;
+	}
+
 	// **** PRIVATE **** //
+	private MockSoql.Simulator getSimulator() {
+		// If the current query has a specific simulator assigned to it, return that simulator
+		// Else return the globally assigned simulator
+		return this.simulator ?? MockSoql.globalMock;
+	}
+
 	private Object simulate() {
 		// Run the Simulator logic, and handle errors just like the super() class does
 		try {
-			return this.simulator?.simulateQuery();
+			return this.getSimulator()?.simulateQuery(this);
 		} catch (Exception error) {
 			this.handleQueryError(error);
 			throw error;
@@ -162,22 +176,22 @@ public class MockSoql extends Soql {
 		 * 	- Return a List<MockSoql.AggregateResult>
 		 *  - Throw an exception
 		 **/
-		List<Object> simulateQuery();
+		List<Object> simulateQuery(Soql queryToMock);
 	}
 
-	private class StaticResults implements MockSoql.Simulator {
+	public class StaticResults implements MockSoql.Simulator {
 		private Exception error;
 		private List<Object> results;
 
-		private StaticResults(Exception error) {
+		public StaticResults(Exception error) {
 			this.error = error;
 		}
 
-		private StaticResults(List<Object> results) {
+		public StaticResults(List<Object> results) {
 			this.results = results;
 		}
 
-		public List<Object> simulateQuery() {
+		public List<Object> simulateQuery(Soql queryToMock) {
 			if (this.error != null) {
 				throw this.error;
 			}

--- a/force-app/main/default/classes/MockSoqlTest.cls
+++ b/force-app/main/default/classes/MockSoqlTest.cls
@@ -265,6 +265,62 @@ private class MockSoqlTest {
 	}
 
 	@IsTest
+	static void shouldSetGlobalMock() {
+		DatabaseLayer.useMocks();
+		MockSoql theQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
+		// Set a global mock - all SOQL objects will return these results by default now:
+		Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
+		MockSoql.Simulator simulator = new MockSoql.StaticResults(new List<Account>{ mockAccount });
+		MockSoql.setGlobalMock(simulator);
+
+		Test.startTest();
+		List<Account> accounts = theQuery?.query();
+		Test.stopTest();
+
+		Assert.areEqual(1, accounts?.size(), 'Wrong # of Accounts returned');
+		Assert.areEqual(mockAccount?.Id, accounts?.get(0)?.Id, 'Wrong Account returned');
+	}
+
+	@IsTest
+	static void shouldIgnoreGlobalMockIfSpecificSimulatorAssignedToQuery() {
+		DatabaseLayer.useMocks();
+		MockSoql theQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
+		// Set a global mock - all SOQL objects will return these results by default now:
+		Account mockAccount1 = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
+		MockSoql.Simulator simulator = new MockSoql.StaticResults(new List<Account>{ mockAccount1 });
+		MockSoql.setGlobalMock(simulator);
+		// Assign a different, specific mock to the query:
+		Account mockAccount2 = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
+		theQuery?.setMock(new MockSoql.StaticResults(new List<Account>{ mockAccount2 }));
+
+		Test.startTest();
+		List<Account> accounts = theQuery?.query();
+		Test.stopTest();
+
+		Assert.areEqual(1, accounts?.size(), 'Wrong # of Accounts returned');
+		Assert.areEqual(mockAccount2?.Id, accounts?.get(0)?.Id, 'Wrong Account returned');
+	}
+
+	@IsTest
+	static void shouldIntelligentlyReturnCorrectQueryResults() {
+		DatabaseLayer.useMocks();
+		MockSoql accountQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
+		MockSoql caseQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Case.SObjectType);
+		MockSoql.Simulator simulator = new MockSoqlTest.DynamicSimulator();
+		MockSoql.setGlobalMock(simulator);
+
+		Test.startTest();
+		List<Account> accounts = (List<Account>) accountQuery?.query();
+		List<Case> cases = (List<Case>) caseQuery?.query();
+		Test.stopTest();
+
+		Assert.areEqual(1, accounts?.size(), 'Wrong # of Accounts returned');
+		Assert.areEqual('Foo', accounts?.get(0)?.Name, 'Wrong Account details');
+		Assert.areEqual(1, cases?.size(), 'Wrong # of Cases returned');
+		Assert.areEqual('12345678', cases?.get(0)?.CaseNumber, 'Wrong Case details');
+	}
+
+	@IsTest
 	static void shouldReturnEmptyListIfNoMocks() {
 		// If a MockSoql is ran, and no Simulator is injected, the methods will automatically return an empty List
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType);
@@ -299,7 +355,7 @@ private class MockSoqlTest {
 
 	// **** INNER **** //
 	private class CustomTaskQueryLogic implements MockSoql.Simulator {
-		public List<Object> simulateQuery() {
+		public List<Object> simulateQuery(Soql queryToMock) {
 			// For each inserted contact, return a Task
 			List<Task> results = new List<Task>();
 			List<Contact> contacts = (List<Contact>) MockDml.INSERTED.getRecords(Contact.SObjectType);
@@ -313,6 +369,30 @@ private class MockSoqlTest {
 				results?.add(task);
 			}
 			return results;
+		}
+	}
+
+	private class DynamicSimulator implements MockSoql.Simulator {
+		// This example returns a different list of records, depending on the from entity
+		// You can use this in conjunction with MockSoql.setGlobalMock to dynamically inject query results into multiple soql objects,
+		// without needing to directly asssign each their own unique simulator object
+		public List<Object> simulateQuery(Soql queryToMock) {
+			String entity = queryToMock?.entity;
+			if (entity == Account.SObjectType.toString()) {
+				Account mockAccount = (Account) new MockRecord(Account.SObjectType)
+					?.setField(Account.Name, 'Foo')
+					?.withId()
+					?.toSObject();
+				return new List<Account>{ mockAccount };
+			} else if (entity == Case.SObjectType.toString()) {
+				Case mockCase = (Case) new MockRecord(Case.SObjectType)
+					?.setField(Case.CaseNumber, '12345678')
+					?.withId()
+					?.toSObject();
+				return new List<Case>{ mockCase };
+			} else {
+				return new List<SObject>();
+			}
 		}
 	}
 

--- a/force-app/main/default/classes/MockSoqlTest.cls
+++ b/force-app/main/default/classes/MockSoqlTest.cls
@@ -12,7 +12,7 @@ private class MockSoqlTest {
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(count);
 		// Inject the query w/mock results
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
-		soql?.setMock(accounts);
+		soql?.setMock()?.withResults(accounts);
 
 		Test.startTest();
 		Integer results = soql?.countQuery();
@@ -27,7 +27,7 @@ private class MockSoqlTest {
 		// Build a query
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		// Inject the query w/a mock error
-		soql?.setError();
+		soql?.setMock()?.withError();
 
 		Test.startTest();
 		try {
@@ -46,7 +46,7 @@ private class MockSoqlTest {
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		// Inject the query w/mock results
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
-		soql?.setMock(accounts);
+		soql?.setMock()?.withResults(accounts);
 
 		Test.startTest();
 		Soql.QueryLocator locator = soql?.getQueryLocator();
@@ -77,7 +77,7 @@ private class MockSoqlTest {
 		// Build a query
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		// Inject the query w/a mock error
-		soql?.setError();
+		soql?.setMock()?.withError();
 
 		Test.startTest();
 		try {
@@ -96,7 +96,7 @@ private class MockSoqlTest {
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		// Inject the query w/mock results
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
-		soql?.setMock(accounts);
+		soql?.setMock()?.withResults(accounts);
 
 		Test.startTest();
 		List<Account> results = soql?.query();
@@ -111,7 +111,7 @@ private class MockSoqlTest {
 		// Build a query
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		// Inject the query w/a mock error
-		soql?.setError();
+		soql?.setMock()?.withError();
 
 		Test.startTest();
 		try {
@@ -141,7 +141,7 @@ private class MockSoqlTest {
 			?.addParameter('Bar Profile')
 			?.addParameter(45);
 		List<Soql.AggregateResult> mockResults = new List<Soql.AggregateResult>{ mockResult1, mockResult2 };
-		soql?.setMock(mockResults);
+		soql?.setMock()?.withResults(mockResults);
 
 		Test.startTest();
 		List<Soql.AggregateResult> results = soql?.aggregateQuery();
@@ -170,7 +170,7 @@ private class MockSoqlTest {
 			?.addSelect(count)
 			?.groupBy('Profile.Name');
 		// Inject an error
-		soql?.setError();
+		soql?.setMock()?.withError();
 
 		Test.startTest();
 		try {
@@ -196,7 +196,7 @@ private class MockSoqlTest {
 		SampleWrapper mockResult1 = new SampleWrapper()?.wrap('Foo Profile', 123);
 		SampleWrapper mockResult2 = new SampleWrapper()?.wrap('Bar Profile', 45);
 		List<SampleWrapper> mockResults = new List<SampleWrapper>{ mockResult1, mockResult2 };
-		soql?.setMock(mockResults);
+		soql?.setMock()?.withResults(mockResults);
 
 		Test.startTest();
 		List<SampleWrapper> results = (List<SampleWrapper>) soql?.query(List<SampleWrapper>.class);
@@ -223,7 +223,7 @@ private class MockSoqlTest {
 			?.addSelect(count)
 			?.groupBy('Profile.Name');
 		// Inject an error
-		soql?.setError(new System.TypeException());
+		soql?.setMock()?.withError(new System.TypeException());
 
 		Test.startTest();
 		try {
@@ -244,7 +244,7 @@ private class MockSoqlTest {
 			?.addSelect(Task.WhatId)
 			?.addSelect(Task.WhoId);
 		// Mock with a custom class that leverages MockDml.INSERTED to generate results
-		soql?.setMock(new CustomTaskQueryLogic());
+		soql?.setMock(new MockSoqlTest.CustomTaskQueryLogic());
 		// Mock insert an account + related contact
 		Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.toSObject();
 		DatabaseLayer.Dml.doInsert(mockAccount);
@@ -270,8 +270,7 @@ private class MockSoqlTest {
 		MockSoql theQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
 		// Set a global mock - all SOQL objects will return these results by default now:
 		Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
-		MockSoql.Simulator simulator = new MockSoql.StaticResults(new List<Account>{ mockAccount });
-		MockSoql.setGlobalMock(simulator);
+		MockSoql.setGlobalMock()?.withResults(new List<Account>{ mockAccount });
 
 		Test.startTest();
 		List<Account> accounts = theQuery?.query();
@@ -287,11 +286,10 @@ private class MockSoqlTest {
 		MockSoql theQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
 		// Set a global mock - all SOQL objects will return these results by default now:
 		Account mockAccount1 = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
-		MockSoql.Simulator simulator = new MockSoql.StaticResults(new List<Account>{ mockAccount1 });
-		MockSoql.setGlobalMock(simulator);
+		MockSoql.setGlobalMock()?.withResults(new List<Account>{ mockAccount1 });
 		// Assign a different, specific mock to the query:
 		Account mockAccount2 = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
-		theQuery?.setMock(new MockSoql.StaticResults(new List<Account>{ mockAccount2 }));
+		theQuery?.setMock()?.withResults(new List<Account>{ mockAccount2 });
 
 		Test.startTest();
 		List<Account> accounts = theQuery?.query();

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -30,7 +30,7 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 	private static final String ID_REFERENCE = 'Id';
 
 	// Member Properties:
-	public String queryIdentifier { get; private set; }
+	public String identifier { get; private set; }
 
 	public Soql(DatabaseLayer factory) {
 		this();
@@ -115,7 +115,7 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 
 	public Soql setQueryIdentifier(String identifier) {
 		// Use this method to give a name/identifier value that can be referenced in mocks
-		this.queryIdentifier = identifier;
+		this.identifier = identifier;
 		return this;
 	}
 

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -29,6 +29,9 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 	private static final Soql.LogicType DEFAULT_LOGIC_TYPE = Soql.LogicType.ALL_CONDITIONS;
 	private static final String ID_REFERENCE = 'Id';
 
+	// Member Properties:
+	public String queryIdentifier { get; private set; }
+
 	public Soql(DatabaseLayer factory) {
 		this();
 	}
@@ -108,6 +111,12 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 		// Now revert to the original row limit
 		this.setRowLimit(originalLimit);
 		return results?.isEmpty() == false ? results?.get(0) : null;
+	}
+
+	public Soql setQueryIdentifier(String identifier) {
+		// Use this method to give a name/identifier value that can be referenced in mocks
+		this.queryIdentifier = identifier;
+		return this;
 	}
 
 	protected void handleQueryError(Exception error) {

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -1039,7 +1039,7 @@ private class SoqlTest {
 		theQuery?.setQueryIdentifier(identifier);
 		Test.stopTest();
 
-		Assert.areEqual(identifier, theQuery?.queryIdentifier, 'Wrong query identifier');
+		Assert.areEqual(identifier, theQuery?.identifier, 'Wrong query identifier');
 	}
 
 	// **** HELPER **** //

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -1030,6 +1030,18 @@ private class SoqlTest {
 		Assert.areEqual('CreatedDate DESC NULLS FIRST', value, 'Wrong value');
 	}
 
+	@IsTest
+	static void shouldSetQueryIdentifier() {
+		String identifier = 'My account query';
+		Soql theQuery = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
+
+		Test.startTest();
+		theQuery?.setQueryIdentifier(identifier);
+		Test.stopTest();
+
+		Assert.areEqual(identifier, theQuery?.queryIdentifier, 'Wrong query identifier');
+	}
+
 	// **** HELPER **** //
 	static Object validateQuery(Soql soql, String expected) {
 		Assert.areEqual('"' + expected + '"', '"' + soql?.toString() + '"', 'Unexpected SOQL output');


### PR DESCRIPTION
- Adds a new `Soql` method: `setQueryIdentifier`
- Reworks `MockSoql`, providing an API to inject query logic on a global basis, or for specific queries.
- Updating docs