### PR TITLE
Feature: Dml/MockDml Savepoints

### DIFF
--- a/docs/DML.md
+++ b/docs/DML.md
@@ -107,7 +107,9 @@ Read more about the `MockDml.ConditionalFailure` interface [here](#the-mockdmlco
 
 ### Simulating Savepoints & Rollbacks
 
-Out of the box, salesforce doesn't give you many tools to check how savepoints were used over the course of a test. When used in conjunction with the `Dml` class's savepoint methods, `MockDml` gives you the ability to inspect each savepoint generated in a transaction, along with details about how they were used, ie., whether they were rolled back or released:
+Out of the box, salesforce doesn't give you many tools to check how savepoints were used over the course of a test. When used in conjunction with the `Dml` class's savepoint methods, `MockDml` gives you the ability to inspect each savepoint generated in a transaction, along with details about how they were used, ie., whether they were rolled back or released.
+
+Example:
 
 ```java
 DatabaseLayer.useMocks();
@@ -153,6 +155,8 @@ The mock database (`MockDml.Database`) consists of several `History` objects, on
 - `MockDml.UNDELETED`
 - `MockDml.UPDATED`
 - `MockDml.UPSERTED`
+
+Example:
 
 ```java
 @IsTest
@@ -238,25 +242,43 @@ This method returns a shallow copy of the current `MockDatabase`, using JSON-ser
 
 The `MockDml.History` class stores records that were submitted for a particular DML operation while using mocks. It contains methods that allow callers to inspect what changes were made during the course of a test.
 
-The `MockDml.History` class includes three public methods:
+The `MockDml.History` class includes these public methods:
 
 ##### `eraseHistory`
 
-Clears the current History object; once called, the `getAll()` and `getRecords()` methods will return empty structures. Returns self.
+:warning: **Important**: This method is deprecated, and will soon be removed in a future release. Replace all instances of this method with `MockDml.eraseAllHistories()`.
+
+Clears the current History object.
 
 - `MockDml.History eraseHistory()`
 
+##### `get`
+
+Returns a specific record that was processed by the current DML operation. Returns `null` if no such record was processed.
+
+- `get(SObjectType objectType, String idOrUuid)`
+- `get(Id recordId)`
+- `get(SObject record)`
+
 ##### `getAll`
 
-Retrieves a map of records that were processed by the current DML operation, grouped by their `SObjectType`'s API Name.
+Retrieves a map of records that were processed by the current DML operation, grouped by their `SObjectType`:
 
-- `Map<String, List<SObject>> getAll()`
+- `Map<SObject, List<SObject>> getAll()`
 
 ##### `getRecords`
 
 Retrieves a list of all records of the provided `SObjectType` that were processed by the current DML operation.
 
 - `List<SObject> getRecords(SObjectType objectType)`
+
+##### `wasProcessed`
+
+Determines if a specific record was processed by the current DML operation.
+
+- `wasProcessed(SObjectType objectType, String idOrUuid)`
+- `wasProcessed(Id recordId)`
+- `wasProcessed(SObject record)`
 
 Example:
 
@@ -307,19 +329,6 @@ Assert.areEqual(false, sp?.wasReleased);
 
 This class stores all `MockDml.Savepoint` objects generated throughout a transction. You can interact with this class's methods to retrieve a specific savepoint, or all savepoints.
 
-Example:
-
-```java
-DatabaseLayer.useMocks();
-System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
-System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
-// Get all savepoints:
-List<MockDml.Savepoint> all = MockDml.SAVEPOINTS?.getAll();
-// Get a specific savepoint:
-MockDml.Savepoint first = MockDml.SAVEPOINTS?.get(0);
-MockDml.Savepoint second = MockDml.SAVEPOINTS?.get(sp2);
-```
-
 ##### `getAll`
 
 Returns all `MockDml.Savepoint` objects generated in a transaction, via `DatabaseLayer.Dml.setSavepoint()`.
@@ -332,3 +341,16 @@ Returns a specific `MockDml.Savepoint` object, by the specified index or `System
 
 - `MockDml.Savepoint get(Integer index)`
 - `MockDml.Savepoint get(System.Savepoint)`
+
+Example:
+
+```java
+DatabaseLayer.useMocks();
+System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
+System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
+// Get all savepoints:
+List<MockDml.Savepoint> all = MockDml.SAVEPOINTS?.getAll();
+// Get a specific savepoint:
+MockDml.Savepoint first = MockDml.SAVEPOINTS?.get(0);
+MockDml.Savepoint second = MockDml.SAVEPOINTS?.get(sp2);
+```

--- a/docs/DML.md
+++ b/docs/DML.md
@@ -46,7 +46,24 @@ The `MockDml` class can be used in placed of a normal `Dml` class in the `@IsTes
 
 ### Instantiating Mocks
 
-In `@IsTest` context, mock DML operations by calling the `DatabaseLayer.useMocks()` method. Once this is done, the `DatabaseLayer.Dml` method will return `MockDml` objects. If the `Dml` methood is called _before_ `useMocks()`, then those objects will continue to be instances of `Dml`. To prevent issues, call the `useMocks()` method as the first line in your test.
+In `@IsTest` context, mock DML operations by calling the `DatabaseLayer.useMocks()` method. Once this is done, the `DatabaseLayer.Dml` method will return `MockDml` objects. If the `Dml` methood is called _before_ `useMocks()`, then those objects will continue to be instances of `Dml`. To prevent issues, call the `useMocks()` method as the first line in your test:
+
+```java
+@IsTest
+static void example() {
+	DatabaseLayer.useMocks();
+	Case testCase = new Case();
+
+	Test.startTest();
+	DatabaseLayer.Dml.doInsert(testCase);
+	Assert.areEqual(0, Limits.getDmlStatements(), 'DML was processed?');
+	Test.stopTest();
+
+	Integer numInserted = MockDml.INSERTED?.getRecords(Case.SObjectType)?.size();
+	Assert.areEqual(1, numInserted, 'Wrong # of cases inserted');
+	Assert.isNotNull(testCase?.Id, 'Test Case was not inserted');
+}
+```
 
 ### Simulating DML Failures
 
@@ -86,42 +103,56 @@ Assert.isFalse(result?.isSuccess, 'DML Operation did not fail');
 Assert.isNull(account?.Id, 'Account was inserted');
 ```
 
-#### The `MockDml.ConditionalFailure` Interface
+Read more about the `MockDml.ConditionalFailure` interface [here](#the-mockdmlconditionalfailure-interface).
 
-Evaluates a given SObject record and DML operation, and returns an Exception object if the operation should fail for that record. If `null` is returned, the operation will succeed. If an Exception is returned, the operation will fail in accordance with the current `Dml` object's defined `allOrNone` behavior. This behavior mirrors standard DML `allOrNone` logic:
+### Simulating Savepoints & Rollbacks
 
--   If `allOrNone == true`, the Exception returned by the `checkFailure()` method is thrown, and the entire operation fails.
--   If `allOrNone == false`, only the current SObject fails. The matching Database Result object returned by the DML operation will indicate that the record failed. The resulting error message for the result is derived from the Exception returned by the `checkFailure()` method.
-
--   `checkFailure(MockDml.Operation operation, SObject record)`
+Out of the box, salesforce doesn't give you many tools to check how savepoints were used over the course of a test. When used in conjunction with the `Dml` class's savepoint methods, `MockDml` gives you the ability to inspect each savepoint generated in a transaction, along with details about how they were used, ie., whether they were rolled back or released:
 
 ```java
-public class ExampleFailure implements MockDml.ConditionalFailure {
-	public Exception checkFailure(MockDml.Operation operation, SObject record) {
-		// Fail any operations that manipulate Account records
-		if (record?.getSObjectType() == Account.SObjectType) {
-			return new System.DmlException();
-		} else {
-			// Success!
-			return null;
-		}
-	}
-}
+DatabaseLayer.useMocks();
+
+Test.startTest();
+System.Savepoint sp1 = Dml.setSavepoint();
+System.Savepoint sp2 = Dml.setSavepoint();
+System.Savepoint sp3 = Dml.setSavepoint();
+Dml.rollback(sp2);
+Dml.releaseSavepoint(sp3);
+Test.stopTest();
+
+Assert.areEqual(3, MockDml.SAVEPOINTS?.getAll()?.size(), 'Wrong # of savepoints');
+// sp1 should not be rolled back *or* released:
+MockDml.Savepoint mockSp1 = MockDml.SAVEPOINTS.get(0);
+Assert.areEqual(false, mockSp1?.wasReleased);
+Assert.areEqual(false, mockSp1?.wasRolledBack);
+// sp2 was rolled back:
+MockDml.Savepoint mockSp2 = MockDml.SAVEPOINTS.get(1);
+Assert.areEqual(false, mockSp2?.wasReleased);
+Assert.areEqual(true, mockSp2?.wasRolledBack);
+// sp3 was released:
+MockDml.Savepoint mockSp3 = MockDml.SAVEPOINTS.get(2);
+Assert.areEqual(true, mockSp3?.wasReleased);
+Assert.areEqual(false, mockSp3?.wasRolledBack);
 ```
+
+Read more about the `MockDml.Savepoint` class [here](#the-mockdmlsavepoint-class).
+
+Read more about the `MockDml.SavepointHistory` class [here](#the-mockdmlsavepointhistory-class).
 
 ### Validating DML Operations
 
-Since the `MockDml` class does not actually manipulate records in the database, you cannot use SOQL to retrieve changes. Instead, use the MockDml `History` objects to retrieve records that were manipulated by a `MockDml` instance.
+The `MockDml` class does not _actually_ manipulate records in the Salesforce database, so you cannot use SOQL to retrieve changes. Instead, use the MockDml's `MockDatabase` to reference records that were manipulated by `MockDml`.
 
-A `History` object exists for each major DML operation, and are enumerated as static properties on the `MockDml` class:
+This class consists of several `History` objects, one for each major DML operation. You can reference these through static getter properties:
 
--   `MockDml.CONVERTED`
--   `MockDml.DELETED`
--   `MockDml.INSERTED`
--   `MockDml.PUBLISHED`
--   `MockDml.UNDELETED`
--   `MockDml.UPDATED`
--   `MockDml.UPSERTED`
+- `MockDml.CONVERTED`
+- `MockDml.DELETED`
+- `MockDml.INSERTED`
+- `MockDml.PUBLISHED`
+- `MockDml.PURGED`
+- `MockDml.UNDELETED`
+- `MockDml.UPDATED`
+- `MockDml.UPSERTED`
 
 ```java
 @IsTest
@@ -138,22 +169,116 @@ static void someTest() {
 }
 ```
 
-Each of the above `History` object includes three public methods:
+Read more about the `MockDml.MockDatabase` class [here](#the-mockdmlmockdatabase-class).
 
-#### `eraseHistory`
+Read more about the `MockDml.History` class [here](#the-mockdmlhistory-class).
+
+### Public Inner Types
+
+#### The `MockDml.ConditionalFailure` Interface
+
+Evaluates a given SObject record and DML operation, and returns an Exception object if the operation should fail for that record.
+
+If `null` is returned, the operation will succeed. If an Exception is returned, the operation will fail in accordance with the current `Dml` object's defined `allOrNone` behavior. This behavior mirrors standard DML `allOrNone` logic:
+
+- If `allOrNone == true`, the Exception returned by the `checkFailure()` method is thrown, and the entire operation fails.
+- If `allOrNone == false`, only the current SObject fails. The matching Database Result object returned by the DML operation will indicate that the record failed. The resulting error message for the result is derived from the Exception returned by the `checkFailure()` method.
+
+The interface contains just one required method.
+
+##### `checkFailure`
+
+The only required method to be implemented by the interface. This method is called once per DML operation, per record submitted for processing.
+
+- `checkFailure(MockDml.Operation operation, SObject record)`
+
+Example:
+
+```java
+public class ExampleFailure implements MockDml.ConditionalFailure {
+	public Exception checkFailure(MockDml.Operation operation, SObject record) {
+		// Fail any operations that manipulate Account records
+		if (record?.getSObjectType() == Account.SObjectType) {
+			return new System.DmlException();
+		} else {
+			// Success!
+			return null;
+		}
+	}
+}
+```
+
+#### The `MockDml.History` Class
+
+The `MockDml.History` class stores records that were submitted for a particular DML operation while using mocks. It contains methods that allow callers to inspect what changes were made during the course of a test.
+
+The `MockDml.History` class includes three public methods:
+
+##### `eraseHistory`
 
 Clears the current History object; once called, the `getAll()` and `getRecords()` methods will return empty structures. Returns self.
 
--   `MockDml.History eraseHistory()`
+- `MockDml.History eraseHistory()`
 
-#### `getAll`
+##### `getAll`
 
-Retrieves a map of records that were processed by the current DML operation, grouped by their `SObjectType`.
+Retrieves a map of records that were processed by the current DML operation, grouped by their `SObjectType`'s API Name.
 
--   `Map<SObjectType, List<SObject>> getAll()`
+- `Map<String, List<SObject>> getAll()`
 
-#### `getRecords`
+##### `getRecords`
 
 Retrieves a list of all records of the provided `SObjectType` that were processed by the current DML operation.
 
--   `List<SObject> getRecords(SObjectType objectType)`
+- `List<SObject> getRecords(SObjectType objectType)`
+
+Example:
+
+```java
+@IsTest
+static void someTest() {
+	DatabaseLayer.useMocks();
+	Account acc = new Account(Name = 'John Doe');
+
+	Test.startTest();
+	DatabaseLayer.Dml.doInsert(acc);
+	Test.stopTest();
+
+	List<Account> insertedAccs = MockDml.INSERTED.getRecords(Account.SObjectType);
+	Assert.areEqual(1, insertedAccs?.size(), 'Account was not inserted');
+}
+```
+
+#### The `MockDml.MockDatabase` Class
+
+Simulates a Salesforce database when mocks are used. The class stores a `MockDml.History` object for each DML method, along with logic to handle savepoint/rollback behavior.
+
+This object is available as a public static property, `MockDml.mockDatabase`. A blank `MockDatabase` is initialized by default. As records are submitted for mock DML over time, the records are then added to the appropriate history object.
+
+This class has the following public properties:
+
+- `MockDml.RecordHistory converted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.CONVERTED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory deleted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.DELETED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory inserted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.INSERTED` getter property returns this value from the current mock database.
+- `MockDml.PlatformEventHistory published`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.PUBLISHED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory purged`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.PURGED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory undeleted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UNDELETED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory updated`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UPDATED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory upserted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UPSERTED` getter property returns this value from the current mock database.
+- `Boolean resetOnRollback`: This property determines how the database will behave when a rollback occurs.
+    - By default (`true`), savepoints will store a "snapshot" of the `MockDatabase` at the time that they were initialized. Rolling back the savepoint will then cause the `mockDatabase` to be replaced with that snapshot.
+    - If set to `false`, the database will "ignore" rollbacks. You'll be still be able to reference any records that were processed in the corresponding history object, even if they were rolled back. This may be desireable if you want to see what happened before the rollback occurred, or to improve performance in cases where this isn't needed.
+
+##### `snapshot`
+
+This method returns a shallow copy of the current `MockDatabase` object, using JSON-serialization. Changes to this snapshot object will not mutate the `MockDatabase` that generated it, and vice-versa.
+
+- `MockDatabase snapshot()`
+
+#### The `MockDml.Savepoint` Class
+
+TODO!
+
+#### The `MockDml.SavepointHistory` Class
+
+TODO!

--- a/docs/DML.md
+++ b/docs/DML.md
@@ -19,9 +19,7 @@ DatabaseLayer.useMocks();
 Assert.isInstanceOfType(DatabaseLayer.Dml, MockDml.class, 'Not a mock');
 ```
 
-## Public Methods
-
-### Performing DML
+## Performing DML
 
 The `Dml` class contains methods which mirror the functionality of DML methods in the standard [`Database` class](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_database.htm), including its numerous method overloads:
 
@@ -34,11 +32,33 @@ DatabaseLayer.Dml.doUpdate(account);
 
 Since DML keywords (like `insert`, `update`, and `delete`) are reserved, the `Dml` class's methods are prefixed with the "do" predicate. For example, `doInsert`, `doUpdate`, and `doDelete`.
 
-> **Note:** The `emptyRecycleBin` method name is not a reserved keyword, so the "do" predicate is not used:
->
-> ```java
-> DatabaseLayer.Dml.emptyRecycleBin(account);
-> ```
+You can also control `System.Savepoint`s via the Dml class. This allows you to reference `MockDml.Savepoint`s in tests, which can be used to assert how a savepoint behaved during a given transaction (ie., if a savepoint(s) were set, rolled back and/or released). Read more about this [here](#simulating-savepoints--rollbacks).
+
+```java
+System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+DatabaseLayer.Dml.rollback(savepoint);
+Assert.isTrue(MockDml.SAVEPOINTS.get(0).wasRolledBack);
+```
+
+### Public Methods
+
+- `doConvert`
+- `doDelete`
+- `doDeleteAsync`
+- `doDeleteImmediate`
+- `doInsert`
+- `doInsertAsync`
+- `doInsertImmediate`
+- `doPublish`
+- `doUndelete`
+- `doUpdate`
+- `doUpdateAsync`
+- `doUpdateImmediate`
+- `doUpsert`
+- `emptyRecycleBin`
+- `releaseSavepoint`
+- `rollback`
+- `setSavepoint`
 
 ## Mocking DML Operations
 
@@ -231,6 +251,8 @@ This class has the following public properties:
 - `Boolean resetOnRollback`: This property determines how the database will behave when a rollback occurs.
     - By default (`true`), savepoints will store a "snapshot" of the mock database at the time that they were initialized. Rolling back the savepoint will then cause the current `MockDatabase` to be replaced with that snapshot.
     - If set to `false`, the database will "ignore" rollbacks. You'll be still be able to reference any records that were processed in the corresponding history object, even if they were rolled back. This may be desireable if you want to see what happened before the rollback occurred, or to improve performance in cases where this isn't needed.
+
+The class has just one public method:
 
 ##### `snapshot`
 

--- a/docs/DML.md
+++ b/docs/DML.md
@@ -113,11 +113,11 @@ Out of the box, salesforce doesn't give you many tools to check how savepoints w
 DatabaseLayer.useMocks();
 
 Test.startTest();
-System.Savepoint sp1 = Dml.setSavepoint();
-System.Savepoint sp2 = Dml.setSavepoint();
-System.Savepoint sp3 = Dml.setSavepoint();
-Dml.rollback(sp2);
-Dml.releaseSavepoint(sp3);
+System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
+System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
+System.Savepoint sp3 = DatabaseLayer.Dml.setSavepoint();
+DatabaseLayer.Dml.rollback(sp2);
+DatabaseLayer.Dml.releaseSavepoint(sp3);
 Test.stopTest();
 
 Assert.areEqual(3, MockDml.SAVEPOINTS?.getAll()?.size(), 'Wrong # of savepoints');
@@ -141,9 +141,9 @@ Read more about the `MockDml.SavepointHistory` class [here](#the-mockdmlsavepoin
 
 ### Validating DML Operations
 
-The `MockDml` class does not _actually_ manipulate records in the Salesforce database, so you cannot use SOQL to retrieve changes. Instead, use the MockDml's `MockDatabase` to reference records that were manipulated by `MockDml`.
+The `MockDml` class does not _actually_ manipulate records in the Salesforce database, so you cannot use SOQL to retrieve changes. Instead, use the MockDml's mock `Database` object to reference records that were manipulated by `MockDml`.
 
-This class consists of several `History` objects, one for each major DML operation. You can reference these through static getter properties:
+The mock database (`MockDml.Database`) consists of several `History` objects, one for each major DML operation. You can reference the database these through static getter properties:
 
 - `MockDml.CONVERTED`
 - `MockDml.DELETED`
@@ -169,7 +169,7 @@ static void someTest() {
 }
 ```
 
-Read more about the `MockDml.MockDatabase` class [here](#the-mockdmlmockdatabase-class).
+Read more about the `MockDml.Database` class [here](#the-mockdmldatabase-class).
 
 Read more about the `MockDml.History` class [here](#the-mockdmlhistory-class).
 
@@ -207,6 +207,32 @@ public class ExampleFailure implements MockDml.ConditionalFailure {
 	}
 }
 ```
+
+#### The `MockDml.Database` Class
+
+Simulates a Salesforce database when mocks are used. The class stores a `MockDml.History` object for each DML method, along with logic to handle savepoint/rollback behavior.
+
+This object is available as a public static property, `MockDml.MockDatabase`. A blank database object is initialized by default. As records are submitted for mock DML over time, the records are then added to the appropriate history object.
+
+This class has the following public properties:
+
+- `MockDml.RecordHistory converted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.CONVERTED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory deleted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.DELETED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory inserted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.INSERTED` getter property returns this value from the current mock database.
+- `MockDml.PlatformEventHistory published`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.PUBLISHED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory purged`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.PURGED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory undeleted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UNDELETED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory updated`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UPDATED` getter property returns this value from the current mock database.
+- `MockDml.RecordHistory upserted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UPSERTED` getter property returns this value from the current mock database.
+- `Boolean resetOnRollback`: This property determines how the database will behave when a rollback occurs.
+    - By default (`true`), savepoints will store a "snapshot" of the mock database at the time that they were initialized. Rolling back the savepoint will then cause the current `MockDatabase` to be replaced with that snapshot.
+    - If set to `false`, the database will "ignore" rollbacks. You'll be still be able to reference any records that were processed in the corresponding history object, even if they were rolled back. This may be desireable if you want to see what happened before the rollback occurred, or to improve performance in cases where this isn't needed.
+
+##### `snapshot`
+
+This method returns a shallow copy of the current `MockDatabase`, using JSON-serialization. Changes to this snapshot object will not mutate the database object that generated it, and vice-versa.
+
+- `MockDml.Database snapshot()`
 
 #### The `MockDml.History` Class
 
@@ -248,32 +274,6 @@ static void someTest() {
 	Assert.areEqual(1, insertedAccs?.size(), 'Account was not inserted');
 }
 ```
-
-#### The `MockDml.MockDatabase` Class
-
-Simulates a Salesforce database when mocks are used. The class stores a `MockDml.History` object for each DML method, along with logic to handle savepoint/rollback behavior.
-
-This object is available as a public static property, `MockDml.mockDatabase`. A blank `MockDatabase` is initialized by default. As records are submitted for mock DML over time, the records are then added to the appropriate history object.
-
-This class has the following public properties:
-
-- `MockDml.RecordHistory converted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.CONVERTED` getter property returns this value from the current mock database.
-- `MockDml.RecordHistory deleted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.DELETED` getter property returns this value from the current mock database.
-- `MockDml.RecordHistory inserted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.INSERTED` getter property returns this value from the current mock database.
-- `MockDml.PlatformEventHistory published`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.PUBLISHED` getter property returns this value from the current mock database.
-- `MockDml.RecordHistory purged`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.PURGED` getter property returns this value from the current mock database.
-- `MockDml.RecordHistory undeleted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UNDELETED` getter property returns this value from the current mock database.
-- `MockDml.RecordHistory updated`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UPDATED` getter property returns this value from the current mock database.
-- `MockDml.RecordHistory upserted`: A read-only property containing a history object that stores all upserted records during a transaction. The `MockDml.UPSERTED` getter property returns this value from the current mock database.
-- `Boolean resetOnRollback`: This property determines how the database will behave when a rollback occurs.
-    - By default (`true`), savepoints will store a "snapshot" of the `MockDatabase` at the time that they were initialized. Rolling back the savepoint will then cause the `mockDatabase` to be replaced with that snapshot.
-    - If set to `false`, the database will "ignore" rollbacks. You'll be still be able to reference any records that were processed in the corresponding history object, even if they were rolled back. This may be desireable if you want to see what happened before the rollback occurred, or to improve performance in cases where this isn't needed.
-
-##### `snapshot`
-
-This method returns a shallow copy of the current `MockDatabase` object, using JSON-serialization. Changes to this snapshot object will not mutate the `MockDatabase` that generated it, and vice-versa.
-
-- `MockDatabase snapshot()`
 
 #### The `MockDml.Savepoint` Class
 

--- a/docs/DML.md
+++ b/docs/DML.md
@@ -277,8 +277,58 @@ static void someTest() {
 
 #### The `MockDml.Savepoint` Class
 
-TODO!
+This class decorates a `System.Savepoint` object, and keeps track of its usage throughout a transaction. Refer to this object's properties when you need to assert if a savepoint was rolled back or released.
+
+You can access `MockDml.Savepoint`s via the `MockDml.SavepointHistory` class, which is acccessible via the `MockDml.SAVEPOINTS` static property. Read more about the `MockDml.SavepointHistory` class [here](#the-mockdmlsavepointhistory-class).
+
+The object has the following properties:
+
+- `Integer index`: (Read-only) The Savepoint's index, corresponding with the number of savepoints generated in the transaction, starting with 0.
+- `String name`: (Read-only) The `System.Savepoint`'s name, which is discoverable via the savepoint's `toString()` implementation.
+- `Boolean wasReleased`: (Read-only) Indicates whether `DatabaseLayer.Dml.releaseSavepoint()` was called for the current savepoint.
+- `Booelan wasRolledBack`: (Read-only) Indicates whether `DatabaseLayer.Dml.rollback()` was called for the current savepoint.
+
+Example:
+
+```java
+DatabaseLayer.useMocks();
+System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+
+Test.startTest();
+DatabaseLayer.Dml.rollback(savepoint);
+Test.stopTest();
+
+MockDml.Savepoint sp = MockDml.SAVEPOINTS.get(0);
+Assert.areEqual(true, sp?.wasRolledBack);
+Assert.areEqual(false, sp?.wasReleased);
+```
 
 #### The `MockDml.SavepointHistory` Class
 
-TODO!
+This class stores all `MockDml.Savepoint` objects generated throughout a transction. You can interact with this class's methods to retrieve a specific savepoint, or all savepoints.
+
+Example:
+
+```java
+DatabaseLayer.useMocks();
+System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
+System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
+// Get all savepoints:
+List<MockDml.Savepoint> all = MockDml.SAVEPOINTS?.getAll();
+// Get a specific savepoint:
+MockDml.Savepoint first = MockDml.SAVEPOINTS?.get(0);
+MockDml.Savepoint second = MockDml.SAVEPOINTS?.get(sp2);
+```
+
+##### `getAll`
+
+Returns all `MockDml.Savepoint` objects generated in a transaction, via `DatabaseLayer.Dml.setSavepoint()`.
+
+- `List<MockDml.Savepoint> getAll()`
+
+##### `get`
+
+Returns a specific `MockDml.Savepoint` object, by the specified index or `System.Savepoint` object.
+
+- `MockDml.Savepoint get(Integer index)`
+- `MockDml.Savepoint get(System.Savepoint)`

--- a/force-app/main/default/classes/Dml.cls
+++ b/force-app/main/default/classes/Dml.cls
@@ -659,6 +659,24 @@ public with sharing virtual class Dml {
 		return this.emptyRecycleBin(new List<SObject>{ record })?.get(0);
 	}
 
+	// ** Savepoint Methods
+	/**
+	 * These System.Savepoint methods mirror the Database class's static methods
+	 * The benefit of calling these methods is largely to gain access to MockDml methods
+	 * to assert if/which savepoints were set, rolled back, released, etc.
+	 */
+	public virtual void releaseSavepoint(System.Savepoint savepoint) {
+		Database.releaseSavepoint(savepoint);
+	}
+
+	public virtual void rollback(System.Savepoint savepoint) {
+		Database.rollback(savepoint);
+	}
+
+	public virtual System.Savepoint setSavepoint() {
+		return Database.setSavepoint();
+	}
+
 	// **** PRIVATE **** //
 	private List<Id> getListOfIds(List<SObject> records) {
 		// Converts a List<SObject> into a List<Id>

--- a/force-app/main/default/classes/DmlTest.cls
+++ b/force-app/main/default/classes/DmlTest.cls
@@ -844,6 +844,28 @@ private class DmlTest {
 		}
 	}
 
+	@IsTest
+	static void shouldHandleSavepoints() {
+		Account account = DmlTest.initAccount();
+
+		Test.startTest();
+		try {
+			// Set a savepoint:
+			System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+			Assert.isNotNull(savepoint, 'Did not set a savepoint');
+			// Perform some DML:
+			insert account;
+			// Roll back that DML & release the savepoint:
+			DatabaseLayer.Dml.rollback(savepoint);
+			DatabaseLayer.Dml.releaseSavepoint(savepoint);
+		} catch (Exception error) {
+			Assert.fail(error?.toString());
+		}
+		Test.stopTest();
+
+		Assert.areEqual(0, [SELECT COUNT() FROM Account], 'DML operation was not rolled back');
+	}
+
 	// **** HELPER **** //
 	static LeadStatus getConvertedStatus() {
 		return [SELECT ApiName FROM LeadStatus WHERE IsConverted = TRUE LIMIT 1] ?? null;

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -437,7 +437,8 @@ public class MockDml extends Dml {
 		}
 
 		public Database snapshot() {
-			// Captures the state of the mock database at the current point in time:
+			// Captures the state of the mock database at the current point in time
+			// Note: Object.clone() retains the original reference, must use serialization to keep the snapshot separate:
 			// https://salesforce.stackexchange.com/questions/162765/object-clone-does-not-work-as-expected
 			return (MockDml.Database) JSON.deserialize(JSON.serialize(this), MockDml.Database.class);
 		}
@@ -472,8 +473,8 @@ public class MockDml extends Dml {
 		public Map<SObjectType, List<SObject>> getAll() {
 			// Retrieve all records processed by the current operation, grouped by SObjectType
 			Map<SObjectType, List<SObject>> allRecords = new Map<SObjectType, List<SObject>>();
-			for (String objectName : this.recordMap?.keySet()) {
-				SObjectType objectType = ((SObject) Type.forName(objectName)?.newInstance())?.getSObjectType();
+			for (String objectApiName : this.recordMap?.keySet()) {
+				SObjectType objectType = ((SObject) Type.forName(objectApiName)?.newInstance())?.getSObjectType();
 				List<SObject> recordList = this.getRecordMap(objectType)?.values();
 				allRecords?.put(objectType, recordList);
 			}
@@ -529,7 +530,8 @@ public class MockDml extends Dml {
 		}
 
 		protected Map<String, SObject> getRecordMap(SObjectType objectType) {
-			return this.recordMap?.get(objectType?.toString()) ?? new Map<String, SObject>();
+			String objectApiName = objectType?.toString();
+			return this.recordMap?.get(objectApiName) ?? new Map<String, SObject>();
 		}
 
 		protected MockDml.Result handleDmlError(SObject record, Exception error, Boolean allOrNone) {
@@ -553,9 +555,10 @@ public class MockDml extends Dml {
 			// and store them in a way that's easy for callers to get & perform asserts
 			record = this.setRecordId(record);
 			SObjectType objectType = record?.getSObjectType();
+			String objectApiName = objectType?.toString();
 			Map<String, SObject> records = this.getRecordMap(objectType);
 			this.addRecordToMap(record, records);
-			this.recordMap?.put(objectType?.toString(), records);
+			this.recordMap?.put(objectApiName, records);
 			return new MockDml.RecordResult(record);
 		}
 	}

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -9,67 +9,74 @@ public class MockDml extends Dml {
 	 * conditions in which operations should fail, via the `fail()` method,
 	 * or the `failIf()` method and the `ConditionalLogic` interface.
 	 **/
+
+	// **** CONSTANT **** //
 	public static final MockDml.SavepointHistory SAVEPOINTS = new MockDml.SavepointHistory();
 	private static final String EVENT_UUID_FIELD = 'EventUuid';
 	private static final String MOCK_STATUS_CODE = 'MOCK_DML';
-	private static MockDml.TransactionHistory currentTransaction = new MockDml.TransactionHistory();
 
-	public static MockDml.RecordHistory CONVERTED {
+	// **** STATIC **** //
+	public static MockDml.MockDatabase mockDatabase { get; private set; }
+
+	public static final MockDml.RecordHistory CONVERTED {
 		get {
-			return MockDml.currentTransaction?.converted;
+			return MockDml.MockDatabase?.converted;
 		}
 	}
-	public static MockDml.RecordHistory DELETED {
+	public static final MockDml.RecordHistory DELETED {
 		get {
-			return MockDml.currentTransaction?.deleted;
+			return MockDml.MockDatabase?.deleted;
 		}
 	}
-	public static MockDml.RecordHistory INSERTED {
+	public static final MockDml.RecordHistory INSERTED {
 		get {
-			return MockDml.currentTransaction?.inserted;
+			return MockDml.MockDatabase?.inserted;
 		}
 	}
 	public static MockDml.PlatformEventHistory PUBLISHED {
 		get {
-			return MockDml.currentTransaction?.published;
+			return MockDml.MockDatabase?.published;
 		}
 	}
-	public static MockDml.RecordHistory PURGED {
+	public static final MockDml.RecordHistory PURGED {
 		get {
-			return MockDml.currentTransaction?.purged;
+			return MockDml.MockDatabase?.purged;
 		}
 	}
-	public static MockDml.RecordHistory UNDELETED {
+	public static final MockDml.RecordHistory UNDELETED {
 		get {
-			return MockDml.currentTransaction?.undeleted;
+			return MockDml.MockDatabase?.undeleted;
 		}
 	}
-	public static MockDml.RecordHistory UPDATED {
+	public static final MockDml.RecordHistory UPDATED {
 		get {
-			return MockDml.currentTransaction?.updated;
+			return MockDml.MockDatabase?.updated;
 		}
 	}
-	public static MockDml.RecordHistory UPSERTED {
+	public static final MockDml.RecordHistory UPSERTED {
 		get {
-			return MockDml.currentTransaction?.upserted;
+			return MockDml.MockDatabase?.upserted;
 		}
 	}
 
-	// **** MEMBER **** //
-	private List<MockDml.ConditionalFailure> failures = new List<MockDml.ConditionalFailure>();
-
-	public MockDml(DatabaseLayer factory) {
-		super(factory);
+	static {
+		mockDatabase = new MockDml.MockDatabase();
 	}
 
-	// **** STATIC **** //
 	public static void eraseAllHistories() {
 		// Reset all of the history objects to their original state
 		// Useful for isolating the actual changes being tested, ie., after test setup
-		MockDml.currentTransaction = new MockDml.TransactionHistory();
+		MockDml.mockDatabase = new MockDml.MockDatabase();
 	}
 
 	// **** MEMBER **** //
+	private List<MockDml.ConditionalFailure> failures;
+
+	public MockDml(DatabaseLayer factory) {
+		super(factory);
+		this.failures = new List<MockDml.ConditionalFailure>();
+	}
+
 	public MockDml clearFailures() {
 		// Clears the list of failures from the current instance.
 		// As a result, all mock DML operations should now succeed.
@@ -263,7 +270,7 @@ public class MockDml extends Dml {
 
 	public override System.Savepoint setSavepoint() {
 		System.Savepoint savepoint = super.setSavepoint();
-		// Now register the savepoint in the mock database:
+		// Now register the savepoint in the mock MockDatabase:
 		MockDml.SAVEPOINTS?.add(savepoint);
 		return savepoint;
 	}
@@ -401,11 +408,11 @@ public class MockDml extends Dml {
 		 * It provides several methods that callers can use to assert if DML actually occurred.
 		 **/
 		protected MockDml.Operation operation;
-		protected Map<SObjectType, Map<String, SObject>> recordMap;
+		protected Map<String, Map<String, SObject>> recordMap;
 
 		protected History(MockDml.Operation operation) {
 			this.operation = operation;
-			this.recordMap = new Map<SObjectType, Map<String, SObject>>();
+			this.recordMap = new Map<String, Map<String, SObject>>();
 		}
 
 		// **** ABSTRACT **** //
@@ -418,12 +425,12 @@ public class MockDml extends Dml {
 			return this;
 		}
 
-		public Map<SObjectType, List<SObject>> getAll() {
+		public Map<String, List<SObject>> getAll() {
 			// Retrieve all records processed by the current operation, grouped by SObjectType
-			Map<SObjectType, List<SObject>> allRecords = new Map<SObjectType, List<SObject>>();
-			for (SObjectType objectType : this.recordMap?.keySet()) {
-				List<SObject> recordList = this.recordMap?.get(objectType)?.values();
-				allRecords?.put(objectType, recordList);
+			Map<String, List<SObject>> allRecords = new Map<String, List<SObject>>();
+			for (String objectName : this.recordMap?.keySet()) {
+				List<SObject> recordList = this.recordMap?.get(objectName)?.values();
+				allRecords?.put(objectName, recordList);
 			}
 			return allRecords;
 		}
@@ -446,7 +453,7 @@ public class MockDml extends Dml {
 		}
 
 		protected Map<String, SObject> getRecordMap(SObjectType objectType) {
-			return this.recordMap?.get(objectType) ?? new Map<String, SObject>();
+			return this.recordMap?.get(objectType?.toString()) ?? new Map<String, SObject>();
 		}
 
 		protected MockDml.Result handleDmlError(SObject record, Exception error, Boolean allOrNone) {
@@ -472,8 +479,46 @@ public class MockDml extends Dml {
 			SObjectType objectType = record?.getSObjectType();
 			Map<String, SObject> records = this.getRecordMap(objectType);
 			this.addRecordToMap(record, records);
-			this.recordMap?.put(objectType, records);
+			this.recordMap?.put(objectType?.toString(), records);
 			return new MockDml.RecordResult(record);
+		}
+	}
+
+	public class MockDatabase {
+		/**
+		 * This class represents a mock Salesforce Database. It stores all DML Methods' corresponding History objects
+		 */
+		public MockDml.RecordHistory converted { get; private set; }
+		public MockDml.RecordHistory deleted { get; private set; }
+		public MockDml.RecordHistory inserted { get; private set; }
+		public MockDml.PlatformEventHistory published { get; private set; }
+		public MockDml.RecordHistory purged { get; private set; }
+		public MockDml.RecordHistory undeleted { get; private set; }
+		public MockDml.RecordHistory updated { get; private set; }
+		public MockDml.RecordHistory upserted { get; private set; }
+		/**
+		 * When this configuration flag is "true", MockDml will mimic a real Database when a rollback occurs
+		 * This is "false" by default, for performance reasons (heap, cpu time, etc).
+		 * Only override this if your testing use case truly warrants it!
+		 **/
+		public Boolean resetOnRollback { get; set; }
+
+		private MockDatabase() {
+			this.converted = new MockDml.RecordHistory(MockDml.Operation.DO_CONVERT);
+			this.deleted = new MockDml.RecordHistory(MockDml.Operation.DO_DELETE);
+			this.inserted = new MockDml.RecordHistory(MockDml.Operation.DO_INSERT);
+			this.published = new MockDml.PlatformEventHistory();
+			this.purged = new MockDml.RecordHistory(MockDml.Operation.DO_PURGE);
+			this.undeleted = new MockDml.RecordHistory(MockDml.Operation.DO_UNDELETE);
+			this.updated = new MockDml.RecordHistory(MockDml.Operation.DO_UPDATE);
+			this.upserted = new MockDml.RecordHistory(MockDml.Operation.DO_UPSERT);
+			this.resetOnRollback = true;
+		}
+
+		public MockDatabase snapshot() {
+			// Captures the state of the MockDatabase at the current point in time:
+			// https://salesforce.stackexchange.com/questions/162765/object-clone-does-not-work-as-expected
+			return (MockDml.MockDatabase) JSON.deserialize(JSON.serialize(this), MockDml.MockDatabase.class);
 		}
 	}
 
@@ -585,8 +630,8 @@ public class MockDml extends Dml {
 		private void add(System.Savepoint savepoint) {
 			// Generate a MockDml.SystemSavepoint for the System.Savepoint, and map it by its index:
 			Integer index = this.getIndexFrom(savepoint);
-			MockDml.Savepoint info = new MockDml.Savepoint(savepoint, index);
-			this.savepointMap?.put(index, info);
+			MockDml.Savepoint savepointInfo = new MockDml.Savepoint(savepoint, index);
+			this.savepointMap?.put(index, savepointInfo);
 		}
 
 		private Integer getIndexFrom(System.Savepoint savepoint) {
@@ -602,14 +647,14 @@ public class MockDml extends Dml {
 		/**
 		 * This class decorates a System.Savepoint object
 		 * Test callers can use the class's methods to determine if the savepoint was saved, released, or rolled back
-		 * This also stores a shallow copy of the TransactionHistory at the time the savepoint was generated,
-		 * in the event of a rollback, the TransactionHistory will be reverted back to this point
+		 * This also stores a shallow copy of the MockDatabase at the time the savepoint was generated,
+		 * in the event of a rollback, the MockDatabase will be reverted back to this point
 		 */
 		public Integer index { get; private set; }
 		public String name { get; private set; }
 		public Boolean wasReleased { get; private set; }
 		public Boolean wasRolledBack { get; private set; }
-		private transient MockDml.TransactionHistory savepointState;
+		private transient MockDml.MockDatabase savepointState;
 
 		private Savepoint(System.Savepoint savepoint, Integer index) {
 			this.index = index;
@@ -620,52 +665,25 @@ public class MockDml extends Dml {
 		}
 
 		private void captureCurrentState() {
-			// Captures the state of the transaction at the time the savepoint was initialized
-			// Note: Object.clone produces a shallow copy, not a true copy
-			// JSON deserialization seems to be the only known way to do this:
-			// https://salesforce.stackexchange.com/questions/162765/object-clone-does-not-work-as-expected
-			this.savepointState = (MockDml.TransactionHistory) JSON.deserialize(
-				JSON.serialize(MockDml.currentTransaction),
-				MockDml.TransactionHistory.class
-			);
+			// Stores a copy of the mock database at the time the savepoint was initialized, if configured to do so
+			// If not configured to do so, returns null,
+			// which means that subsuquent rollbacks will not affect the current MockDml.MockDatabase
+			if (MockDml.MockDatabase.resetOnRollback == true) {
+				this.savepointState = MockDml.MockDatabase.snapshot();
+			}
 		}
 
 		private void release() {
 			// Release the current savepoint's state
-			// Subsuquent calls to rollback should not affect the TransactionHistory
+			// Subsuquent calls to rollback should not affect the MockDatabase
 			this.wasReleased = true;
 			this.savepointState = null;
 		}
 
 		private void rollback() {
-			// Revert the MockDml's TransactionHistory to what it was when the Savepoint was generated
-			MockDml.currentTransaction = this.savepointState ?? MockDml.currentTransaction;
+			// Revert the MockDml's MockDatabase to what it was when the Savepoint was generated
+			MockDml.mockDatabase = this.savepointState ?? MockDml.MockDatabase;
 			this.wasRolledBack = true;
-		}
-	}
-
-	public class TransactionHistory {
-		/**
-		 * This class represents the mock database at a particular point in time
-		 */
-		public MockDml.RecordHistory converted { get; private set; }
-		public MockDml.RecordHistory deleted { get; private set; }
-		public MockDml.RecordHistory inserted { get; private set; }
-		public MockDml.PlatformEventHistory published { get; private set; }
-		public MockDml.RecordHistory purged { get; private set; }
-		public MockDml.RecordHistory undeleted { get; private set; }
-		public MockDml.RecordHistory updated { get; private set; }
-		public MockDml.RecordHistory upserted { get; private set; }
-
-		private TransactionHistory() {
-			this.converted = new MockDml.RecordHistory(MockDml.Operation.DO_CONVERT);
-			this.deleted = new MockDml.RecordHistory(MockDml.Operation.DO_DELETE);
-			this.inserted = new MockDml.RecordHistory(MockDml.Operation.DO_INSERT);
-			this.published = new MockDml.PlatformEventHistory();
-			this.purged = new MockDml.RecordHistory(MockDml.Operation.DO_PURGE);
-			this.undeleted = new MockDml.RecordHistory(MockDml.Operation.DO_UNDELETE);
-			this.updated = new MockDml.RecordHistory(MockDml.Operation.DO_UPDATE);
-			this.upserted = new MockDml.RecordHistory(MockDml.Operation.DO_UPSERT);
 		}
 	}
 

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -462,16 +462,20 @@ public class MockDml extends Dml {
 
 		// **** PUBLIC **** //
 		public History eraseHistory() {
+			// ! Deprecated! Will be removed in a future release
+			// ! This functionality will not be supported 1:1 going forward;
+			// ! Replace usage of this method with MockDml.clearAllHistories()
 			this.recordMap?.clear();
 			return this;
 		}
 
-		public Map<String, List<SObject>> getAll() {
+		public Map<SObjectType, List<SObject>> getAll() {
 			// Retrieve all records processed by the current operation, grouped by SObjectType
-			Map<String, List<SObject>> allRecords = new Map<String, List<SObject>>();
+			Map<SObjectType, List<SObject>> allRecords = new Map<SObjectType, List<SObject>>();
 			for (String objectName : this.recordMap?.keySet()) {
-				List<SObject> recordList = this.recordMap?.get(objectName)?.values();
-				allRecords?.put(objectName, recordList);
+				SObjectType objectType = ((SObject) Type.forName(objectName)?.newInstance())?.getSObjectType();
+				List<SObject> recordList = this.getRecordMap(objectType)?.values();
+				allRecords?.put(objectType, recordList);
 			}
 			return allRecords;
 		}
@@ -479,6 +483,37 @@ public class MockDml extends Dml {
 		public List<SObject> getRecords(SObjectType objectType) {
 			// Retrieves all records of the specified SObjectType
 			return this.getRecordMap(objectType)?.values();
+		}
+
+		public SObject get(SObjectType objectType, String idOrUuuid) {
+			// Retrieves a specific record that was processed
+			// Use this method with platform events, who have a UUID but not a traditional Record ID with a reference to the SObjectType
+			return this.getRecordMap(objectType)?.get(idOrUuuid);
+		}
+
+		public SObject get(Id recordId) {
+			// Retrieves a specific record that was processed
+			SObjectType objectType = recordId?.getSObjectType();
+			return this.get(objectType, recordId);
+		}
+
+		public SObject get(SObject record) {
+			return this.get(record?.Id);
+		}
+
+		public Boolean wasProcessed(SObjectType objectType, String idOrUuid) {
+			// Returns true if the record was processed for DML, else returns false
+			return this.get(objectType, idOrUuid) != null;
+		}
+
+		public Boolean wasProcessed(Id recordId) {
+			// Returns true if the record was processed for DML, else returns false
+			SObjectType objectType = recordId?.getSObjectType();
+			return this.wasProcessed(objectType, recordId);
+		}
+
+		public Boolean wasProcessed(SObject record) {
+			return this.wasProcessed(record?.Id);
 		}
 
 		// **** PRIVATE **** //
@@ -536,7 +571,7 @@ public class MockDml extends Dml {
 		DO_UPSERT
 	}
 
-	public virtual class PlatformEventHistory extends History {
+	public virtual class PlatformEventHistory extends MockDml.History {
 		/**
 		 * This class tracks platform events that were mock published.
 		 * Necessary since platform events' unique identifier is the `EventUuid` field - not `Id`
@@ -562,7 +597,7 @@ public class MockDml extends Dml {
 		}
 	}
 
-	public virtual class RecordHistory extends History {
+	public virtual class RecordHistory extends MockDml.History {
 		/**
 		 * This class is responsible for tracking DML made against most SObject types
 		 **/
@@ -571,22 +606,16 @@ public class MockDml extends Dml {
 		}
 
 		public SObject getRecord(Id recordId) {
+			// ! Deprecated! Will be removed in a future release
+			// ! Replace usage of this method with the MockDml.History's get(Id recordId) method
 			// Retrieve a specific SObject from the History tracking
-			SObjectType objectType = recordId?.getSObjectType();
-			return this.getRecordMap(objectType)?.get(recordId);
+			return super.get(recordId);
 		}
 
 		public SObject getRecord(SObject record) {
-			return this.getRecord(record?.Id);
-		}
-
-		public Boolean wasProcessed(Id recordId) {
-			// Returns true if the provided recordId was processed by the DML operation
-			return this.getRecord(recordId) != null;
-		}
-
-		public Boolean wasProcessed(SObject record) {
-			return this.wasProcessed(record?.Id);
+			// ! Deprecated! Will be removed in a future release
+			// ! Replace usage of this method with the MockDml.History's get(SObject record) method
+			return super.get(record);
 		}
 
 		protected override void addRecordToMap(SObject record, Map<String, Object> records) {
@@ -691,7 +720,7 @@ public class MockDml extends Dml {
 	}
 
 	// **** INNER: PRIVATE **** //
-	private class BaseFailure implements ConditionalFailure {
+	private class BaseFailure implements MockDml.ConditionalFailure {
 		/**
 		 * The `MockDml` class ships with one concrete implementation of the `ConditionalFailure` interface.
 		 * This one is simple -- it always returns an error to be thrown.
@@ -732,7 +761,7 @@ public class MockDml extends Dml {
 		}
 	}
 
-	private virtual class LeadConvertResult extends Result {
+	private virtual class LeadConvertResult extends MockDml.Result {
 		/**
 		 * Mocks `Database.LeadConvertResult` objects
 		 * Unlike most Database result objects, `Database.LeadConvertResult` does not have a singular id field.
@@ -763,7 +792,7 @@ public class MockDml extends Dml {
 		}
 	}
 
-	private virtual class RecordResult extends Result {
+	private virtual class RecordResult extends MockDml.Result {
 		/**
 		 * Mocks most Database result types; ex., `Database.SaveResult`, `Database.DeleteResult`, etc.
 		 * Only `Database.LeadConvertResult` deviates from this type's structure.

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -1,5 +1,5 @@
 @SuppressWarnings(
-	'PMD.ApexDoc, PMD.CognitiveComplexity, PMD.CyclomaticComplexity, PMD.ExcessiveParameterList, PMD.FieldNamingConventions'
+	'PMD.ApexDoc, PMD.CognitiveComplexity, PMD.CyclomaticComplexity, PMD.ExcessiveParameterList, PMD.FieldNamingConventions, PMD.PropertyNamingConventions'
 )
 @IsTest
 public class MockDml extends Dml {
@@ -9,17 +9,51 @@ public class MockDml extends Dml {
 	 * conditions in which operations should fail, via the `fail()` method,
 	 * or the `failIf()` method and the `ConditionalLogic` interface.
 	 **/
-	// **** CONSTANTS **** //
-	public static final MockDml.RecordHistory CONVERTED = new MockDml.RecordHistory(MockDml.Operation.DO_CONVERT);
-	public static final MockDml.RecordHistory DELETED = new MockDml.RecordHistory(MockDml.Operation.DO_DELETE);
-	public static final MockDml.RecordHistory INSERTED = new MockDml.RecordHistory(MockDml.Operation.DO_INSERT);
-	public static final MockDml.PlatformEventHistory PUBLISHED = new MockDml.PlatformEventHistory();
-	public static final MockDml.RecordHistory PURGED = new MockDml.RecordHistory(MockDml.Operation.DO_PURGE);
-	public static final MockDml.RecordHistory UNDELETED = new MockDml.RecordHistory(MockDml.Operation.DO_UNDELETE);
-	public static final MockDml.RecordHistory UPDATED = new MockDml.RecordHistory(MockDml.Operation.DO_UPDATE);
-	public static final MockDml.RecordHistory UPSERTED = new MockDml.RecordHistory(MockDml.Operation.DO_UPSERT);
+	public static final MockDml.SavepointHistory SAVEPOINTS = new MockDml.SavepointHistory();
 	private static final String EVENT_UUID_FIELD = 'EventUuid';
 	private static final String MOCK_STATUS_CODE = 'MOCK_DML';
+	private static MockDml.TransactionHistory currentTransaction = new MockDml.TransactionHistory();
+
+	public static MockDml.RecordHistory CONVERTED {
+		get {
+			return MockDml.currentTransaction?.converted;
+		}
+	}
+	public static MockDml.RecordHistory DELETED {
+		get {
+			return MockDml.currentTransaction?.deleted;
+		}
+	}
+	public static MockDml.RecordHistory INSERTED {
+		get {
+			return MockDml.currentTransaction?.inserted;
+		}
+	}
+	public static MockDml.PlatformEventHistory PUBLISHED {
+		get {
+			return MockDml.currentTransaction?.published;
+		}
+	}
+	public static MockDml.RecordHistory PURGED {
+		get {
+			return MockDml.currentTransaction?.purged;
+		}
+	}
+	public static MockDml.RecordHistory UNDELETED {
+		get {
+			return MockDml.currentTransaction?.undeleted;
+		}
+	}
+	public static MockDml.RecordHistory UPDATED {
+		get {
+			return MockDml.currentTransaction?.updated;
+		}
+	}
+	public static MockDml.RecordHistory UPSERTED {
+		get {
+			return MockDml.currentTransaction?.upserted;
+		}
+	}
 
 	// **** MEMBER **** //
 	private List<MockDml.ConditionalFailure> failures = new List<MockDml.ConditionalFailure>();
@@ -32,19 +66,7 @@ public class MockDml extends Dml {
 	public static void eraseAllHistories() {
 		// Reset all of the history objects to their original state
 		// Useful for isolating the actual changes being tested, ie., after test setup
-		for (
-			MockDml.History history : new List<MockDml.History>{
-				MockDml.CONVERTED,
-				MockDml.DELETED,
-				MockDml.INSERTED,
-				MockDml.PUBLISHED,
-				MockDml.UNDELETED,
-				MockDml.UPDATED,
-				MockDml.UPSERTED
-			}
-		) {
-			history?.eraseHistory();
-		}
+		MockDml.currentTransaction = new MockDml.TransactionHistory();
 	}
 
 	// **** MEMBER **** //
@@ -227,6 +249,23 @@ public class MockDml extends Dml {
 			results?.add(result);
 		}
 		return this.toUpsertResults(results);
+	}
+
+	public override void releaseSavepoint(System.Savepoint savepoint) {
+		MockDml.SAVEPOINTS.get(savepoint)?.release();
+		super.releaseSavepoint(savepoint);
+	}
+
+	public override void rollback(System.Savepoint savepoint) {
+		MockDml.SAVEPOINTS.get(savepoint)?.rollback();
+		super.rollback(savepoint);
+	}
+
+	public override System.Savepoint setSavepoint() {
+		System.Savepoint savepoint = super.setSavepoint();
+		// Now register the savepoint in the mock database:
+		MockDml.SAVEPOINTS?.add(savepoint);
+		return savepoint;
 	}
 
 	// **** PRIVATE **** //
@@ -513,6 +552,109 @@ public class MockDml extends Dml {
 				record.Id = MockRecord.initRecordId(objectType);
 			}
 			return record;
+		}
+	}
+
+	public class SavepointHistory {
+		/**
+		 * This class maintains a map of MockDml.SavepointInfos,
+		 * and provides methods to easily get a particular savepoint by their index or by the object itself
+		 */
+		private Map<Integer, MockDml.SavepointInfo> savepointMap;
+
+		private SavepointHistory() {
+			this.savepointMap = new Map<Integer, MockDml.SavepointInfo>();
+		}
+
+		public List<MockDml.SavepointInfo> getAll() {
+			// Returns all registered MockDml.SavepointInfos:
+			return this.savepointMap?.values();
+		}
+
+		public MockDml.SavepointInfo get(Integer index) {
+			// Retrieves a MockDml.SavepointInfo by its index:
+			return this.savepointMap?.get(index);
+		}
+
+		public MockDml.SavepointInfo get(System.Savepoint savepoint) {
+			// Retrieves a System.Savepoint's MockDml.SavepointInfo wrapper:
+			Integer index = this.getIndexFrom(savepoint);
+			return this.savepointMap?.get(index);
+		}
+
+		private void add(System.Savepoint savepoint) {
+			// Generate a MockDml.SystemSavepoint for the System.Savepoint, and map it by its index:
+			Integer index = this.getIndexFrom(savepoint);
+			MockDml.SavepointInfo info = new MockDml.SavepointInfo(savepoint, index);
+			this.savepointMap?.put(index, info);
+		}
+
+		private Integer getIndexFrom(System.Savepoint savepoint) {
+			// Note: System.Savepoints don't have any known properties or methods,
+			// but printing them toString() reveals a hidden name: "SavepointValueX"
+			// where X is the ordered index of created savepoints in the transaction
+			// This method extracts that index, so that test callers can identify a particular savepoint if desired:
+			return Integer.valueOf(savepoint?.toString()?.replaceAll('[^0-9]', ''));
+		}
+	}
+
+	public class SavepointInfo {
+		/**
+		 * This class decorates a System.Savepoint object
+		 * Test callers can use the class's methods to determine if the savepoint was saved, released, or rolled back
+		 * This also stores a shallow copy of the TransactionHistory at the time the savepoint was generated,
+		 * in the event of a rollback, the TransactionHistory will be reverted back to this point
+		 */
+		public Integer index { get; private set; }
+		public String name { get; private set; }
+		public Boolean wasReleased { get; private set; }
+		public Boolean wasRolledBack { get; private set; }
+		private transient TransactionHistory savepointState;
+
+		private SavepointInfo(System.Savepoint savepoint, Integer index) {
+			this.index = index;
+			this.name = 'SavepointValue' + index;
+			this.wasReleased = false;
+			this.wasRolledBack = false;
+			this.savepointState = MockDml.currentTransaction?.clone();
+		}
+
+		private void release() {
+			// Release the current savepoint's state
+			// Subsuquent calls to rollback should not affect the TransactionHistory
+			this.wasReleased = true;
+			this.savepointState = null;
+		}
+
+		private void rollback() {
+			// Revert the MockDml's TransactionHistory to what it was when the Savepoint was generated
+			MockDml.currentTransaction = this.savepointState ?? MockDml.currentTransaction;
+			this.wasRolledBack = true;
+		}
+	}
+
+	public class TransactionHistory {
+		/**
+		 * This class represents the mock database at a particular point in time
+		 */
+		public MockDml.RecordHistory converted { get; private set; }
+		public MockDml.RecordHistory deleted { get; private set; }
+		public MockDml.RecordHistory inserted { get; private set; }
+		public MockDml.PlatformEventHistory published { get; private set; }
+		public MockDml.RecordHistory purged { get; private set; }
+		public MockDml.RecordHistory undeleted { get; private set; }
+		public MockDml.RecordHistory updated { get; private set; }
+		public MockDml.RecordHistory upserted { get; private set; }
+
+		private TransactionHistory() {
+			this.converted = new MockDml.RecordHistory(MockDml.Operation.DO_CONVERT);
+			this.deleted = new MockDml.RecordHistory(MockDml.Operation.DO_DELETE);
+			this.inserted = new MockDml.RecordHistory(MockDml.Operation.DO_INSERT);
+			this.published = new MockDml.PlatformEventHistory();
+			this.purged = new MockDml.RecordHistory(MockDml.Operation.DO_PURGE);
+			this.undeleted = new MockDml.RecordHistory(MockDml.Operation.DO_UNDELETE);
+			this.updated = new MockDml.RecordHistory(MockDml.Operation.DO_UPDATE);
+			this.upserted = new MockDml.RecordHistory(MockDml.Operation.DO_UPSERT);
 		}
 	}
 

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -11,12 +11,12 @@ public class MockDml extends Dml {
 	 **/
 
 	// **** CONSTANT **** //
-	public static final MockDml.SavepointHistory SAVEPOINTS = new MockDml.SavepointHistory();
-	private static final String EVENT_UUID_FIELD = 'EventUuid';
-	private static final String MOCK_STATUS_CODE = 'MOCK_DML';
+	public static final MockDml.SavepointHistory SAVEPOINTS;
+	private static final String EVENT_UUID_FIELD;
+	private static final String MOCK_STATUS_CODE;
 
 	// **** STATIC **** //
-	public static MockDml.MockDatabase mockDatabase { get; private set; }
+	public static MockDml.Database MockDatabase { get; private set; }
 
 	public static final MockDml.RecordHistory CONVERTED {
 		get {
@@ -60,13 +60,16 @@ public class MockDml extends Dml {
 	}
 
 	static {
-		mockDatabase = new MockDml.MockDatabase();
+		EVENT_UUID_FIELD = 'EventUuid';
+		MOCK_STATUS_CODE = 'MOCK_DML';
+		SAVEPOINTS = new MockDml.SavepointHistory();
+		MockDatabase = new MockDml.Database();
 	}
 
 	public static void eraseAllHistories() {
 		// Reset all of the history objects to their original state
 		// Useful for isolating the actual changes being tested, ie., after test setup
-		MockDml.mockDatabase = new MockDml.MockDatabase();
+		MockDml.MockDatabase = new MockDml.Database();
 	}
 
 	// **** MEMBER **** //
@@ -270,7 +273,7 @@ public class MockDml extends Dml {
 
 	public override System.Savepoint setSavepoint() {
 		System.Savepoint savepoint = super.setSavepoint();
-		// Now register the savepoint in the mock MockDatabase:
+		// Now register the savepoint in the mock database:
 		MockDml.SAVEPOINTS?.add(savepoint);
 		return savepoint;
 	}
@@ -402,6 +405,44 @@ public class MockDml extends Dml {
 		Exception checkFailure(MockDml.Operation operation, SObject record);
 	}
 
+	public class Database {
+		/**
+		 * This class represents a mock Salesforce Database. It stores all DML Methods' corresponding History objects
+		 */
+		public MockDml.RecordHistory converted { get; private set; }
+		public MockDml.RecordHistory deleted { get; private set; }
+		public MockDml.RecordHistory inserted { get; private set; }
+		public MockDml.PlatformEventHistory published { get; private set; }
+		public MockDml.RecordHistory purged { get; private set; }
+		public MockDml.RecordHistory undeleted { get; private set; }
+		public MockDml.RecordHistory updated { get; private set; }
+		public MockDml.RecordHistory upserted { get; private set; }
+		/**
+		 * When this configuration flag is "true", MockDml will mimic a real Database when a rollback occurs
+		 * This is "false" by default, for performance reasons (heap, cpu time, etc).
+		 * Only override this if your testing use case truly warrants it!
+		 **/
+		public Boolean resetOnRollback { get; set; }
+
+		private Database() {
+			this.converted = new MockDml.RecordHistory(MockDml.Operation.DO_CONVERT);
+			this.deleted = new MockDml.RecordHistory(MockDml.Operation.DO_DELETE);
+			this.inserted = new MockDml.RecordHistory(MockDml.Operation.DO_INSERT);
+			this.published = new MockDml.PlatformEventHistory();
+			this.purged = new MockDml.RecordHistory(MockDml.Operation.DO_PURGE);
+			this.undeleted = new MockDml.RecordHistory(MockDml.Operation.DO_UNDELETE);
+			this.updated = new MockDml.RecordHistory(MockDml.Operation.DO_UPDATE);
+			this.upserted = new MockDml.RecordHistory(MockDml.Operation.DO_UPSERT);
+			this.resetOnRollback = true;
+		}
+
+		public Database snapshot() {
+			// Captures the state of the mock database at the current point in time:
+			// https://salesforce.stackexchange.com/questions/162765/object-clone-does-not-work-as-expected
+			return (MockDml.Database) JSON.deserialize(JSON.serialize(this), MockDml.Database.class);
+		}
+	}
+
 	public abstract class History {
 		/**
 		 * Responsible for recording records that were processed by a given DML operation.
@@ -481,44 +522,6 @@ public class MockDml extends Dml {
 			this.addRecordToMap(record, records);
 			this.recordMap?.put(objectType?.toString(), records);
 			return new MockDml.RecordResult(record);
-		}
-	}
-
-	public class MockDatabase {
-		/**
-		 * This class represents a mock Salesforce Database. It stores all DML Methods' corresponding History objects
-		 */
-		public MockDml.RecordHistory converted { get; private set; }
-		public MockDml.RecordHistory deleted { get; private set; }
-		public MockDml.RecordHistory inserted { get; private set; }
-		public MockDml.PlatformEventHistory published { get; private set; }
-		public MockDml.RecordHistory purged { get; private set; }
-		public MockDml.RecordHistory undeleted { get; private set; }
-		public MockDml.RecordHistory updated { get; private set; }
-		public MockDml.RecordHistory upserted { get; private set; }
-		/**
-		 * When this configuration flag is "true", MockDml will mimic a real Database when a rollback occurs
-		 * This is "false" by default, for performance reasons (heap, cpu time, etc).
-		 * Only override this if your testing use case truly warrants it!
-		 **/
-		public Boolean resetOnRollback { get; set; }
-
-		private MockDatabase() {
-			this.converted = new MockDml.RecordHistory(MockDml.Operation.DO_CONVERT);
-			this.deleted = new MockDml.RecordHistory(MockDml.Operation.DO_DELETE);
-			this.inserted = new MockDml.RecordHistory(MockDml.Operation.DO_INSERT);
-			this.published = new MockDml.PlatformEventHistory();
-			this.purged = new MockDml.RecordHistory(MockDml.Operation.DO_PURGE);
-			this.undeleted = new MockDml.RecordHistory(MockDml.Operation.DO_UNDELETE);
-			this.updated = new MockDml.RecordHistory(MockDml.Operation.DO_UPDATE);
-			this.upserted = new MockDml.RecordHistory(MockDml.Operation.DO_UPSERT);
-			this.resetOnRollback = true;
-		}
-
-		public MockDatabase snapshot() {
-			// Captures the state of the MockDatabase at the current point in time:
-			// https://salesforce.stackexchange.com/questions/162765/object-clone-does-not-work-as-expected
-			return (MockDml.MockDatabase) JSON.deserialize(JSON.serialize(this), MockDml.MockDatabase.class);
 		}
 	}
 
@@ -647,14 +650,14 @@ public class MockDml extends Dml {
 		/**
 		 * This class decorates a System.Savepoint object
 		 * Test callers can use the class's methods to determine if the savepoint was saved, released, or rolled back
-		 * This also stores a shallow copy of the MockDatabase at the time the savepoint was generated,
-		 * in the event of a rollback, the MockDatabase will be reverted back to this point
+		 * This also stores a shallow copy of the mock database at the time the savepoint was generated,
+		 * in the event of a rollback, the mock database will be reverted back to this point
 		 */
 		public Integer index { get; private set; }
 		public String name { get; private set; }
 		public Boolean wasReleased { get; private set; }
 		public Boolean wasRolledBack { get; private set; }
-		private transient MockDml.MockDatabase savepointState;
+		private transient MockDml.Database savepointState;
 
 		private Savepoint(System.Savepoint savepoint, Integer index) {
 			this.index = index;
@@ -667,7 +670,7 @@ public class MockDml extends Dml {
 		private void captureCurrentState() {
 			// Stores a copy of the mock database at the time the savepoint was initialized, if configured to do so
 			// If not configured to do so, returns null,
-			// which means that subsuquent rollbacks will not affect the current MockDml.MockDatabase
+			// which means that subsuquent rollbacks will not affect the current MockDml.Database
 			if (MockDml.MockDatabase.resetOnRollback == true) {
 				this.savepointState = MockDml.MockDatabase.snapshot();
 			}
@@ -675,14 +678,14 @@ public class MockDml extends Dml {
 
 		private void release() {
 			// Release the current savepoint's state
-			// Subsuquent calls to rollback should not affect the MockDatabase
+			// Subsuquent calls to rollback should not affect the mock database
 			this.wasReleased = true;
 			this.savepointState = null;
 		}
 
 		private void rollback() {
-			// Revert the MockDml's MockDatabase to what it was when the Savepoint was generated
-			MockDml.mockDatabase = this.savepointState ?? MockDml.MockDatabase;
+			// Revert the mock database to what it was when the Savepoint was generated
+			MockDml.MockDatabase = this.savepointState ?? MockDml.MockDatabase;
 			this.wasRolledBack = true;
 		}
 	}

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -609,14 +609,25 @@ public class MockDml extends Dml {
 		public String name { get; private set; }
 		public Boolean wasReleased { get; private set; }
 		public Boolean wasRolledBack { get; private set; }
-		private transient TransactionHistory savepointState;
+		private transient MockDml.TransactionHistory savepointState;
 
 		private SavepointInfo(System.Savepoint savepoint, Integer index) {
 			this.index = index;
 			this.name = 'SavepointValue' + index;
 			this.wasReleased = false;
 			this.wasRolledBack = false;
-			this.savepointState = MockDml.currentTransaction?.clone();
+			this.captureCurrentState();
+		}
+
+		private void captureCurrentState() {
+			// Captures the state of the transaction at the time the savepoint was initialized
+			// Note: Object.clone produces a shallow copy, not a true copy
+			// JSON deserialization seems to be the only known way to do this:
+			// https://salesforce.stackexchange.com/questions/162765/object-clone-does-not-work-as-expected
+			this.savepointState = (MockDml.TransactionHistory) JSON.deserialize(
+				JSON.serialize(MockDml.currentTransaction),
+				MockDml.TransactionHistory.class
+			);
 		}
 
 		private void release() {

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -557,27 +557,27 @@ public class MockDml extends Dml {
 
 	public class SavepointHistory {
 		/**
-		 * This class maintains a map of MockDml.SavepointInfos,
+		 * This class maintains a map of MockDml.Savepoints,
 		 * and provides methods to easily get a particular savepoint by their index or by the object itself
 		 */
-		private Map<Integer, MockDml.SavepointInfo> savepointMap;
+		private Map<Integer, MockDml.Savepoint> savepointMap;
 
 		private SavepointHistory() {
-			this.savepointMap = new Map<Integer, MockDml.SavepointInfo>();
+			this.savepointMap = new Map<Integer, MockDml.Savepoint>();
 		}
 
-		public List<MockDml.SavepointInfo> getAll() {
-			// Returns all registered MockDml.SavepointInfos:
+		public List<MockDml.Savepoint> getAll() {
+			// Returns all registered MockDml.Savepoints:
 			return this.savepointMap?.values();
 		}
 
-		public MockDml.SavepointInfo get(Integer index) {
-			// Retrieves a MockDml.SavepointInfo by its index:
+		public MockDml.Savepoint get(Integer index) {
+			// Retrieves a MockDml.Savepoint by its index:
 			return this.savepointMap?.get(index);
 		}
 
-		public MockDml.SavepointInfo get(System.Savepoint savepoint) {
-			// Retrieves a System.Savepoint's MockDml.SavepointInfo wrapper:
+		public MockDml.Savepoint get(System.Savepoint savepoint) {
+			// Retrieves a System.Savepoint's MockDml.Savepoint wrapper:
 			Integer index = this.getIndexFrom(savepoint);
 			return this.savepointMap?.get(index);
 		}
@@ -585,7 +585,7 @@ public class MockDml extends Dml {
 		private void add(System.Savepoint savepoint) {
 			// Generate a MockDml.SystemSavepoint for the System.Savepoint, and map it by its index:
 			Integer index = this.getIndexFrom(savepoint);
-			MockDml.SavepointInfo info = new MockDml.SavepointInfo(savepoint, index);
+			MockDml.Savepoint info = new MockDml.Savepoint(savepoint, index);
 			this.savepointMap?.put(index, info);
 		}
 
@@ -598,7 +598,7 @@ public class MockDml extends Dml {
 		}
 	}
 
-	public class SavepointInfo {
+	public class Savepoint {
 		/**
 		 * This class decorates a System.Savepoint object
 		 * Test callers can use the class's methods to determine if the savepoint was saved, released, or rolled back
@@ -611,7 +611,7 @@ public class MockDml extends Dml {
 		public Boolean wasRolledBack { get; private set; }
 		private transient MockDml.TransactionHistory savepointState;
 
-		private SavepointInfo(System.Savepoint savepoint, Integer index) {
+		private Savepoint(System.Savepoint savepoint, Integer index) {
 			this.index = index;
 			this.name = 'SavepointValue' + index;
 			this.wasReleased = false;

--- a/force-app/main/default/classes/MockDmlTest.cls
+++ b/force-app/main/default/classes/MockDmlTest.cls
@@ -754,12 +754,28 @@ private class MockDmlTest {
 		DatabaseLayer.Dml.doInsert(accounts);
 
 		Test.startTest();
-		Map<String, List<SObject>> results = MockDml.INSERTED.getAll();
+		Map<SObjectType, List<SObject>> results = MockDml.INSERTED.getAll();
 		Test.stopTest();
 
-		String objectName = Account.SObjectType.toString();
-		Assert.isTrue(results?.containsKey(objectName), 'No Accounts inserted');
-		Assert.areEqual(accounts?.size(), results?.get(objectName)?.size(), 'Wrong # of Accounts inserted');
+		List<Account> insertedAccounts = results?.get(Account.SObjectType);
+		Assert.areEqual(accounts?.size(), insertedAccounts?.size(), 'Wrong # of Accounts inserted');
+	}
+
+	@IsTest
+	static void shouldGetSpecificRecordFromHistory() {
+		DatabaseLayer.useMockDml();
+		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
+		Account firstAccount = accounts?.get(0);
+		DatabaseLayer.Dml.doInsert(accounts);
+
+		Test.startTest();
+		DatabaseLayer.Dml.doInsert(accounts);
+		Test.stopTest();
+
+		Assert.isTrue(MockDml.INSERTED?.wasProcessed(firstAccount), 'Account was not inserted');
+		Assert.isFalse(MockDml.UPDATED?.wasProcessed(firstAccount), 'Account should not have updated');
+		Account insertedAccount = (Account) MockDml.INSERTED?.get(firstAccount);
+		Assert.areEqual(firstAccount?.Id, insertedAccount?.Id, 'Wrong Account retrieved');
 	}
 
 	@IsTest

--- a/force-app/main/default/classes/MockDmlTest.cls
+++ b/force-app/main/default/classes/MockDmlTest.cls
@@ -770,9 +770,9 @@ private class MockDmlTest {
 		Test.stopTest();
 
 		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
-		List<MockDml.SavepointInfo> savepointInfos = MockDml.SAVEPOINTS?.getAll();
+		List<MockDml.Savepoint> savepointInfos = MockDml.SAVEPOINTS?.getAll();
 		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');
-		MockDml.SavepointInfo savepointInfo = savepointInfos?.get(0);
+		MockDml.Savepoint savepointInfo = savepointInfos?.get(0);
 		Assert.isFalse(savepointInfo?.wasReleased, 'Should not have been released');
 		Assert.isFalse(savepointInfo?.wasRolledBack, 'Should not have been rolled back');
 	}
@@ -787,9 +787,9 @@ private class MockDmlTest {
 		Test.stopTest();
 
 		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
-		List<MockDml.SavepointInfo> savepointInfos = MockDml.SAVEPOINTS.getAll();
+		List<MockDml.Savepoint> savepointInfos = MockDml.SAVEPOINTS.getAll();
 		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');
-		MockDml.SavepointInfo savepointInfo = savepointInfos?.get(0);
+		MockDml.Savepoint savepointInfo = savepointInfos?.get(0);
 		Assert.isTrue(savepointInfo?.wasReleased, 'Was not released');
 		Assert.isFalse(savepointInfo?.wasRolledBack, 'Should not have been rolled back');
 	}
@@ -806,15 +806,15 @@ private class MockDmlTest {
 
 		Assert.isTrue(MockDml.INSERTED.getAll()?.isEmpty(), 'Did not roll back DML operation');
 		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
-		List<MockDml.SavepointInfo> savepointInfos = MockDml.SAVEPOINTS.getAll();
+		List<MockDml.Savepoint> savepointInfos = MockDml.SAVEPOINTS.getAll();
 		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');
-		MockDml.SavepointInfo savepointInfo = savepointInfos?.get(0);
+		MockDml.Savepoint savepointInfo = savepointInfos?.get(0);
 		Assert.isFalse(savepointInfo?.wasReleased, 'Should not have been released');
 		Assert.isTrue(savepointInfo?.wasRolledBack, 'Was not rolled back');
 	}
 
 	@IsTest
-	static void shouldGetASpecificSavepointInfoByIndex() {
+	static void shouldGetASpecificSavepointByIndex() {
 		DatabaseLayer.useMockDml();
 		System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
 		System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
@@ -822,17 +822,17 @@ private class MockDmlTest {
 		DatabaseLayer.Dml.rollback(sp2);
 
 		Test.startTest();
-		MockDml.SavepointInfo spInfo1 = MockDml.SAVEPOINTS.get(0);
+		MockDml.Savepoint spInfo1 = MockDml.SAVEPOINTS.get(0);
 		Assert.isNotNull(spInfo1, 'Did not return a Savepoint');
 		Assert.isFalse(spInfo1?.wasRolledBack, 'Should not have been rolled back');
-		MockDml.SavepointInfo spInfo2 = MockDml.SAVEPOINTS.get(1);
+		MockDml.Savepoint spInfo2 = MockDml.SAVEPOINTS.get(1);
 		Assert.isNotNull(spInfo2, 'Did not return a Savepoint');
 		Assert.isTrue(spInfo2?.wasRolledBack, 'Was not rolled back');
 		Test.stopTest();
 	}
 
 	@IsTest
-	static void shouldGetASpecificSavepointInfoBySavepoint() {
+	static void shouldGetASpecificSavepointBySavepoint() {
 		DatabaseLayer.useMockDml();
 		System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
 		System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
@@ -840,10 +840,10 @@ private class MockDmlTest {
 		DatabaseLayer.Dml.rollback(sp2);
 
 		Test.startTest();
-		MockDml.SavepointInfo spInfo1 = MockDml.SAVEPOINTS.get(sp1);
+		MockDml.Savepoint spInfo1 = MockDml.SAVEPOINTS.get(sp1);
 		Assert.isNotNull(spInfo1, 'Did not return a Savepoint');
 		Assert.isFalse(spInfo1?.wasRolledBack, 'Should not have been rolled back');
-		MockDml.SavepointInfo spInfo2 = MockDml.SAVEPOINTS.get(sp2);
+		MockDml.Savepoint spInfo2 = MockDml.SAVEPOINTS.get(sp2);
 		Assert.isNotNull(spInfo2, 'Did not return a Savepoint');
 		Assert.isTrue(spInfo2?.wasRolledBack, 'Was not rolled back');
 		Test.stopTest();

--- a/force-app/main/default/classes/MockDmlTest.cls
+++ b/force-app/main/default/classes/MockDmlTest.cls
@@ -797,10 +797,10 @@ private class MockDmlTest {
 	@IsTest
 	static void shouldHandleRolledBackSavepoints() {
 		DatabaseLayer.useMockDml();
-		DatabaseLayer.Dml.doInsert(new Account());
 
 		Test.startTest();
 		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+		DatabaseLayer.Dml.doInsert(new Account());
 		DatabaseLayer.Dml.rollback(savepoint);
 		Test.stopTest();
 

--- a/force-app/main/default/classes/MockDmlTest.cls
+++ b/force-app/main/default/classes/MockDmlTest.cls
@@ -754,11 +754,33 @@ private class MockDmlTest {
 		DatabaseLayer.Dml.doInsert(accounts);
 
 		Test.startTest();
-		Map<SObjectType, List<SObject>> results = MockDml.INSERTED.getAll();
+		Map<String, List<SObject>> results = MockDml.INSERTED.getAll();
 		Test.stopTest();
 
-		Assert.isTrue(results?.containsKey(Account.SObjectType), 'No Accounts inserted');
-		Assert.areEqual(accounts?.size(), results?.get(Account.SObjectType)?.size(), 'Wrong # of Accounts inserted');
+		String objectName = Account.SObjectType.toString();
+		Assert.isTrue(results?.containsKey(objectName), 'No Accounts inserted');
+		Assert.areEqual(accounts?.size(), results?.get(objectName)?.size(), 'Wrong # of Accounts inserted');
+	}
+
+	@IsTest
+	static void shouldCreateSnapshotOfMockDatabase() {
+		DatabaseLayer.useMockDml();
+		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
+		DatabaseLayer.Dml.doInsert(accounts);
+
+		Test.startTest();
+		// Take a snapshot
+		MockDml.MockDatabase snapshot = MockDml.mockDatabase?.snapshot();
+		Test.stopTest();
+
+		// Now simulate deleting the records:
+		DatabaseLayer.Dml.doDelete(accounts);
+		// Both the current MockDatabase & the snapshot should be aware Inserted records:
+		Assert.isFalse(MockDml.INSERTED?.getAll()?.isEmpty(), 'MockDatabase: Should have inserted records');
+		Assert.isFalse(snapshot?.inserted?.getAll()?.isEmpty(), 'Snapshot: Should have inserted records');
+		// Only the MockDatabase is aware of the deleted records:
+		Assert.isFalse(MockDml.DELETED?.getAll()?.isEmpty(), 'MockDatabase: Should have deleted records');
+		Assert.isTrue(snapshot?.deleted?.getAll()?.isEmpty(), 'Snapshot: Should not have deleted records');
 	}
 
 	@IsTest
@@ -797,6 +819,7 @@ private class MockDmlTest {
 	@IsTest
 	static void shouldHandleRolledBackSavepoints() {
 		DatabaseLayer.useMockDml();
+		MockDml.MockDatabase.resetOnRollback = true;
 
 		Test.startTest();
 		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
@@ -805,6 +828,26 @@ private class MockDmlTest {
 		Test.stopTest();
 
 		Assert.isTrue(MockDml.INSERTED.getAll()?.isEmpty(), 'Did not roll back DML operation');
+		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
+		List<MockDml.Savepoint> savepointInfos = MockDml.SAVEPOINTS.getAll();
+		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');
+		MockDml.Savepoint savepointInfo = savepointInfos?.get(0);
+		Assert.isFalse(savepointInfo?.wasReleased, 'Should not have been released');
+		Assert.isTrue(savepointInfo?.wasRolledBack, 'Was not rolled back');
+	}
+
+	@IsTest
+	static void shouldHandleRolledBackSavepointsWithoutResettingMockDatabase() {
+		DatabaseLayer.useMockDml();
+		MockDml.MockDatabase.resetOnRollback = false;
+
+		Test.startTest();
+		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+		DatabaseLayer.Dml.doInsert(new Account());
+		DatabaseLayer.Dml.rollback(savepoint);
+		Test.stopTest();
+
+		Assert.isFalse(MockDml.INSERTED.getAll()?.isEmpty(), 'Savepoint should not have reset DML history');
 		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
 		List<MockDml.Savepoint> savepointInfos = MockDml.SAVEPOINTS.getAll();
 		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');

--- a/force-app/main/default/classes/MockDmlTest.cls
+++ b/force-app/main/default/classes/MockDmlTest.cls
@@ -31,7 +31,7 @@ private class MockDmlTest {
 			'Wrong # of converted records'
 		);
 		for (Database.LeadConvertResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Id leadId = result?.getLeadId();
 			Lead lead = leads?.get(leadId);
 			Assert.areNotEqual(null, lead, 'No lead w/matching Id: ' + leadId);
@@ -69,7 +69,7 @@ private class MockDmlTest {
 			'Wrong # of converted records'
 		);
 		for (Database.LeadConvertResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Id leadId = result?.getLeadId();
 			Lead lead = leads?.get(leadId);
 			Assert.areNotEqual(null, lead, 'No lead w/matching Id: ' + leadId);
@@ -171,7 +171,7 @@ private class MockDmlTest {
 		Assert.areEqual(leadsToConvert?.size(), results?.size(), 'Wrong # of results');
 		Assert.areEqual(0, MockDml.CONVERTED?.getRecords(Lead.SObjectType)?.size(), 'Wrong # of converted records');
 		for (Database.LeadConvertResult result : results) {
-			Assert.areEqual(false, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isFalse(result?.isSuccess(), 'Should not have succeeded');
 		}
 	}
 
@@ -192,7 +192,7 @@ private class MockDmlTest {
 			'Wrong # of deleted records'
 		);
 		for (Database.DeleteResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isTrue(result?.isSuccess(), 'Should not have succeeded');
 		}
 	}
 
@@ -213,7 +213,7 @@ private class MockDmlTest {
 			'Wrong # of deleted records'
 		);
 		for (Database.DeleteResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isTrue(result?.isSuccess(), 'Should not have succeeded');
 		}
 	}
 
@@ -234,7 +234,7 @@ private class MockDmlTest {
 			'Wrong # of deleted records'
 		);
 		for (Database.DeleteResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isTrue(result?.isSuccess(), 'Should not have succeeded');
 		}
 	}
 
@@ -252,7 +252,7 @@ private class MockDmlTest {
 		Assert.areEqual(leads?.size(), results?.size(), 'Wrong # of results');
 		Assert.areEqual(results?.size(), MockDml.PURGED?.getRecords(Lead.SObjectType)?.size(), 'Wrong # purged');
 		for (Database.EmptyRecycleBinResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isTrue(result?.isSuccess(), 'Should not have succeeded');
 		}
 	}
 
@@ -286,7 +286,7 @@ private class MockDmlTest {
 		Assert.areEqual(leads?.size(), results?.size(), 'Wrong # of results');
 		Assert.areEqual(0, MockDml.DELETED?.getRecords(Lead.SObjectType)?.size(), 'Wrong # of deleted records');
 		for (Database.DeleteResult result : results) {
-			Assert.areEqual(false, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isFalse(result?.isSuccess(), 'Should not have succeeded');
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -308,7 +308,7 @@ private class MockDmlTest {
 			'Wrong # of inserted records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -330,7 +330,7 @@ private class MockDmlTest {
 			'Wrong # of inserted records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -352,7 +352,7 @@ private class MockDmlTest {
 			'Wrong # of inserted records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -387,7 +387,7 @@ private class MockDmlTest {
 		Assert.areEqual(leads?.size(), results?.size(), 'Wrong # of results');
 		Assert.areEqual(0, MockDml.INSERTED?.getRecords(Lead.SObjectType)?.size(), 'Wrong # of inserted records');
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(false, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isFalse(result?.isSuccess(), 'Should not have succeeded');
 			Assert.areEqual(null, result?.getId(), 'Insert failed, but has an Id?');
 		}
 	}
@@ -409,7 +409,7 @@ private class MockDmlTest {
 			'Wrong # of published records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -448,7 +448,7 @@ private class MockDmlTest {
 			'Wrong # of published records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(false, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isFalse(result?.isSuccess(), 'Should not have succeeded');
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -470,7 +470,7 @@ private class MockDmlTest {
 			'Wrong # of undeleted records'
 		);
 		for (Database.UndeleteResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -505,7 +505,7 @@ private class MockDmlTest {
 		Assert.areEqual(leads?.size(), results?.size(), 'Wrong # of results');
 		Assert.areEqual(0, MockDml.UNDELETED?.getRecords(Lead.SObjectType)?.size(), 'Wrong # of undeleted records');
 		for (Database.UndeleteResult result : results) {
-			Assert.areEqual(false, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isFalse(result?.isSuccess(), 'Should not have succeeded');
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -527,7 +527,7 @@ private class MockDmlTest {
 			'Wrong # of updated records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -549,7 +549,7 @@ private class MockDmlTest {
 			'Wrong # of updated records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -571,7 +571,7 @@ private class MockDmlTest {
 			'Wrong # of updated records'
 		);
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -606,7 +606,7 @@ private class MockDmlTest {
 		Assert.areEqual(leads?.size(), results?.size(), 'Wrong # of results');
 		Assert.areEqual(0, MockDml.UPDATED?.getRecords(Lead.SObjectType)?.size(), 'Wrong # of updated records');
 		for (Database.SaveResult result : results) {
-			Assert.areEqual(false, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isFalse(result?.isSuccess(), 'Should not have succeeded');
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -628,7 +628,7 @@ private class MockDmlTest {
 			'Wrong # of upserted records'
 		);
 		for (Database.UpsertResult result : results) {
-			Assert.areEqual(true, result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
+			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -663,7 +663,7 @@ private class MockDmlTest {
 		Assert.areEqual(leads?.size(), results?.size(), 'Wrong # of results');
 		Assert.areEqual(0, MockDml.UPSERTED?.getRecords(Lead.SObjectType)?.size(), 'Wrong # of upserted records');
 		for (Database.UpsertResult result : results) {
-			Assert.areEqual(false, result?.isSuccess(), 'Should not have succeeded');
+			Assert.isFalse(result?.isSuccess(), 'Should not have succeeded');
 			Assert.areNotEqual(null, result?.getId(), 'Missing Id');
 		}
 	}
@@ -673,7 +673,7 @@ private class MockDmlTest {
 		DatabaseLayer.useMockDml();
 		Lead testLead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
 		// Pre-test asserts
-		Assert.areEqual(false, MockDml.UPDATED.wasProcessed(testLead), 'Pre-test: Should not have been processed');
+		Assert.isFalse(MockDml.UPDATED.wasProcessed(testLead), 'Pre-test: Should not have been processed');
 		Assert.areEqual(null, MockDml.UPDATED.getRecord(testLead), 'Pre-test: Lead was processed');
 		Assert.areEqual(0, MockDml.UPDATED.getRecords(Lead.SObjectType)?.size(), 'Pre-test: Wrong # of lead updates');
 		Assert.areEqual(0, MockDml.UPDATED.getRecords(Lead.SObjectType)?.size(), 'Pre-test: Wrong # of total updates');
@@ -684,7 +684,7 @@ private class MockDmlTest {
 		Test.stopTest();
 
 		// Post-test asserts
-		Assert.areEqual(true, MockDml.UPDATED.wasProcessed(testLead), 'Lead was not processed');
+		Assert.isTrue(MockDml.UPDATED.wasProcessed(testLead), 'Lead was not processed');
 		Lead updatedLead = (Lead) MockDml.UPDATED.getRecord(testLead);
 		Assert.areNotEqual(null, updatedLead, 'Lead was not updated');
 		Assert.areEqual(testLead?.Company, updatedLead?.Company, 'Did not update Company');
@@ -693,7 +693,7 @@ private class MockDmlTest {
 
 		// Callers can also call this method to erase the current history:
 		MockDml.eraseAllHistories();
-		Assert.areEqual(true, MockDml.UPDATED.getAll()?.isEmpty(), 'Did not reset history');
+		Assert.isTrue(MockDml.UPDATED.getAll()?.isEmpty(), 'Did not reset history');
 	}
 
 	@IsTest
@@ -757,8 +757,96 @@ private class MockDmlTest {
 		Map<SObjectType, List<SObject>> results = MockDml.INSERTED.getAll();
 		Test.stopTest();
 
-		Assert.areEqual(true, results?.containsKey(Account.SObjectType), 'No Accounts inserted');
+		Assert.isTrue(results?.containsKey(Account.SObjectType), 'No Accounts inserted');
 		Assert.areEqual(accounts?.size(), results?.get(Account.SObjectType)?.size(), 'Wrong # of Accounts inserted');
+	}
+
+	@IsTest
+	static void shouldHandleSetSavepoints() {
+		DatabaseLayer.useMockDml();
+
+		Test.startTest();
+		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+		Test.stopTest();
+
+		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
+		List<MockDml.SavepointInfo> savepointInfos = MockDml.SAVEPOINTS?.getAll();
+		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');
+		MockDml.SavepointInfo savepointInfo = savepointInfos?.get(0);
+		Assert.isFalse(savepointInfo?.wasReleased, 'Should not have been released');
+		Assert.isFalse(savepointInfo?.wasRolledBack, 'Should not have been rolled back');
+	}
+
+	@IsTest
+	static void shouldHandleReleasedSavepoints() {
+		DatabaseLayer.useMockDml();
+
+		Test.startTest();
+		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+		DatabaseLayer.Dml.releaseSavepoint(savepoint);
+		Test.stopTest();
+
+		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
+		List<MockDml.SavepointInfo> savepointInfos = MockDml.SAVEPOINTS.getAll();
+		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');
+		MockDml.SavepointInfo savepointInfo = savepointInfos?.get(0);
+		Assert.isTrue(savepointInfo?.wasReleased, 'Was not released');
+		Assert.isFalse(savepointInfo?.wasRolledBack, 'Should not have been rolled back');
+	}
+
+	@IsTest
+	static void shouldHandleRolledBackSavepoints() {
+		DatabaseLayer.useMockDml();
+		DatabaseLayer.Dml.doInsert(new Account());
+
+		Test.startTest();
+		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+		DatabaseLayer.Dml.rollback(savepoint);
+		Test.stopTest();
+
+		Assert.isTrue(MockDml.INSERTED.getAll()?.isEmpty(), 'Did not roll back DML operation');
+		Assert.isNotNull(savepoint, 'Did not return a System.Savepoint');
+		List<MockDml.SavepointInfo> savepointInfos = MockDml.SAVEPOINTS.getAll();
+		Assert.areEqual(1, savepointInfos?.size(), 'Wrong # of Savepoints');
+		MockDml.SavepointInfo savepointInfo = savepointInfos?.get(0);
+		Assert.isFalse(savepointInfo?.wasReleased, 'Should not have been released');
+		Assert.isTrue(savepointInfo?.wasRolledBack, 'Was not rolled back');
+	}
+
+	@IsTest
+	static void shouldGetASpecificSavepointInfoByIndex() {
+		DatabaseLayer.useMockDml();
+		System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
+		System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
+		// Roll back the second savepoint, to distinguish the two:
+		DatabaseLayer.Dml.rollback(sp2);
+
+		Test.startTest();
+		MockDml.SavepointInfo spInfo1 = MockDml.SAVEPOINTS.get(0);
+		Assert.isNotNull(spInfo1, 'Did not return a Savepoint');
+		Assert.isFalse(spInfo1?.wasRolledBack, 'Should not have been rolled back');
+		MockDml.SavepointInfo spInfo2 = MockDml.SAVEPOINTS.get(1);
+		Assert.isNotNull(spInfo2, 'Did not return a Savepoint');
+		Assert.isTrue(spInfo2?.wasRolledBack, 'Was not rolled back');
+		Test.stopTest();
+	}
+
+	@IsTest
+	static void shouldGetASpecificSavepointInfoBySavepoint() {
+		DatabaseLayer.useMockDml();
+		System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
+		System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
+		// Roll back the second savepoint, to distinguish the two:
+		DatabaseLayer.Dml.rollback(sp2);
+
+		Test.startTest();
+		MockDml.SavepointInfo spInfo1 = MockDml.SAVEPOINTS.get(sp1);
+		Assert.isNotNull(spInfo1, 'Did not return a Savepoint');
+		Assert.isFalse(spInfo1?.wasRolledBack, 'Should not have been rolled back');
+		MockDml.SavepointInfo spInfo2 = MockDml.SAVEPOINTS.get(sp2);
+		Assert.isNotNull(spInfo2, 'Did not return a Savepoint');
+		Assert.isTrue(spInfo2?.wasRolledBack, 'Was not rolled back');
+		Test.stopTest();
 	}
 
 	// **** HELPER **** //

--- a/force-app/main/default/classes/MockDmlTest.cls
+++ b/force-app/main/default/classes/MockDmlTest.cls
@@ -770,7 +770,7 @@ private class MockDmlTest {
 
 		Test.startTest();
 		// Take a snapshot
-		MockDml.MockDatabase snapshot = MockDml.mockDatabase?.snapshot();
+		MockDml.Database snapshot = MockDml.MockDatabase?.snapshot();
 		Test.stopTest();
 
 		// Now simulate deleting the records:


### PR DESCRIPTION
Closes #43 by introducing new public methods on the `Dml` / `MockDml` classes to set, release, and rollback savepoints. 

The `Dml` class has a pretty vanilla implementation which mirrors the `Database` class methods for this.

The `MockDml` class gets a couple of nice upgrades:
- You can get information about all of the savepoints called during your test, by calling `MockDml.SAVEPOINTS`. This returns an object that allows you to retrieve a `MockDml.Savepoint` object by its index, or by the savepoint object itself.
- The `MockDml.Savepoint` object contains information about whether the savepoint was released or rolled back. Test callers can use these methods to assert that certain code paths were taken -- for instance, if a savepoint was rolled back during a `catch` block.
- `MockDml`'s history objects are reorganized around a new class: `MockDatabase`, which stores all of the history objects, as well as a public `snapshot` method which returns a copy of the object at the current moment in time.
  - This mock database can be configured to mimic standard behavior around rollbacks. When the `resetOnRollback` static property is _true_, each new savepoint will store a copy of the database at the time it was initialized. If rolled back, the mock database will revert back to this previous state.
  - **Note**: This behavior comes with potential heap concerns, particularly at scale. For this reason it can be overridden uif needed, using `MockDml.MockDatabase.resetOnRollback = false`
- Changed the underlying map in `MockDml.History` to use the `SObjectType`'s API Name (String), instead of the SObjectType itself. This was necessary to allow for JSON serialization when making copies of the `MockDatabase` in rollbacks, since SObjectTypes are not JSON-serializable. 

Added new `MockDml.History` methods to improve the DX:
- `SObject get(SObjectType objectType, String idOrUuid)`
- `SObject get(Id recordId)`
- `SObject get(SObject record)`

And added/promoted these methods from `MockDml.RecordHistory` to `MockDml.History`:
- `Boolean wasProcessed(SObjectType objectType, String idOrUuid)`
- `Bollean wasProcessed(Id recordId)`
- `Bollean wasProcessed(SObject record)`

Finally, marked the following methods as deprecated, to be removed entirely in v3.0.0 - #56 
  - `MockDml.History.eraseHistory()`
  - `MockDml.RecordHistory getRecord(Id recordId)`
  - `MockDml.RecordHistory getRecord(SObject record)`