### PR TITLE
#44: New `Soql` Methods to support up to 5 `addSelect` entities at once

### DIFF
--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -85,8 +85,8 @@ MockSoql.Simulator simulator = new MyCustomQueryLogic();
 MockSoql.setGlobalMock(simulator);
 ```
 
--   `MockSoql.Simulator static setGlobalMock(MockSoql.Simulator simulator)`
--   `MockSoql.StaticResults static setGlobalMock()`
+- `MockSoql.Simulator static setGlobalMock(MockSoql.Simulator simulator)`
+- `MockSoql.StaticResults static setGlobalMock()`
     </details>
 
 <details>
@@ -112,8 +112,8 @@ MockSoql queryToMock = (MockSoql) MyClass.SOME_QUERY;
 queryToMock?.setMock(simulator);
 ```
 
--   `MockSoql.Simulator setMock(MockSoql.Simulator simulator)`
--   `MockSoql.StaticResults setMock()`
+- `MockSoql.Simulator setMock(MockSoql.Simulator simulator)`
+- `MockSoql.StaticResults setMock()`
 
 </details>
 
@@ -124,7 +124,7 @@ The `MockSoql.Simulator` interface defines custom logic for returning query resu
 
 The interface has one required method:
 
--   `List<Object> simulateQuery(Soql queryToMock)`
+- `List<Object> simulateQuery(Soql queryToMock)`
 
 Callers can conditionally return results based on the details of the provided `Soql` argument. For example, you if the query is `FROM Task`, return a list of Tasks:
 
@@ -176,8 +176,8 @@ This object implements `MockSoql.Simulator` interface, and includes methods whic
 
 Injects an error to be thrown each time the query runs. Callers can provide a specific exception object, if desired. The 0-argument overload of this method will inject a generic `System.QueryException`.
 
--   `MockSoql.StaticResults withError(System.Exception error)`
--   `MockSoql.StaticResults withError()`
+- `MockSoql.StaticResults withError(System.Exception error)`
+- `MockSoql.StaticResults withError()`
 
 ```java
 DatabaseLayer.useMocks();
@@ -192,7 +192,7 @@ MockSoql.setGlobalMock()?.withError(someOtherError);
 
 Injects a static list of results. This list will be returned each time the query runs.
 
--   `MockSoql.StaticResults withResults(List<Object> results)`
+- `MockSoql.StaticResults withResults(List<Object> results)`
 
 ```java
 DatabaseLayer.useMocks();
@@ -223,8 +223,8 @@ List<Soql.AggregateResult> results = soql?.aggregateQuery();
 
 Adds a column to the current `AggregateResult`. These can be created with or without an _alias_. If an alias isn't provided, the column is assigned a default alias, ex. `expr0'`. This mirrors the behavior of the underlying `Schema.AggregateResult` object.
 
--   `MockSoql.AggregateResult addParameter(String alias, Object value)`
--   `MockSoql.AggregateResult addParameter(Object value)`
+- `MockSoql.AggregateResult addParameter(String alias, Object value)`
+- `MockSoql.AggregateResult addParameter(Object value)`
 
 </details>
 
@@ -284,9 +284,9 @@ static void cannotMockBatchableQueryLocator() {
 
 Developers can employ one of the following strategies to work around this:
 
--   Have your unit tests call the batch's `start`, `execute`, and `finish` methods invidually.
--   Amend the `start` method to return an [iterable object](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_iterable.htm) instead.
--   Use `System.Queueable` jobs paired with a `System.Finalizer` instead of `Database.Batchable`.
+- Have your unit tests call the batch's `start`, `execute`, and `finish` methods invidually.
+- Amend the `start` method to return an [iterable object](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_iterable.htm) instead.
+- Use `System.Queueable` jobs paired with a `System.Finalizer` instead of `Database.Batchable`.
     </details>
 
 ---
@@ -302,32 +302,32 @@ The `Soql` class contains several methods which provide parity with the query me
 
 Performs aggregate queries and returns results as a list of `Soql.AggregateResult` objects. This type wraps the `Schema.AggregateResult` objects to provide mockable results in tests.
 
--   `List<Soql.AggregateResult> aggregateQuery()`
+- `List<Soql.AggregateResult> aggregateQuery()`
 
 #### `countQuery`
 
 Executes a count query, which should only contain aggregation functions like `COUNT()`. Returns the count of records that match the query.
 
--   `Integer countQuery()`
+- `Integer countQuery()`
 
 #### `getQueryLocator`
 
 Retrieves a `Soql.QueryLocator` object that can be used to iterate over query results.
 
--   `Soql.QueryLocator getQueryLocator()`
+- `Soql.QueryLocator getQueryLocator()`
 
 #### `query`
 
 Executes the query and returns the results as a list of `SObject`. Alternatively, this method can return results as a specific `returnType`, ie., for aggregate queries.
 
--   `List<SObject> query()`
--   `Object query(Type returnType)`
+- `List<SObject> query()`
+- `Object query(Type returnType)`
 
 #### `queryFirst`
 
 Fetches the first result of the query or returns `null` if no results are found. This method is useful for cases where only a single result is expected.
 
--   `SObject queryFirst()`
+- `SObject queryFirst()`
 
 </details>
 
@@ -352,100 +352,115 @@ Soql query = (Soql) DatabaseLayer.Soql
 
 Adds conditions to the HAVING clause of the query.
 
--   `Soql.Builder addHaving(Soql.Aggregation agg, Soql.Operator operator, Object value)`
+- `Soql.Builder addHaving(Soql.Aggregation agg, Soql.Operator operator, Object value)`
 
 #### `addSelect`
 
 Adds fields or aggregations to the SELECT clause of the query.
 
--   `Soql.Builder addSelect(String fieldName, String alias)`
--   `Soql.Builder addSelect(SObjectField field, String alias)`
--   `Soql.Builder addSelect(String fieldName)`
--   `Soql.Builder addSelect(SObjectField field)`
--   `Soql.Builder addSelect(Soql.Aggregation aggregation)`
--   `Soql.Builder addSelect(Soql.Subquery subQuery)`
+- `Soql.Builder addSelect(String fieldName, String alias)`
+- `Soql.Builder addSelect(SObjectField field, String alias)`
+- `Soql.Builder addSelect(String fieldName)`
+- `Soql.Builder addSelect(List<SObjectField> fields)`
+- `Soql.Builder addSelect(SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4, SObjectField field5)`
+- `Soql.Builder addSelect(SObjectField field1, SObjectField field2, SObjectField field3, SObjectField field4)`
+- `Soql.Builder addSelect(SObjectField field1, SObjectField field2, SObjectField field3)`
+- `Soql.Builder addSelect(SObjectField field1, SObjectField field2)`
+- `Soql.Builder addSelect(SObjectField field)`
+- `Soql.Builder addSelect(List<Soql.Aggregation> aggregations)`
+- `Soql.Builder addSelect(Soql.Aggregation agg1, Soql.Aggregation agg2, Soql.Aggregation agg3, Soql.Aggregation agg4, Soql.Aggregation agg5)`
+- `Soql.Builder addSelect(Soql.Aggregation agg1, Soql.Aggregation agg2, Soql.Aggregation agg3, Soql.Aggregation agg4)`
+- `Soql.Builder addSelect(Soql.Aggregation agg1, Soql.Aggregation agg2, Soql.Aggregation agg3)`
+- `Soql.Builder addSelect(Soql.Aggregation agg1, Soql.Aggregation agg2`
+- `Soql.Builder addSelect(Soql.Aggregation aggregation)`
+- `Soql.Builder addSelect(List<Soql.Subquery> subqueries)`
+- `Soql.Builder addSelect(Soql.Subquery sub1, Soql.Subquery sub2, Soql.Subquery sub3, Soql.Subquery sub4, Soql.Subquery sub5)`
+- `Soql.Builder addSelect(Soql.Subquery sub1, Soql.Subquery sub2, Soql.Subquery sub3, Soql.Subquery sub4)`
+- `Soql.Builder addSelect(Soql.Subquery sub1, Soql.Subquery sub2, Soql.Subquery sub3)`
+- `Soql.Builder addSelect(Soql.Subquery sub1, Soql.Subquery sub2)`
+- `Soql.Builder addSelect(Soql.Subquery subQuery)`
 
 #### `addWhere`
 
 Adds conditions to the WHERE clause of the query.
 
--   `Soql.Builder addWhere(Soql.Criteria criteria)`
--   `Soql.Builder addWhere(String fieldName, Soql.Operator operator, Object value)`
--   `Soql.Builder addWhere(SObjectField field, Soql.Operator operator, Object value)`
--   `Soql.Builder addWhere(String fieldName, Soql.Operator operator, Soql.Binder binder)`
--   `Soql.Builder addWhere(SObjectField field, Soql.Operator operator, Soql.Binder binder)`
+- `Soql.Builder addWhere(Soql.Criteria criteria)`
+- `Soql.Builder addWhere(String fieldName, Soql.Operator operator, Object value)`
+- `Soql.Builder addWhere(SObjectField field, Soql.Operator operator, Object value)`
+- `Soql.Builder addWhere(String fieldName, Soql.Operator operator, Soql.Binder binder)`
+- `Soql.Builder addWhere(SObjectField field, Soql.Operator operator, Soql.Binder binder)`
 
 #### `bind`
 
 Adds binding variables to the query. Binding variables are used to dynamically insert values into the query.
 
--   `Soql.Builder bind(Map<String, Object> bindMap)`
--   `Soql.Builder bind(String key, Object value)`
--   `Soql.Builder bind(Soql.Binder binder)`
+- `Soql.Builder bind(Map<String, Object> bindMap)`
+- `Soql.Builder bind(String key, Object value)`
+- `Soql.Builder bind(Soql.Binder binder)`
 
 #### `defineAccess`
 
 Sets the access level for the query.
 
--   `Soql.Builder defineAccess(System.AccessLevel accessLevel)`
+- `Soql.Builder defineAccess(System.AccessLevel accessLevel)`
 
 #### `deselect`
 
 Removes specific fields from the SELECT clause of the query.
 
--   `Soql.Builder deselect(String fieldName)`
--   `Soql.Builder deselect(SObjectField field)`
+- `Soql.Builder deselect(String fieldName)`
+- `Soql.Builder deselect(SObjectField field)`
 
 #### `deselectAll`
 
 Removes all fields from the SELECT clause of the query, essentially clearing any previously selected fields.
 
--   `Soql.Builder deselectAll()`
+- `Soql.Builder deselectAll()`
 
 #### `fromSObject`
 
 Sets the entity from which to query data. Only call this method if you need to override the SObjectType set when constructing the query, via the `DatabaseLayer.Soql.newQuery(SObjectType objectType)` method.
 
--   `Soql.Builder fromSObject(SObjectType objectType)`
+- `Soql.Builder fromSObject(SObjectType objectType)`
 
 #### `groupBy`
 
 Adds fields to the GROUP BY clause of the query.
 
--   `Soql.Builder groupBy(String fieldName)`
--   `Soql.Builder groupBy(SObjectField field)`
+- `Soql.Builder groupBy(String fieldName)`
+- `Soql.Builder groupBy(SObjectField field)`
 
 #### `orderBy`
 
 Adds fields to the ORDER BY clause of the query.
 
--   `Soql.Builder orderBy(Soql.SortOrder sortOrder)`
--   `Soql.Builder orderBy(String fieldName, Soql.SortDirection direction)`
--   `Soql.Builder orderBy(SObjectField field, Soql.SortDirection direction)`
+- `Soql.Builder orderBy(Soql.SortOrder sortOrder)`
+- `Soql.Builder orderBy(String fieldName, Soql.SortDirection direction)`
+- `Soql.Builder orderBy(SObjectField field, Soql.SortDirection direction)`
 
 #### `reset`
 
 Resets the builder to its default state, clearing all previously set clauses and parameters.
 
--   `Soql.Builder reset()`
+- `Soql.Builder reset()`
 
 #### `selectAll`
 
 Selects all fields from the specified entity by querying the schema for all available fields.
 
--   `Soql.Builder selectAll()`
+- `Soql.Builder selectAll()`
 
 #### `setOuterHavingLogic`
 
 Sets the logical operator (AND/OR) for combining HAVING conditions.
 
--   `Soql.Builder setOuterHavingLogic(Soql.LogicType newLogicType)`
+- `Soql.Builder setOuterHavingLogic(Soql.LogicType newLogicType)`
 
 #### `setQueryIdentifier`
 
 Assigns an identifier to the query. Callers can use this identifier to distinguish queries from one another, for example in mocks.
 
--   `Soql setQueryIdentifier(String identifier)`
+- `Soql setQueryIdentifier(String identifier)`
 
 ```java
 // In MyClass.cls:
@@ -472,55 +487,55 @@ private class MyQueryMock implements MockSoql.Simulator {
 
 Sets the maximum number of rows to return in the query result.
 
--   `Soql.Builder setRowLimit(Integer rowLimit)`
+- `Soql.Builder setRowLimit(Integer rowLimit)`
 
 #### `setRowOffset`
 
 Sets the number of rows to skip before starting to return results.
 
--   `Soql.Builder setRowOffset(Integer rowOffset)`
+- `Soql.Builder setRowOffset(Integer rowOffset)`
 
 #### `setUsage`
 
 Sets the usage context for the query.
 
--   `Soql.Builder setUsage(Soql.Usage usage)`
+- `Soql.Builder setUsage(Soql.Usage usage)`
 
 #### `setOuterWhereLogic`
 
 Sets the logical operator (AND/OR) for combining WHERE conditions.
 
--   `Soql.Builder setOuterWhereLogic(Soql.LogicType newLogicType)`
+- `Soql.Builder setOuterWhereLogic(Soql.LogicType newLogicType)`
 
 #### `toInnerQuery`
 
 Explicitly casts the current `Soql.Builder` to a `Soql.InnerQuery` instance. Useful for chaining complex queries.
 
--   `Soql.InnerQuery toInnerQuery()`
+- `Soql.InnerQuery toInnerQuery()`
 
 #### `toSoql`
 
 Explicitly casts the current `Soql.Builder` to a `Soql` instance. Useful for chaining complex queries.
 
--   `Soql toSoql()`
+- `Soql toSoql()`
 
 #### `toSubquery`
 
 Explicitly casts the current `Soql.Builder` to a `Soql.Subquery` instance. Useful for chaining complex queries.
 
--   `Soql.Subquery toSubquery()`
+- `Soql.Subquery toSubquery()`
 
 #### `usingScope`
 
 Sets the scope for the query.
 
--   `Soql.Builder usingScope(Soql.Scope scope)`
+- `Soql.Builder usingScope(Soql.Scope scope)`
 
 #### `withSecurityEnforced`
 
 Enforces security in the query to ensure that the user has appropriate access to the queried records.
 
--   `Soql.Builder withSecurityEnforced()`
+- `Soql.Builder withSecurityEnforced()`
 
 </details>
 
@@ -535,7 +550,7 @@ Wraps the `Schema.AggregateResult` class, which cannot be mocked otherwise. Obje
 
 Calls the underlying `Schema.AggregateResult` object's `get` method. The `key` parameter refers to the field alias if one is assigned, or the parameter's index in query preceded by the `expr` if one is not assigned (x, `expr0`).
 
--   `get(String key)`
+- `get(String key)`
 
 </details>
 
@@ -546,21 +561,21 @@ Represents an aggregate expression in a SOQL query. For example, `COUNT(Id) numR
 
 Each `Soql.Aggregation` is comprised of the following:
 
--   (required) a `Soql.Function` (ex., `COUNT`
--   (usually) a field (ex., `Id`)
--   (optionally) An alias (ex, `numRecords`)
+- (required) a `Soql.Function` (ex., `COUNT`
+- (usually) a field (ex., `Id`)
+- (optionally) An alias (ex, `numRecords`)
 
 #### Constructors
 
--   `Soql.Aggregation(Soql.Function, String innerFieldName)`
--   `Soql.Aggregation(Soql.Function, SObjectField field)`
--   `Soql.Aggregation(Soql.Function)`
+- `Soql.Aggregation(Soql.Function, String innerFieldName)`
+- `Soql.Aggregation(Soql.Function, SObjectField field)`
+- `Soql.Aggregation(Soql.Function)`
 
 #### `withAlias`
 
 Adds an alias to the aggregation. Ex., `numRecords`.
 
--   `Soql.Aggregation withAlias(String alias)`
+- `Soql.Aggregation withAlias(String alias)`
 
 </details>
 
@@ -573,26 +588,26 @@ Use this method in conjunction with the `addWhere` and `bind` SOQL methods.
 
 #### Constructors
 
--   `Soql.Binder(String key, Object value)`
--   `Soql.Binder(String key)`
+- `Soql.Binder(String key, Object value)`
+- `Soql.Binder(String key)`
 
 #### `getKey`
 
 Returns the name of the bind variable to be used in the query.
 
--   `String getKey()`
+- `String getKey()`
 
 #### `getValue`
 
 Returns the underlying value to be substituted at runtime during the query.
 
--   `Object getValue()`
+- `Object getValue()`
 
 #### `setValue`
 
 Set the underlying value to be substituted for the bind variable. This is done at runtime, when the query is actually made, via the `Database.queryWithBinds()` method.
 
--   `Soql.Binder setValue(Object value)`
+- `Soql.Binder setValue(Object value)`
 
 </details>
 
@@ -634,8 +649,8 @@ Like `Soql.ConditionalLogic`, the `Soql.Conditional` class implements a base `So
 
 #### Constructors
 
--   `Soql.Condition(String property, Soql.Operator operator, Object value)`
--   `Soql.Condition(SObjectField field, Soql.Operator operator, Object value)`
+- `Soql.Condition(String property, Soql.Operator operator, Object value)`
+- `Soql.Condition(SObjectField field, Soql.Operator operator, Object value)`
 
 </details>
 
@@ -733,16 +748,16 @@ Like `Soql.Condition`, the `Soql.ConditionalLogic` class implements a base `Soql
 
 Adds a `Soql.Criteria` object (`Soql.Condition` or another `Soql.ConditionalLogic` object(s)) to the current list of criterion.
 
--   `Soql.ConditionalLogic addCondition(List<Soql.Criteria> criterion)`
--   `Soql.ConditionalLogic addCondition(Soql.Criteria criteria)`
--   `Soql.ConditionalLogic addCondition(String fieldName, Soql.Operator operator, Object value)`
--   `Soql.ConditionalLogic addCondition(SObjectField field, Soql.Operator operator, Object value)`
+- `Soql.ConditionalLogic addCondition(List<Soql.Criteria> criterion)`
+- `Soql.ConditionalLogic addCondition(Soql.Criteria criteria)`
+- `Soql.ConditionalLogic addCondition(String fieldName, Soql.Operator operator, Object value)`
+- `Soql.ConditionalLogic addCondition(SObjectField field, Soql.Operator operator, Object value)`
 
 #### `setLogicType`
 
 Determines the enclosing `Soql.LogicType` object. This affects the delimiter that will be applied to the `Soql.ConditionalLogic`'s criterion at runtime; `ANY_CONDITIONS` will produce an "OR" delimiter. `ALL_CONDITIONS` will produce an "AND" delimiter. By default, the `Soql.ConditionalLogic` uses `Soql.LogicType.ALL_CONDITIONS`; there is no need to set this explicitly in most cases except for changing this to use "OR" logic.
 
--   `Soql.ConditionalLogic setLogicType(Soql.LogicType logicType)`
+- `Soql.ConditionalLogic setLogicType(Soql.LogicType logicType)`
 
 </details>
 
@@ -763,19 +778,19 @@ List<SObject> records = cursor?.fetch(0, 10);
 
 Fetches cursor rows that correspond to the offset position and the specified record count.
 
--   `List<SObject> fetch(Integer position, Integer count)`
+- `List<SObject> fetch(Integer position, Integer count)`
 
 #### `getCursor`
 
 Returns the underlying `Database.QueryLocator` object used to construct this object.
 
--   `Database.QueryLocator getLocator()`
+- `Database.QueryLocator getLocator()`
 
 #### `getNumRecords`
 
 Gets the number of rows returned in an Apex cursor from a `Cursor.fetch` operation.
 
--   `Integer getNumRecords()`
+- `Integer getNumRecords()`
 
 </details>
 
@@ -784,13 +799,13 @@ Gets the number of rows returned in an Apex cursor from a `Cursor.fetch` operati
 
 Enumerates the different [Aggregate Functions](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_agg_functions.htm) that can be used in SOQL queries. Valid options include:
 
--   `AVG`
--   `COUNT`
--   `COUNT_DISTINCT`
--   `FORMAT`
--   `MIN`
--   `MAX`
--   `SUM`
+- `AVG`
+- `COUNT`
+- `COUNT_DISTINCT`
+- `FORMAT`
+- `MIN`
+- `MAX`
+- `SUM`
 
 </details>
 
@@ -809,7 +824,7 @@ Soql soql = (Soql) Database.Soql.newQuery(Account.SObjectType)
 
 This class extends `Soql.Builder`, and therefore has all of the same query-building [methods](#building-queries).
 
--   `InnerQuery(SObjectType objectType)`
+- `InnerQuery(SObjectType objectType)`
 
 </details>
 
@@ -825,8 +840,8 @@ This custom exception type wraps the standard `System.InvalidParameterValueExcep
 
 Indicates the enclosing logic for the `Soql.ConditionalLogic` objects used in _WHERE_ or _HAVING_ clauses. Values include:
 
--   `ALL_CONDITIONS`
--   `ANY_CONDITIONS`
+- `ALL_CONDITIONS`
+- `ANY_CONDITIONS`
 
 Use in the `setOuterWhereLogic` or `setOuterHavingLogic` SOQL methods. Example:
 
@@ -864,8 +879,8 @@ Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Opportunity.SObjectType)
 
 Indicates how null values should be processed in _ORDER BY_ clauses. Values include:
 
--   `NULLS_FIRST`
--   `NULLS_LAST`
+- `NULLS_FIRST`
+- `NULLS_LAST`
 
 Use this in conjunction with the `Soql.SortOrder` class's `setNullOrder` method. Example:
 
@@ -896,19 +911,19 @@ Soql.QueryLocator locator = soql?.getQueryLocator();
 
 Returns the underlying `Database.QueryLocator` object used to construct this object.
 
--   `Database.QueryLocator getLocator()`
+- `Database.QueryLocator getLocator()`
 
 #### `getQuery`
 
 Returns the query from the underlying `Database.QueryLocator`'s `getQuery()` method.
 
--   `String getQuery()`
+- `String getQuery()`
 
 #### `iterator`
 
 Returns a `System.Iterator<SObject>` from the underlying `Database.QueryLocator`'s `iterator()` method.
 
--   `System.Iterator<SObject> iterator()`
+- `System.Iterator<SObject> iterator()`
 
 </details>
 
@@ -917,13 +932,13 @@ Returns a `System.Iterator<SObject>` from the underlying `Database.QueryLocator`
 
 Enumerates possible values to be used with the optional [_USING SCOPE_](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_using_scope.htm) SOQL clause. Values include:
 
--   `DELEGATED`
--   `EVERYTHING`
--   `MINE`
--   `MINE_AND_MY_GROUPS`
--   `MY_TERRITORY`
--   `MY_TEAM_TERRITORY`
--   `TEAM`
+- `DELEGATED`
+- `EVERYTHING`
+- `MINE`
+- `MINE_AND_MY_GROUPS`
+- `MY_TERRITORY`
+- `MY_TEAM_TERRITORY`
+- `TEAM`
 
 Use this in conjunction with the `usingScope` SOQL method. For example:
 
@@ -939,8 +954,8 @@ Soql soql = (Soql) DatabaseLayer.Soql.newQuery(User.SObjectType)
 
 Indicates the direction of the _ORDER BY_ clause. Values include:
 
--   `ASCENDING`
--   `DESCENDING`
+- `ASCENDING`
+- `DESCENDING`
 
 Use this in conjunction with the `orderBy` SOQL method. For example:
 
@@ -969,16 +984,16 @@ Soql query = (Soql) DatabaseLayer.Soql
 
 #### Constructors
 
--   `SortOrder(List<String> fieldNames, Soql.SortDirection direction)`
--   `SortOrder(String fieldName, Soql.SortDirection)`
--   `SortOrder(List<SObjectField> fields, Soql.SortDirection direction)`
--   `SortOrder(SObjectField field, Soql.SortDirection direction)`
+- `SortOrder(List<String> fieldNames, Soql.SortDirection direction)`
+- `SortOrder(String fieldName, Soql.SortDirection)`
+- `SortOrder(List<SObjectField> fields, Soql.SortDirection direction)`
+- `SortOrder(SObjectField field, Soql.SortDirection direction)`
 
 #### `setNullOrder`
 
 Adds an optional "null order" clause to the `ORDER BY` condition. For example, "ORDER BY ExternalId\_\_c ASC NULLS LAST"
 
--   `Soql.SortOrder setNullOrder(Soql.NullOrder nullOrder)`
+- `Soql.SortOrder setNullOrder(Soql.NullOrder nullOrder)`
 
 </details>
 
@@ -999,8 +1014,8 @@ This class extends `Soql.Builder`, and therefore has all of the same query-build
 
 Constructors:
 
--   `Soql.Subquery(Schema.ChildRelationship relationship)`
--   `Soql.Subquery(SObjectField lookupFieldOnChildObject)`
+- `Soql.Subquery(Schema.ChildRelationship relationship)`
+- `Soql.Subquery(SObjectField lookupFieldOnChildObject)`
 
 </details>
 
@@ -1009,10 +1024,10 @@ Constructors:
 
 Enumerates possible values to be used with the optional query suffixes. Values include:
 
--   `ALL_ROWS`
--   `FOR_VIEW`
--   `FOR_REFERENCE`
--   `FOR_UPDATE`
+- `ALL_ROWS`
+- `FOR_VIEW`
+- `FOR_REFERENCE`
+- `FOR_UPDATE`
 
 Use this in conjunction with the SOQL `setUsage` method. For example:
 

--- a/docs/SOQL.md
+++ b/docs/SOQL.md
@@ -87,7 +87,7 @@ MockSoql.setGlobalMock(simulator);
 
 - `MockSoql.Simulator static setGlobalMock(MockSoql.Simulator simulator)`
 - `MockSoql.StaticResults static setGlobalMock()`
-    </details>
+      </details>
 
 <details>
   <summary><h4>The <code>setMock</code> Method</h4></summary>
@@ -287,7 +287,7 @@ Developers can employ one of the following strategies to work around this:
 - Have your unit tests call the batch's `start`, `execute`, and `finish` methods invidually.
 - Amend the `start` method to return an [iterable object](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_iterable.htm) instead.
 - Use `System.Queueable` jobs paired with a `System.Finalizer` instead of `Database.Batchable`.
-    </details>
+      </details>
 
 ---
 
@@ -799,13 +799,26 @@ Gets the number of rows returned in an Apex cursor from a `Cursor.fetch` operati
 
 Enumerates the different [Aggregate Functions](https://developer.salesforce.com/docs/atlas.en-us.soql_sosl.meta/soql_sosl/sforce_api_calls_soql_select_agg_functions.htm) that can be used in SOQL queries. Valid options include:
 
-- `AVG`
-- `COUNT`
-- `COUNT_DISTINCT`
-- `FORMAT`
-- `MIN`
-- `MAX`
-- `SUM`
+- `AVG`,
+- `CALENDAR_MONTH`,
+- `CALENDAR_QUARTER`,
+- `CALENDAR_YEAR`,
+- `COUNT`,
+- `COUNT_DISTINCT`,
+- `DAY_IN_MONTH`,
+- `DAY_IN_WEEK`,
+- `DAY_IN_YEAR`,
+- `DAY_ONLY`,
+- `FISCAL_MONTH`,
+- `FISCAL_QUARTER`,
+- `FISCAL_YEAR`,
+- `FORMAT`,
+- `HOUR_IN_DAY`,
+- `MIN`,
+- `MAX`,
+- `SUM`,
+- `WEEK_IN_MONTH`,
+- `WEEK_IN_YEAR`
 
 </details>
 

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -138,12 +138,25 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 	// **** ENUMS *** //
 	public enum Function {
 		AVG,
+		CALENDAR_MONTH,
+		CALENDAR_QUARTER,
+		CALENDAR_YEAR,
 		COUNT,
 		COUNT_DISTINCT,
+		DAY_IN_MONTH,
+		DAY_IN_WEEK,
+		DAY_IN_YEAR,
+		DAY_ONLY,
+		FISCAL_MONTH,
+		FISCAL_QUARTER,
+		FISCAL_YEAR,
 		FORMAT,
+		HOUR_IN_DAY,
 		MIN,
 		MAX,
-		SUM
+		SUM,
+		WEEK_IN_MONTH,
+		WEEK_IN_YEAR
 	}
 
 	public enum LogicType {
@@ -378,18 +391,121 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 			return this.addSelect(fieldName, '');
 		}
 
+		public Soql.Builder addSelect(List<SObjectField> fields) {
+			for (SObjectField field : fields) {
+				this.addSelect(field?.toString());
+			}
+			return this;
+		}
+
+		@SuppressWarnings('PMD.ExcessiveParameterList')
+		public Soql.Builder addSelect(
+			SObjectField field1,
+			SObjectField field2,
+			SObjectField field3,
+			SObjectField field4,
+			SObjectField field5
+		) {
+			// The Soql class supports up to 5 SObjectFields per addSelect call:
+			return this.addSelect(new List<SObjectField>{ field1, field2, field3, field4, field5 });
+		}
+
+		@SuppressWarnings('PMD.ExcessiveParameterList')
+		public Soql.Builder addSelect(
+			SObjectField field1,
+			SObjectField field2,
+			SObjectField field3,
+			SObjectField field4
+		) {
+			return this.addSelect(new List<SObjectField>{ field1, field2, field3, field4 });
+		}
+
+		public Soql.Builder addSelect(SObjectField field1, SObjectField field2, SObjectField field3) {
+			return this.addSelect(new List<SObjectField>{ field1, field2, field3 });
+		}
+
+		public Soql.Builder addSelect(SObjectField field1, SObjectField field2) {
+			return this.addSelect(new List<SObjectField>{ field1, field2 });
+		}
+
 		public Soql.Builder addSelect(SObjectField field) {
-			return this.addSelect(field?.toString());
+			return this.addSelect(new List<SObjectField>{ field });
+		}
+
+		public Soql.Builder addSelect(List<Soql.Aggregation> aggregations) {
+			// Note: Id should never be included in the SELECT clause for Aggregate queries
+			this.deselect(ID_REFERENCE);
+			for (Soql.Aggregation aggregation : aggregations) {
+				this.addSelect(aggregation?.toString());
+			}
+			return this;
+		}
+
+		public Soql.Builder addSelect(
+			Soql.Aggregation agg1,
+			Soql.Aggregation agg2,
+			Soql.Aggregation agg3,
+			Soql.Aggregation agg4,
+			Soql.Aggregation agg5
+		) {
+			// The Soql class supports up to 5 Soql.Aggregates per addSelect call:
+			return this.addSelect(new List<Soql.Aggregation>{ agg1, agg2, agg3, agg4, agg5 });
+		}
+
+		public Soql.Builder addSelect(
+			Soql.Aggregation agg1,
+			Soql.Aggregation agg2,
+			Soql.Aggregation agg3,
+			Soql.Aggregation agg4
+		) {
+			return this.addSelect(new List<Soql.Aggregation>{ agg1, agg2, agg3, agg4 });
+		}
+
+		public Soql.Builder addSelect(Soql.Aggregation agg1, Soql.Aggregation agg2, Soql.Aggregation agg3) {
+			return this.addSelect(new List<Soql.Aggregation>{ agg1, agg2, agg3 });
+		}
+
+		public Soql.Builder addSelect(Soql.Aggregation agg1, Soql.Aggregation agg2) {
+			return this.addSelect(new List<Soql.Aggregation>{ agg1, agg2 });
 		}
 
 		public Soql.Builder addSelect(Soql.Aggregation aggregation) {
-			// Note: Id should never be included in the SELECT clause for Aggregate queries
-			return this.deselect(ID_REFERENCE)?.addSelect(aggregation?.toString());
+			return this.addSelect(new List<Soql.Aggregation>{ aggregation });
+		}
+
+		public Soql.Builder addSelect(List<Soql.Subquery> subqueries) {
+			for (Soql.Subquery subquery : subqueries) {
+				this.addBindsFromChildQuery(subquery);
+				this.addSelect(subquery?.toString());
+			}
+			return this;
+		}
+
+		public Soql.Builder addSelect(
+			Soql.Subquery sub1,
+			Soql.Subquery sub2,
+			Soql.Subquery sub3,
+			Soql.Subquery sub4,
+			Soql.Subquery sub5
+		) {
+			// The Soql class supports up to 5 Soql.Subqueries per addSelect call:
+			return this.addSelect(new List<Soql.Subquery>{ sub1, sub2, sub3, sub4, sub5 });
+		}
+
+		public Soql.Builder addSelect(Soql.Subquery sub1, Soql.Subquery sub2, Soql.Subquery sub3, Soql.Subquery sub4) {
+			return this.addSelect(new List<Soql.Subquery>{ sub1, sub2, sub3, sub4 });
+		}
+
+		public Soql.Builder addSelect(Soql.Subquery sub1, Soql.Subquery sub2, Soql.Subquery sub3) {
+			return this.addSelect(new List<Soql.Subquery>{ sub1, sub2, sub3 });
+		}
+
+		public Soql.Builder addSelect(Soql.Subquery sub1, Soql.Subquery sub2) {
+			return this.addSelect(new List<Soql.Subquery>{ sub1, sub2 });
 		}
 
 		public Soql.Builder addSelect(Soql.Subquery subquery) {
-			this.addBindsFromChildQuery(subquery);
-			return this.addSelect(Subquery.toString());
+			return this.addSelect(new List<Soql.Subquery>{ subquery });
 		}
 
 		// * FROM *

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -290,6 +290,77 @@ private class SoqlTest {
 	}
 
 	@IsTest
+	static void shouldSelectListOfFields() {
+		List<SObjectField> fields = new List<SObjectField>{
+			Account.Name,
+			Account.NumberOfEmployees,
+			Account.OwnerId,
+			Account.CreatedDate,
+			Account.LastModifiedDate
+		};
+		Soql soql = DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(fields)?.toSoql();
+		String expected = 'SELECT Id, Name, NumberOfEmployees, OwnerId, CreatedDate, LastModifiedDate FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect5Fields() {
+		Soql soql = DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				Account.Name,
+				Account.NumberOfEmployees,
+				Account.OwnerId,
+				Account.CreatedDate,
+				Account.LastModifiedDate
+			)
+			?.toSoql();
+		String expected = 'SELECT Id, Name, NumberOfEmployees, OwnerId, CreatedDate, LastModifiedDate FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect4Fields() {
+		Soql soql = DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(Account.Name, Account.NumberOfEmployees, Account.OwnerId, Account.CreatedDate)
+			?.toSoql();
+		String expected = 'SELECT Id, Name, NumberOfEmployees, OwnerId, CreatedDate FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect3Fields() {
+		Soql soql = DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(Account.Name, Account.NumberOfEmployees, Account.OwnerId)
+			?.toSoql();
+		String expected = 'SELECT Id, Name, NumberOfEmployees, OwnerId FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect2Fields() {
+		Soql soql = DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(Account.Name, Account.NumberOfEmployees)
+			?.toSoql();
+		String expected = 'SELECT Id, Name, NumberOfEmployees FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
 	static void shouldSelectAggregation() {
 		Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT, User.Id);
 		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(User.SObjectType)?.addSelect(count);
@@ -301,10 +372,165 @@ private class SoqlTest {
 	}
 
 	@IsTest
+	static void shouldSelectListOfAggregations() {
+		List<Soql.Aggregation> aggs = new List<Soql.Aggregation>{
+			new Soql.Aggregation(Soql.Function.COUNT, Account.Id),
+			new Soql.Aggregation(Soql.Function.SUM, Account.NumberOfEmployees),
+			new Soql.Aggregation(Soql.Function.MIN, Account.NumberOfEmployees),
+			new Soql.Aggregation(Soql.Function.MAX, Account.NumberOfEmployees),
+			new Soql.Aggregation(Soql.Function.AVG, Account.NumberOfEmployees)
+		};
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(aggs);
+		String expected = 'SELECT COUNT(Id), SUM(NumberOfEmployees), MIN(NumberOfEmployees), MAX(NumberOfEmployees), AVG(NumberOfEmployees) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect5Aggregations() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				new Soql.Aggregation(Soql.Function.COUNT, Account.Id),
+				new Soql.Aggregation(Soql.Function.SUM, Account.NumberOfEmployees),
+				new Soql.Aggregation(Soql.Function.MIN, Account.NumberOfEmployees),
+				new Soql.Aggregation(Soql.Function.MAX, Account.NumberOfEmployees),
+				new Soql.Aggregation(Soql.Function.AVG, Account.NumberOfEmployees)
+			);
+		String expected = 'SELECT COUNT(Id), SUM(NumberOfEmployees), MIN(NumberOfEmployees), MAX(NumberOfEmployees), AVG(NumberOfEmployees) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect4Aggregations() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				new Soql.Aggregation(Soql.Function.COUNT, Account.Id),
+				new Soql.Aggregation(Soql.Function.SUM, Account.NumberOfEmployees),
+				new Soql.Aggregation(Soql.Function.MIN, Account.NumberOfEmployees),
+				new Soql.Aggregation(Soql.Function.MAX, Account.NumberOfEmployees)
+			);
+		String expected = 'SELECT COUNT(Id), SUM(NumberOfEmployees), MIN(NumberOfEmployees), MAX(NumberOfEmployees) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect3Aggregations() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				new Soql.Aggregation(Soql.Function.COUNT, Account.Id),
+				new Soql.Aggregation(Soql.Function.SUM, Account.NumberOfEmployees),
+				new Soql.Aggregation(Soql.Function.MIN, Account.NumberOfEmployees)
+			);
+		String expected = 'SELECT COUNT(Id), SUM(NumberOfEmployees), MIN(NumberOfEmployees) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect2Aggregations() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				new Soql.Aggregation(Soql.Function.COUNT, Account.Id),
+				new Soql.Aggregation(Soql.Function.SUM, Account.NumberOfEmployees)
+			);
+		String expected = 'SELECT COUNT(Id), SUM(NumberOfEmployees) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
 	static void shouldSelectSubquery() {
 		Soql.Subquery subquery = new Soql.Subquery(User.ProfileId);
 		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Profile.SObjectType)?.addSelect(subquery)?.setRowLimit(1);
 		String expected = 'SELECT Id, (SELECT Id FROM Users) FROM Profile LIMIT 1';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelectListOfSubqueries() {
+		List<Soql.Subquery> subqueries = new List<Soql.Subquery>{
+			new Soql.Subquery(Account.ParentId),
+			new Soql.Subquery(Case.AccountId),
+			new Soql.Subquery(Contact.AccountId),
+			new Soql.Subquery(Opportunity.AccountId),
+			new Soql.Subquery(AccountContactRole.AccountId)
+		};
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(subqueries);
+		String expected = 'SELECT Id, (SELECT Id FROM ChildAccounts), (SELECT Id FROM Cases), (SELECT Id FROM Contacts), (SELECT Id FROM Opportunities), (SELECT Id FROM AccountContactRoles) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect5Subqueries() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				new Soql.Subquery(Account.ParentId),
+				new Soql.Subquery(Case.AccountId),
+				new Soql.Subquery(Contact.AccountId),
+				new Soql.Subquery(Opportunity.AccountId),
+				new Soql.Subquery(AccountContactRole.AccountId)
+			);
+		String expected = 'SELECT Id, (SELECT Id FROM ChildAccounts), (SELECT Id FROM Cases), (SELECT Id FROM Contacts), (SELECT Id FROM Opportunities), (SELECT Id FROM AccountContactRoles) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect4Subqueries() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				new Soql.Subquery(Account.ParentId),
+				new Soql.Subquery(Case.AccountId),
+				new Soql.Subquery(Contact.AccountId),
+				new Soql.Subquery(Opportunity.AccountId)
+			);
+		String expected = 'SELECT Id, (SELECT Id FROM ChildAccounts), (SELECT Id FROM Cases), (SELECT Id FROM Contacts), (SELECT Id FROM Opportunities) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect3Subqueries() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(
+				new Soql.Subquery(Account.ParentId),
+				new Soql.Subquery(Case.AccountId),
+				new Soql.Subquery(Contact.AccountId)
+			);
+		String expected = 'SELECT Id, (SELECT Id FROM ChildAccounts), (SELECT Id FROM Cases), (SELECT Id FROM Contacts) FROM Account';
+
+		Test.startTest();
+		SoqlTest.validateQuery(soql, expected);
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldSelect2Subqueries() {
+		Soql soql = (Soql) DatabaseLayer.Soql.newQuery(Account.SObjectType)
+			?.addSelect(new Soql.Subquery(Account.ParentId), new Soql.Subquery(Case.AccountId));
+		String expected = 'SELECT Id, (SELECT Id FROM ChildAccounts), (SELECT Id FROM Cases) FROM Account';
 
 		Test.startTest();
 		SoqlTest.validateQuery(soql, expected);


### PR DESCRIPTION
Solves #44 by adding new `addSelect` overloads to the `Soql.Builder` class. This allows users to add multiples of the following types, either as a `List<T>` or by adding up to 5 instances of the same object 

- `SObjectField`
- `Soql.Aggregation`
- `Soql.Subquery`

Example:
```java

Soql query1 = DatabaseLayer.Soql.newQuery(Account.SObjectType)
  ?.addSelect(Account.Name, Account.OwnerId, Account.CreatedDate)
  ?.toSoql();

List<Soql.Aggregation> aggs = new List<Soql.Aggregation>{
  new Soql.Aggregation(Soql.Function.COUNT, Account.Id),
  new Soql.Aggregation(Soql.Function.MAX, Account.CreatedDate)
};
Soql query2 = DatabaseLayer.newQuery(Account.SObjectType)
  ?.addSelect(aggs)
  ?.toSoql();

Soql query3 = DatabaseLayer.newQuery(Account.SObjectType)
  ?.addSelect(Account.OwnerId, Account.CreatedDate)
  ?.addSelect(Case.AccountId, Contact.AccountId)
  ?.toSoql();
```

**Note:** We didn't include plain `String` members in this, since there's already an `addSelect` method that includes a second `String alias` property -- this would interfere:

```java
// The second addSelect String parameter here is the alias!  
Soql query = DatabaseLayer.Soql.newQuery(Account.SObjectType)
  ?.addSelect('Profile.Name', 'profileName')
  ?.groupBy('Profile.Name')
  ?.toSoql();
```

Also, bonus feature 🎉 Adds new date functions to the `Soql.Function` enum. This allows us to support date functions like `DAY_ONLY(CreatedDate)`. Not sure why these weren't previously supported...