### PR TITLE
Version/2.1.0

### DIFF
--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -87,7 +87,7 @@ MockSoql.setGlobalMock(simulator);
 
 -   `MockSoql.Simulator static setGlobalMock(MockSoql.Simulator simulator)`
 -   `MockSoql.StaticResults static setGlobalMock()`
-</details>
+      </details>
 
 <details>
   <summary><h4>The <code>setMock</code> Method</h4></summary>
@@ -287,7 +287,7 @@ Developers can employ one of the following strategies to work around this:
 -   Have your unit tests call the batch's `start`, `execute`, and `finish` methods invidually.
 -   Amend the `start` method to return an [iterable object](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_iterable.htm) instead.
 -   Use `System.Queueable` jobs paired with a `System.Finalizer` instead of `Database.Batchable`.
-</details>
+      </details>
 
 ---
 
@@ -729,6 +729,39 @@ Determines the enclosing `Soql.LogicType` object. This affects the delimiter tha
 </details>
 
 <details>
+  <summary><h3>Cursor</h3></summary>
+
+Decorates `Database.Cursor` objects that are returned by `Database.getCursor`. These objects cannot be serialized or mocked by other means.
+
+Use this object in conjunction with the `getCursor` method:
+
+```java
+Soql soql = DatabaseLayer.Soql.newQuery(Account.SObjectType);
+Soql.Cursor cursor = soql?.getCursor();
+List<SObject> records = cursor?.fetch(0, 10);
+```
+
+#### `fetch`
+
+Fetches cursor rows that correspond to the offset position and the specified record count.
+
+-   `List<SObject> fetch(Integer position, Integer count)`
+
+#### `getCursor`
+
+Returns the underlying `Database.QueryLocator` object used to construct this object.
+
+-   `Database.QueryLocator getLocator()`
+
+#### `getNumRecords`
+
+Gets the number of rows returned in an Apex cursor from a `Cursor.fetch` operation.
+
+-   `Integer getNumRecords()`
+
+</details>
+
+<details>
   <summary><h3>Function</h3></summary>
 
 Enumerates the different [Aggregate Functions](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_agg_functions.htm) that can be used in SOQL queries. Valid options include:
@@ -759,6 +792,13 @@ Soql soql = (Soql) Database.Soql.newQuery(Account.SObjectType)
 This class extends `Soql.Builder`, and therefore has all of the same query-building [methods](#building-queries).
 
 -   `InnerQuery(SObjectType objectType)`
+
+</details>
+
+<details>
+  <summary><h3>InvalidParameterValueException</h3></summary>
+
+This custom exception type wraps the standard `System.InvalidParameterValueException` thrown by the Database.Cursor class in certain circumstances, ex., when using a negative Integer in a `fetch()` call. These exceptions can only be manually constructed in VF or Aura contexts, so they cannot be mocked in apex tests. Both `Soql` and `MockSoql` classes will throw this custom exception type instead.
 
 </details>
 
@@ -834,11 +874,11 @@ Soql soql = DatabaseLayer.Soql?.newQuery(Account.SObjectType);
 Soql.QueryLocator locator = soql?.getQueryLocator();
 ```
 
-#### `getCursor`
+#### `getLocator`
 
 Returns the underlying `Database.QueryLocator` object used to construct this object.
 
--   `Database.QueryLocator getCursor()`
+-   `Database.QueryLocator getLocator()`
 
 #### `getQuery`
 

--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -87,7 +87,7 @@ MockSoql.setGlobalMock(simulator);
 
 -   `MockSoql.Simulator static setGlobalMock(MockSoql.Simulator simulator)`
 -   `MockSoql.StaticResults static setGlobalMock()`
-      </details>
+    </details>
 
 <details>
   <summary><h4>The <code>setMock</code> Method</h4></summary>
@@ -287,7 +287,7 @@ Developers can employ one of the following strategies to work around this:
 -   Have your unit tests call the batch's `start`, `execute`, and `finish` methods invidually.
 -   Amend the `start` method to return an [iterable object](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_iterable.htm) instead.
 -   Use `System.Queueable` jobs paired with a `System.Finalizer` instead of `Database.Batchable`.
-      </details>
+    </details>
 
 ---
 

--- a/force-app/main/default/classes/MockRecord.cls
+++ b/force-app/main/default/classes/MockRecord.cls
@@ -38,6 +38,30 @@ public class MockRecord {
 	}
 
 	// **** MEMBER **** //
+	public Object get(String parameterName) {
+		return this.recordValues?.get(parameterName);
+	}
+
+	public Object get(SObjectField field) {
+		return this.get(field?.toString());
+	}
+
+	public SObject getLookup(SObjectField lookupField) {
+		String relationshipName = lookupField?.getDescribe()?.getRelationshipName();
+		return (SObject) this.get(relationshipName);
+	}
+
+	public List<SObject> getRelatedList(Schema.ChildRelationship relationship) {
+		String relationshipName = relationship?.getRelationshipName();
+		MockRecord.RelatedList relatedList = (MockRecord.RelatedList) this.get(relationshipName);
+		return relatedList?.getRecords();
+	}
+
+	public List<SObject> getRelatedList(SObjectField lookupField) {
+		Schema.ChildRelationship relationship = ChildRelationshipService.getChildRelationshipFrom(lookupField);
+		return this.getRelatedList(relationship);
+	}
+
 	public MockRecord setField(Map<String, Object> incomingValues) {
 		// Sets the provided field(s) to their specified values(s)
 		// If a field value is already set, it will be overwritten.
@@ -93,14 +117,18 @@ public class MockRecord {
 	private class RelatedList {
 		// Represents a child object relationship retrieved by SOQL.
 		// This structure is required when mocking related lists on an SObject
-		Boolean done;
-		List<SObject> records;
-		Integer totalSize;
+		private Boolean done;
+		private List<SObject> records;
+		private Integer totalSize;
 
 		private RelatedList(List<SObject> records) {
 			this.done = true;
 			this.records = records ?? new List<SObject>();
 			this.totalSize = records?.size() ?? 0;
+		}
+
+		private List<SObject> getRecords() {
+			return this.records;
 		}
 	}
 }

--- a/force-app/main/default/classes/MockRecordTest.cls
+++ b/force-app/main/default/classes/MockRecordTest.cls
@@ -39,4 +39,43 @@ private class MockRecordTest {
 		Assert.areEqual('UK', mockedAccount?.BillingCountry, 'Did not overwrite existing value');
 		Assert.areNotEqual(null, mockedAccount?.Id, 'Did not set Id');
 	}
+
+	@IsTest
+	static void shouldGetValuesFromMockRecord() {
+		String accountName = 'John Doe Enterprises';
+		DateTime now = DateTime.now();
+		Contact contact = (Contact) new MockRecord(Contact.SObjectType)?.withId()?.toSObject();
+		MockRecord accountMock = new MockRecord(Account.SObjectType)
+			?.setField(Account.Name, accountName)
+			?.setField(Account.CreatedDate, now)
+			?.setLookup(Account.OwnerId, new User(Id = UserInfo.getUserId()))
+			?.setRelatedList(Schema.Contact.AccountId, new List<Contact>{ contact })
+			?.withId();
+
+		Test.startTest();
+		Assert.areEqual(accountName, accountMock?.get(Account.Name), 'Wrong Name value');
+		User owner = (User) accountMock?.getLookup(Account.OwnerId);
+		Assert.areEqual(UserInfo.getUserId(), owner?.Id, 'Wrong OwnerId value');
+		List<Contact> contacts = accountMock?.getRelatedList(Schema.Contact.AccountId);
+		Assert.areEqual(1, contacts?.size(), 'Wrong # of Contacts');
+		Assert.areEqual(contact?.Id, contacts?.get(0)?.Id, 'Wrong Contact Id');
+	}
+
+	@IsTest
+	static void shouldAddToExistingRelatedList() {
+		Contact contact1 = (Contact) new MockRecord(Contact.SObjectType)?.withId()?.toSObject();
+		Contact contact2 = (Contact) new MockRecord(Contact.SObjectType)?.withId()?.toSObject();
+		MockRecord accountMock = new MockRecord(Account.SObjectType)
+			?.setRelatedList(Contact.AccountId, new List<Contact>{ contact1 })
+			?.withId();
+
+		Test.startTest();
+		accountMock?.getRelatedList(Contact.AccountId)?.add(contact2);
+		Test.stopTest();
+
+		List<Contact> contacts = accountMock?.getRelatedList(Contact.AccountId);
+		Map<Id, Contact> contactMap = new Map<Id, Contact>(contacts);
+		Assert.areEqual(2, contactMap?.size(), 'Wrong # of Contacts');
+		Assert.areEqual(true, contactMap?.containsKey(contact2?.Id), 'Did not add Contact to related list');
+	}
 }

--- a/force-app/main/default/classes/MockSoql.cls
+++ b/force-app/main/default/classes/MockSoql.cls
@@ -52,6 +52,10 @@ public class MockSoql extends Soql {
 		return this.query()?.size();
 	}
 
+	public override Soql.Cursor getCursor() {
+		return new MockSoql.Cursor(this);
+	}
+
 	public override Soql.QueryLocator getQueryLocator() {
 		return new MockSoql.QueryLocator(this);
 	}
@@ -115,12 +119,84 @@ public class MockSoql extends Soql {
 		}
 	}
 
+	public class Cursor extends Soql.Cursor {
+		/**
+		 * Mocks the Database.Cursor object, using an underlying List<SObject> to drive its behavior
+		 **/
+		private List<SObject> records;
+
+		private Cursor(MockSoql mockQuery) {
+			super(null);
+			this.cursor = this.initMockCursor();
+			this.records = mockQuery?.query();
+		}
+
+		public override List<SObject> fetch(Integer position, Integer count) {
+			// Mocks native functionality by retrieving SObjects between the specified params from the underlying list
+			this.validateFetch(position, count);
+			// Strangely, there isn't a native List.slice method in Apex:
+			return (List<SObject>) this.slice(this.records, position, count);
+		}
+
+		public override Integer getNumRecords() {
+			return this.records?.size() ?? 0;
+		}
+
+		private Database.Cursor initMockCursor() {
+			// Mocks a fake Database.Cursor object, so that Soql.Cursor.getCursor() will return a non-null object
+			// Note: Cursors have a 15-character queryId property that always starts with the same key prefix
+			// Hijacking the existing mock record Id to generate this:
+			String queryId = '0r8' + String.valueOf(MockRecord.initRecordId(User.SObjectType))?.right(12);
+			return (Database.Cursor) JSON.deserialize(
+				JSON.serialize(new Map<String, Object>{ 'queryId' => queryId }),
+				Database.Cursor.class
+			);
+		}
+
+		private List<Object> slice(List<Object> input, Integer first, Integer numElements) {
+			// Retrieves a portion of the provided objects, starting at the "first" index, until the list size matches the numElements
+			// Similar to slice() in JS, except the second parameter specifies the number of elements to return, not the ending index
+			List<Object> results = input?.clone();
+			// Remove any elements that precede the starting index:
+			for (Integer i = 0; i < first; i++) {
+				results?.remove(0);
+			}
+			// Remove any elements after the ending index:
+			while (results?.size() > numElements) {
+				results?.remove(numElements);
+			}
+			return results;
+		}
+
+		private void validateFetch(Integer position, Integer count) {
+			// Throws an exception if the provided arguments are invalid
+			// 1. Neither parameter should be null:
+			if (position == null || count == null) {
+				System.Exception npe = new System.NullPointerException();
+				npe?.setMessage('Attempt to de-reference a null object');
+				throw npe;
+			}
+			// 2. Neither parameter should be negative:
+			if (position < 0) {
+				throw new Soql.InvalidParameterValueException('Start position cannot be a negative value: ' + position);
+			} else if (count < 0) {
+				throw new Soql.InvalidParameterValueException('Fetch size cannot be a negative value: ' + count);
+			}
+			// 3. Should not attempt to fetch an index that doesn't exist:
+			Integer maxIndexToFetch = (position + count);
+			Integer upperBound = (this.records?.size() - 1);
+			if (maxIndexToFetch > upperBound) {
+				throw new Soql.InvalidParameterValueException('Fetch beyond bound detected: ' + maxIndexToFetch);
+			}
+		}
+	}
+
 	public class QueryLocator extends Soql.QueryLocator {
 		/**
 		 * Mocks the Database.QueryLocator object, used in batch jobs.
 		 * Note: This mock implementation has one big shortcoming.
 		 * Because the underlying Database.QueryLocator object cannot be mocked,
-		 * getCursor() will always return null in mock scenarios.
+		 * getLocator() will always return null in mock scenarios.
 		 * Most custom implementations will call getQuery() or iterator() directly,
 		 * but standard mechanisms (ie., Database.Batchable classes) won't work with this.
 		 * One workaround is to individually test the start(), execute(), and finish() methods,

--- a/force-app/main/default/classes/MockSoqlTest.cls
+++ b/force-app/main/default/classes/MockSoqlTest.cls
@@ -41,6 +41,97 @@ private class MockSoqlTest {
 	}
 
 	@IsTest
+	static void shouldMockCursor() {
+		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
+		// Inject the query w/mock results
+		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
+		soql?.setMock()?.withResults(accounts);
+		Integer numToFetch = 3;
+
+		Test.startTest();
+		Soql.Cursor cursor = soql?.getCursor();
+		List<SObject> records = cursor?.fetch(0, numToFetch);
+		Assert.areEqual(0, Limits.getQueries(), 'Actually executed SOQL');
+		Test.stopTest();
+
+		Assert.areNotEqual(null, cursor?.getCursor(), 'Underlying cursor is null');
+		Assert.areEqual(numToFetch, records?.size(), 'Wrong # of records returned by the cursor');
+		Assert.areEqual(NUM_ACCS, cursor?.getNumRecords(), 'Wrong # of records stored in cursor');
+	}
+
+	@IsTest
+	static void shouldHandleCursorFetchCallWithNegativePositionParameter() {
+		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
+		// Inject the query w/mock results
+		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
+		soql?.setMock()?.withResults(accounts);
+		Soql.Cursor cursor = soql?.getCursor();
+
+		Test.startTest();
+		try {
+			cursor?.fetch(-1, 1);
+			Assert.fail('Did not throw a Soql.InvalidParameterValueException for invalid position param');
+		} catch (Soql.InvalidParameterValueException error) {
+			// As expected...
+		}
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldHandleCursorFetchCallWithNegativeCountParameter() {
+		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
+		// Inject the query w/mock results
+		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
+		soql?.setMock()?.withResults(accounts);
+		Soql.Cursor cursor = soql?.getCursor();
+
+		Test.startTest();
+		try {
+			cursor?.fetch(0, -1);
+			Assert.fail('Did not throw a Soql.InvalidParameterValueException for invalid count param');
+		} catch (Soql.InvalidParameterValueException error) {
+			// As expected...
+		}
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldHandleCursorFetchCallThatExceedsNumberOfRecords() {
+		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
+		// Inject the query w/mock results
+		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
+		soql?.setMock()?.withResults(accounts);
+		Soql.Cursor cursor = soql?.getCursor();
+
+		Test.startTest();
+		try {
+			cursor?.fetch(0, (NUM_ACCS + 1));
+			Assert.fail('Did not throw a Soql.InvalidParameterValueException for fetch that exceeds upper bound');
+		} catch (Soql.InvalidParameterValueException error) {
+			// As expected...
+		}
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldHandleCursorFetchCallWithNullParameters() {
+		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
+		// Inject the query w/mock results
+		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
+		soql?.setMock()?.withResults(accounts);
+		Soql.Cursor cursor = soql?.getCursor();
+
+		Test.startTest();
+		try {
+			cursor?.fetch(0, null);
+			Assert.fail('Did not throw a System.NullPointerException for null fetch param');
+		} catch (System.NullPointerException error) {
+			// As expected...
+		}
+		Test.stopTest();
+	}
+
+	@IsTest
 	static void shouldMockQueryLocator() {
 		// Build a query
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -71,14 +71,24 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 		}
 	}
 
+	public virtual Soql.Cursor getCursor() {
+		try {
+			Database.Cursor cursor = Database.getCursorWithBinds(this.toString(), this.binds, this.accessLevel);
+			return new Soql.Cursor(cursor);
+		} catch (Exception error) {
+			this.handleQueryError(error);
+			throw error;
+		}
+	}
+
 	public virtual Soql.QueryLocator getQueryLocator() {
 		try {
-			Database.QueryLocator cursor = Database.getQueryLocatorWithBinds(
+			Database.QueryLocator locator = Database.getQueryLocatorWithBinds(
 				this.toString(),
 				this.binds,
 				this.accessLevel
 			);
-			return new Soql.QueryLocator(cursor);
+			return new Soql.QueryLocator(locator);
 		} catch (Exception error) {
 			this.handleQueryError(error);
 			throw error;
@@ -647,6 +657,37 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 		}
 	}
 
+	public virtual class Cursor {
+		// Decorates a Database.Cursor so that it can be mocked
+		// These objects can't be manually constructed;
+		// they *can* be serialized, but their query details can't be this way
+		protected Database.Cursor cursor;
+
+		protected Cursor(Database.Cursor cursor) {
+			this.cursor = cursor;
+		}
+
+		public virtual List<SObject> fetch(Integer position, Integer count) {
+			try {
+				return this.cursor?.fetch(position, count);
+			} catch (System.InvalidParameterValueException error) {
+				// This type of system exception cannot be manually constructed, except in VF/Aura contexts (??)
+				// It is thrown whenever invalid parameters are supplied to the fetch() method
+				// Wrap these exceptions so that both real and fake queries throw the same type of Exception for consistency
+				String msg = error?.getMessage();
+				throw new Soql.InvalidParameterValueException(msg);
+			}
+		}
+
+		public Database.Cursor getCursor() {
+			return this.cursor;
+		}
+
+		public virtual Integer getNumRecords() {
+			return this.cursor?.getNumRecords();
+		}
+	}
+
 	public class EndsWithOperator extends Soql.Operator {
 		private EndsWithOperator(String token) {
 			super(token);
@@ -672,6 +713,10 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 		public override String toString() {
 			return '(' + super.toString() + ')';
 		}
+	}
+
+	public class InvalidParameterValueException extends Exception {
+		// This class wraps System.InvalidParameterValueExceptions thrown by invalid fetch calls in Database.Cursors
 	}
 
 	public virtual class Operator {
@@ -702,7 +747,7 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 			this.locator = locator;
 		}
 
-		public virtual Database.QueryLocator getCursor() {
+		public virtual Database.QueryLocator getLocator() {
 			return this.locator;
 		}
 

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -64,6 +64,52 @@ private class SoqlTest {
 	}
 
 	@IsTest
+	static void shouldGetCursor() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(User.SObjectType);
+
+		Test.startTest();
+		Soql.Cursor cursor = soql?.getCursor();
+		Test.stopTest();
+
+		Assert.areNotEqual(null, cursor?.getCursor(), 'Did not return Database.Cursor object');
+		Assert.areNotEqual(null, cursor?.getNumRecords(), 'Did not return the number of records');
+		List<User> users = cursor?.fetch(0, 1);
+		Assert.areEqual(1, users?.size(), 'Wrong # of records fetched from the cursor');
+	}
+
+	@IsTest
+	static void shouldHandleCursorQueryErrors() {
+		String illegalFieldName = 'abcd'; // Will cause a System.QueryException when run
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(illegalFieldName);
+
+		Test.startTest();
+		try {
+			soql?.getCursor();
+			Assert.fail('Illegal query did not throw an error');
+		} catch (System.QueryException error) {
+			String msg = error?.getMessage();
+			Assert.areEqual(true, msg?.contains(illegalFieldName), 'Did not append query to the error');
+		}
+		Test.stopTest();
+	}
+
+	@SuppressWarnings('PMD.EmptyCatchBlock')
+	@IsTest
+	static void shouldWrapInvalidCursorFetchErrors() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(User.SObjectType)?.setRowLimit(1);
+
+		Test.startTest();
+		try {
+			// Negative parameters are not allowed!
+			soql?.getCursor()?.fetch(0, -1);
+			Assert.fail('Did not throw a Soql.InvalidParameterValueException for batch fetch params');
+		} catch (Soql.InvalidParameterValueException error) {
+			// As expected...
+		}
+		Test.stopTest();
+	}
+
+	@IsTest
 	static void shouldGetQueryLocator() {
 		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(User.SObjectType);
 
@@ -71,7 +117,7 @@ private class SoqlTest {
 		Soql.QueryLocator locator = soql?.getQueryLocator();
 		Test.stopTest();
 
-		Assert.areNotEqual(null, locator?.getCursor(), 'Did not return Database.QueryLocator cursor');
+		Assert.areNotEqual(null, locator?.getLocator(), 'Did not return Database.QueryLocator object');
 		Assert.areEqual(soql?.toString(), locator?.getQuery(), 'Unexpected Query');
 		Assert.areNotEqual(null, locator?.iterator(), 'Did not return iterator');
 	}


### PR DESCRIPTION
Closes #31 and #32

- Adds support for the new `Database.Cursor` class in `Soql`/`MockSoql`.
- Adds new `get` methods to the `MockRecord` class; this plugs a gap in functionality that allows callers to inspect the values of these objects.
