### PR TITLE
Added methods to cast Soql.Builder to subtypes

### DIFF
--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -363,7 +363,7 @@ Adds fields or aggregations to the SELECT clause of the query.
 -   `Soql.Builder addSelect(String fieldName)`
 -   `Soql.Builder addSelect(SObjectField field)`
 -   `Soql.Builder addSelect(Soql.Aggregation aggregation)`
--   `Soql.Builder addSelect(Soql.SubQuery subQuery)`
+-   `Soql.Builder addSelect(Soql.Subquery subQuery)`
 
 #### `addWhere`
 
@@ -491,6 +491,24 @@ Sets the usage context for the query.
 Sets the logical operator (AND/OR) for combining WHERE conditions.
 
 -   `Soql.Builder setOuterWhereLogic(Soql.LogicType newLogicType)`
+
+#### `toInnerQuery`
+
+Explicitly casts the current `Soql.Builder` to a `Soql.InnerQuery` instance. Useful for chaining complex queries.
+
+-   `Soql.InnerQuery toInnerQuery()`
+
+#### `toSoql`
+
+Explicitly casts the current `Soql.Builder` to a `Soql` instance. Useful for chaining complex queries.
+
+-   `Soql toSoql()`
+
+#### `toSubquery`
+
+Explicitly casts the current `Soql.Builder` to a `Soql.Subquery` instance. Useful for chaining complex queries.
+
+-   `Soql.Subquery toSubquery()`
 
 #### `usingScope`
 
@@ -973,7 +991,7 @@ Use this in conjunction with the `addSelect` SOQL method. For example:
 
 ```java
 // SELECT Id, (SELECT Id FROM Contacts) FROM Account
-Soql.SubQuery sub = new Soql.SubQuery(Contact.AccountId);
+Soql.Subquery sub = new Soql.Subquery(Contact.AccountId);
 Soql soql = (Soql) Database.Soql.newQuery(Account.SObjectType).addSelect(sub);
 ```
 
@@ -981,8 +999,8 @@ This class extends `Soql.Builder`, and therefore has all of the same query-build
 
 Constructors:
 
--   `Soql.SubQuery(Schema.ChildRelationship relationship)`
--   `Soql.SubQuery(SObjectField lookupFieldOnChildObject)`
+-   `Soql.Subquery(Schema.ChildRelationship relationship)`
+-   `Soql.Subquery(SObjectField lookupFieldOnChildObject)`
 
 </details>
 

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -336,6 +336,18 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 			return this;
 		}
 
+		public Soql.InnerQuery toInnerQuery() {
+			return (Soql.InnerQuery) this;
+		}
+
+		public Soql toSoql() {
+			return (Soql) this;
+		}
+
+		public Soql.Subquery toSubquery() {
+			return (Soql.Subquery) this;
+		}
+
 		// * SELECT *
 		@SuppressWarnings('PMD.EagerlyLoadedDescribeSObjectResult')
 		public Soql.Builder selectAll() {
@@ -375,8 +387,8 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 			return this.deselect(ID_REFERENCE)?.addSelect(aggregation?.toString());
 		}
 
-		public Soql.Builder addSelect(Soql.SubQuery subQuery) {
-			return this.addSelect(subQuery.toString());
+		public Soql.Builder addSelect(Soql.Subquery Subquery) {
+			return this.addSelect(Subquery.toString());
 		}
 
 		// * FROM *
@@ -817,12 +829,12 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 	public class Subquery extends Soql.InnerQuery {
 		private String relationshipName;
 
-		public SubQuery(Schema.ChildRelationship relationship) {
+		public Subquery(Schema.ChildRelationship relationship) {
 			this.addSelect(ID_REFERENCE);
 			this.relationshipName = relationship?.getRelationshipName();
 		}
 
-		public SubQuery(SObjectField lookupFieldOnChildObject) {
+		public Subquery(SObjectField lookupFieldOnChildObject) {
 			this(ChildRelationshipService.getChildRelationshipFrom(lookupFieldOnChildObject));
 		}
 

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -1088,6 +1088,55 @@ private class SoqlTest {
 		Assert.areEqual(identifier, theQuery?.identifier, 'Wrong query identifier');
 	}
 
+	@IsTest
+	static void shouldCastToInnerQuery() {
+		Soql.Builder builder = new Soql.InnerQuery(Case.SObjectType)?.addSelect(Case.AccountId);
+
+		Test.startTest();
+		Soql.InnerQuery result = builder?.toInnerQuery();
+		Test.stopTest();
+
+		Assert.areEqual(builder?.toString(), result?.toString(), 'Wrong query string');
+	}
+
+	@IsTest
+	static void shouldCastToSoql() {
+		Soql.Builder builder = DatabaseLayer.Soql.newQuery(Case.SObjectType)?.addSelect(Case.AccountId);
+
+		Test.startTest();
+		Soql result = builder?.toSoql();
+		Test.stopTest();
+
+		Assert.areEqual(builder?.toString(), result?.toString(), 'Wrong query string');
+	}
+
+	@IsTest
+	static void shouldCastToSubquery() {
+		Soql.Builder builder = new Soql.Subquery(Case.AccountId)?.addSelect(Case.Status);
+
+		Test.startTest();
+		Soql.Subquery result = builder?.toSubquery();
+		Test.stopTest();
+
+		Assert.areEqual(builder?.toString(), result?.toString(), 'Wrong query string');
+	}
+
+	@SuppressWarnings('PMD.EmptyCatchBlock')
+	@IsTest
+	static void shouldThrowExceptionIfInvalidCasting() {
+		Soql.Builder builder = new Soql.Subquery(Case.AccountId)?.addSelect(Case.Status);
+
+		Test.startTest();
+		// Subquery is never an instance of Soql!
+		try {
+			Soql result = builder?.toSoql();
+			Assert.fail('Did not throw a System.TypeException');
+		} catch (System.TypeException error) {
+			// As expected...
+		}
+		Test.stopTest();
+	}
+
 	// **** HELPER **** //
 	static Object validateQuery(Soql soql, String expected) {
 		Assert.areEqual('"' + expected + '"', '"' + soql?.toString() + '"', 'Unexpected SOQL output');


### PR DESCRIPTION
Closes #33 

Adds three new methods to `Soql.Builder`, which casts it to explict subtypes:
- `toInnerQuery()`
- `toSoql()`
- `toSubquery()`

This is useful for method chaining in complex queries. Most `Soql.Builder` methods returns itself; without this, we have to explicitly cast each object at the end of the call.

Before:
```java
Soql soql = (Soql) DatabaseLayer.newQuery(Account.SObjectType)?.addSelect(Account.OwnerId);
```

After:
```java
Soql soql = DatabaseLayer.newQuery(Account.SObjectType)?.addSelect(Account.OwnerId)?.toSoql();
```
