### PR TITLE
Feature: ChildRelationshipService: Move Logic to new DatabaseLayerUtils

### DIFF
--- a/force-app/main/default/classes/ChildRelationshipService.cls
+++ b/force-app/main/default/classes/ChildRelationshipService.cls
@@ -1,69 +1,12 @@
 @SuppressWarnings('PMD.ApexDoc')
 public abstract class ChildRelationshipService {
-	/**
-	 * This small service aims to make it easier to retrieve Schema.ChildRelationship objects from their linked SObjectField.
-	 * Unlike SObjectTypes/SObjectFields, they do not have a declarable token, ex. Account.Contacts.
-	 * Callers typically have to perform expensive & verbose describe operations to retrieve this object.
-	 * By using this class, callers can retrieve a relationship object with a single line, ex:
-	 * `Schema.ChildRelationship rel = ChildRelationshipService.getChildRelationshipFrom(Contact.AccountId);`
-	 * As an added bonus, the relationship information for the lookup field's referenceTo object is cached,
-	 * so that successive calls to the same object do not take the same processing time.
-	 **/
-	private static final Map<SObjectType, CachedDescribe> DESCRIBES = new Map<SObjectType, CachedDescribe>();
-
+	// ! Deprecated: This class & all its methods will be removed in future versions
+	// ! Replace all uses of this class with DatabaseLayer.Utils methods w/the same name
 	public static Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
-		// Returns the Schema.ChildRelationshp on the referenceTo SObjectType, that the provided lookupField points to.
-		// Ex., getChildRelationshipFrom(Task.WhoId, Lead.SObjectType) -> Lead.Tasks
-		return ChildRelationshipService.getDescribeFromCache(referenceTo)?.get(lookupField);
+		return DatabaseLayer.Utils.getChildRelationshipFrom(lookupField, referenceTo);
 	}
 
 	public static Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
-		// Overload that uses the first SObjectType in the getReferenceTo() list to find the child relationship.
-		// Use this overload when you know the field in question is not polymorphic; ex., Contact.AccountId.
-		// * Note: the Schema.getReferenceTo() method returns a List<SObjectType>, not a single SObjectType.
-		// Typically, a field is only be related to a single SObjectType; exceptions include polymorphic fields (ie, Task.WhatId).
-		List<SObjectType> references = lookupField?.getDescribe()?.getReferenceTo();
-		SObjectType referenceTo = references?.isEmpty() == false ? references?.get(0) : null;
-		return ChildRelationshipService.getChildRelationshipFrom(lookupField, referenceTo);
-	}
-
-	// **** PRIVATE **** //
-	private static ChildRelationshipService.CachedDescribe getDescribeFromCache(SObjectType objectType) {
-		// Retrieves a CachedDescribe object that represents cached Schema.ChildRelationships for the SObjectType
-		ChildRelationshipService.CachedDescribe repo = DESCRIBES?.containsKey(objectType)
-			? DESCRIBES?.get(objectType)
-			: new ChildRelationshipService.CachedDescribe(objectType);
-		DESCRIBES?.put(objectType, repo);
-		return repo;
-	}
-
-	// **** INNER **** //
-	private class CachedDescribe {
-		// Object used to map & cache Schema.ChildRelationships by their lookup field.
-		// Useful since the operation to retrieve Schema.ChildRelationships from an object can be expensive,
-		// and Salesforce's built in Schema caching mechanism doesn't seem to handle this.
-		// Note: In the future, consider upgrading this to use actual System.Cache.
-		private Map<SObjectField, Schema.ChildRelationship> relationshipMap;
-
-		public CachedDescribe(SObjectType objectType) {
-			this.mapRelationships(objectType);
-		}
-
-		public Schema.ChildRelationship get(SObjectField field) {
-			return this.relationshipMap?.get(field);
-		}
-
-		private List<Schema.ChildRelationship> getRelationshipList(SObjectType objectType) {
-			return objectType?.getDescribe(Schema.SObjectDescribeOptions.DEFERRED)?.getChildRelationships() ??
-				new List<Schema.ChildRelationship>();
-		}
-
-		private void mapRelationships(SObjectType objectType) {
-			this.relationshipMap = new Map<SObjectField, Schema.ChildRelationship>();
-			for (Schema.ChildRelationship relationship : this.getRelationshipList(objectType)) {
-				SObjectField field = relationship?.getField();
-				this.relationshipMap?.put(field, relationship);
-			}
-		}
+		return DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
 	}
 }

--- a/force-app/main/default/classes/DatabaseLayer.cls
+++ b/force-app/main/default/classes/DatabaseLayer.cls
@@ -7,6 +7,7 @@ public class DatabaseLayer {
 	 **/
 	// **** CONSTANTS **** //
 	private static final DatabaseLayer INSTANCE = new DatabaseLayer();
+	public static final DatabaseLayerUtils UTILS = new DatabaseLayerUtils(INSTANCE);
 
 	// **** MEMBER **** //
 	private Dml currentDml;

--- a/force-app/main/default/classes/DatabaseLayer.cls
+++ b/force-app/main/default/classes/DatabaseLayer.cls
@@ -6,8 +6,13 @@ public class DatabaseLayer {
 	 * Automatically inject mock versions of these classes via the `useMocks()` method.
 	 **/
 	// **** CONSTANTS **** //
-	private static final DatabaseLayer INSTANCE = new DatabaseLayer();
-	public static final DatabaseLayerUtils UTILS = new DatabaseLayerUtils(INSTANCE);
+	public static final DatabaseLayerUtils UTILS;
+	private static final DatabaseLayer INSTANCE;
+
+	static {
+		INSTANCE = new DatabaseLayer();
+		UTILS = new DatabaseLayerUtils(INSTANCE);
+	}
 
 	// **** MEMBER **** //
 	private Dml currentDml;

--- a/force-app/main/default/classes/DatabaseLayerUtils.cls
+++ b/force-app/main/default/classes/DatabaseLayerUtils.cls
@@ -1,0 +1,97 @@
+public class DatabaseLayerUtils {
+	private static final DatabaseLayerUtils.ChildRelationshipUtility CHILD_RELATIONSHIPS;
+
+	static {
+		CHILD_RELATIONSHIPS = new DatabaseLayerUtils.ChildRelationshipUtility();
+	}
+
+	@SuppressWarnings('PMD.EmptyStatementBlock')
+	public DatabaseLayerUtils(DatabaseLayer factory) {
+		// The utility class can't be manually constructed outside of this package
+		// Necessary in the absence of @NamespaceAccessible-like annotation for unlocked packages
+	}
+
+	public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
+		// Returns the Schema.ChildRelationshp on the referenceTo SObjectType, that the provided lookupField points to.
+		// Ex., getChildRelationshipFrom(Task.WhoId, Lead.SObjectType) -> Lead.Tasks
+		return CHILD_RELATIONSHIPS?.getChildRelationshipFrom(lookupField, referenceTo);
+	}
+
+	public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
+		// Overload that uses the first SObjectType in the getReferenceTo() list to find the child relationship.
+		// Use this overload when you know the field in question is not polymorphic; ex., Contact.AccountId.
+		return CHILD_RELATIONSHIPS?.getChildRelationshipFrom(lookupField);
+	}
+
+	// **** INNER **** //
+	private class CachedDescribe {
+		// Object used to map & cache Schema.ChildRelationships by their lookup field.
+		// Useful since the operation to retrieve Schema.ChildRelationships from an object can be expensive,
+		// and Salesforce's built in Schema caching mechanism doesn't seem to handle this.
+		// Note: In the future, consider upgrading this to use actual System.Cache.
+		private Map<SObjectField, Schema.ChildRelationship> relationshipMap;
+
+		public CachedDescribe(SObjectType objectType) {
+			this.mapRelationships(objectType);
+		}
+
+		public Schema.ChildRelationship get(SObjectField field) {
+			return this.relationshipMap?.get(field);
+		}
+
+		private List<Schema.ChildRelationship> getRelationshipList(SObjectType objectType) {
+			return objectType?.getDescribe(Schema.SObjectDescribeOptions.DEFERRED)?.getChildRelationships() ??
+				new List<Schema.ChildRelationship>();
+		}
+
+		private void mapRelationships(SObjectType objectType) {
+			this.relationshipMap = new Map<SObjectField, Schema.ChildRelationship>();
+			for (Schema.ChildRelationship relationship : this.getRelationshipList(objectType)) {
+				SObjectField field = relationship?.getField();
+				this.relationshipMap?.put(field, relationship);
+			}
+		}
+	}
+
+	private class ChildRelationshipUtility {
+		/**
+		 * This small utility aims to make it easier to retrieve Schema.ChildRelationship objects from their linked SObjectField.
+		 * Unlike SObjectTypes/SObjectFields, they do not have a declarable token, ex. Account.Contacts.
+		 * Callers typically have to perform expensive & verbose describe operations to retrieve this object.
+		 * Using this utility, callers can retrieve a relationship object with a single line, ex:
+		 * `Schema.ChildRelationship rel = DatabaseLayer.Utils.getChildRelationshipFrom(Contact.AccountId);`
+		 * As an added bonus, the relationship information for the lookup field's referenceTo object is cached,
+		 * so that successive calls to the same object do not take the same processing time.
+		 **/
+		private Map<SObjectType, DatabaseLayerUtils.CachedDescribe> describes;
+
+		private ChildRelationshipUtility() {
+			this.describes = new Map<SObjectType, DatabaseLayerUtils.CachedDescribe>();
+		}
+
+		public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
+			// Returns the Schema.ChildRelationshp on the referenceTo SObjectType, that the provided lookupField points to.
+			// Ex., getChildRelationshipFrom(Task.WhoId, Lead.SObjectType) -> Lead.Tasks
+			return this.getDescribeFromCache(referenceTo)?.get(lookupField);
+		}
+
+		public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
+			// Overload that uses the first SObjectType in the getReferenceTo() list to find the child relationship.
+			// Use this overload when you know the field in question is not polymorphic; ex., Contact.AccountId.
+			List<SObjectType> references = lookupField?.getDescribe()?.getReferenceTo();
+			// Note: the Schema.getReferenceTo() method returns a List<SObjectType>, not a single SObjectType.
+			// Typically, a field is only be related to a single SObjectType; excluding polymorphic fields (ie, Task.WhatId).
+			SObjectType referenceTo = references?.isEmpty() == false ? references?.get(0) : null;
+			return this.getChildRelationshipFrom(lookupField, referenceTo);
+		}
+
+		private DatabaseLayerUtils.CachedDescribe getDescribeFromCache(SObjectType objectType) {
+			// Retrieves a CachedDescribe object, which represents a cached Schema.ChildRelationships for the SObjectType
+			DatabaseLayerUtils.CachedDescribe describe = this.describes?.containsKey(objectType)
+				? this.describes?.get(objectType)
+				: new DatabaseLayerUtils.CachedDescribe(objectType);
+			this.describes?.put(objectType, describe);
+			return describe;
+		}
+	}
+}

--- a/force-app/main/default/classes/DatabaseLayerUtils.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseLayerUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DatabaseLayerUtilsTest.cls
+++ b/force-app/main/default/classes/DatabaseLayerUtilsTest.cls
@@ -1,0 +1,59 @@
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DatabaseLayerUtilsTest {
+	@IsTest
+	static void shouldGetChildRelationshipFromLookupField() {
+		SObjectField field = Contact.AccountId;
+
+		Test.startTest();
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Test.stopTest();
+
+		Assert.areEqual(field, relationship?.getField(), 'Relationship does not point to ' + field);
+	}
+
+	@IsTest
+	static void shouldGetChildRelationshipFromPolymorphicLookupField() {
+		SObjectField field = Task.WhoId; // Polymorphic! Can be a reference to Contact.Tasks OR Lead.Tasks
+		SObjectType referenceTo = Lead.SObjectType; // ...in this case, we want Lead.Tasks
+
+		Test.startTest();
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field, referenceTo);
+		Test.stopTest();
+
+		Assert.areEqual(field, relationship?.getField(), 'Relationship does not point to ' + field);
+	}
+
+	@IsTest
+	static void shouldReturnChildRelationshipsUnderHighStress() {
+		// The operation to retrieve Schema.ChildRelationships from an object can be expensive,
+		// so the class internally caches these results via an inner class.
+		// Successive calls to retrieve the same SObjectType's relationships
+		// should have similar performance implications as calling it once.
+		SObjectField field = Contact.AccountId;
+		DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Integer firstTime = Limits.getCpuTime();
+
+		for (Integer i = 0; i < 10; i++) {
+			Integer start = Limits.getCpuTime();
+			DatabaseLayer.Utils.getChildRelationshipFrom(field);
+			Integer thisTime = Limits.getCpuTime() - start;
+			Assert.areEqual(
+				true,
+				thisTime < firstTime,
+				'Took longer than initial call: ' + new List<Integer>{ firstTime, thisTime }
+			);
+		}
+	}
+
+	@IsTest
+	static void shouldReturnNullChildRelationshipIfNotLookupField() {
+		SObjectField field = Contact.CreatedDate;
+
+		Test.startTest();
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Test.stopTest();
+
+		Assert.areEqual(null, relationship, 'Non-lookup field returned a relationship anyways');
+	}
+}

--- a/force-app/main/default/classes/DatabaseLayerUtilsTest.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseLayerUtilsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/Dml.cls
+++ b/force-app/main/default/classes/Dml.cls
@@ -20,6 +20,7 @@ public with sharing virtual class Dml {
 	private static final DataSource.AsyncDeleteCallback DEFAULT_DELETE_CALLBACK = new Dml.EmptyDeleteCallback();
 	private static final DataSource.AsyncSaveCallback DEFAULT_SAVE_CALLBACK = new Dml.EmptySaveCallback();
 
+	@SuppressWarnings('PMD.EmptyStatementBlock')
 	public Dml(DatabaseLayer factory) {
 		// Dml classes can't be constructed manually
 		// Instead, use the DatabaseLayer.Dml static property

--- a/force-app/main/default/classes/DmlTest.cls
+++ b/force-app/main/default/classes/DmlTest.cls
@@ -866,6 +866,26 @@ private class DmlTest {
 		Assert.areEqual(0, [SELECT COUNT() FROM Account], 'DML operation was not rolled back');
 	}
 
+	@IsTest
+	static void shouldHandleNoDefinedSettings() {
+		Assert.fail('You still need to build this test');
+	}
+
+	@IsTest
+	static void shouldHandleNoDefinedPlugin() {
+		Assert.fail('You still need to build this test');
+	}
+
+	@IsTest
+	static void shouldUseDmlPluginIfDefined() {
+		Assert.fail('You still need to build this test');
+	}
+
+	@IsTest
+	static void shouldHandleInvalidDmlPlugin() {
+		Assert.fail('You still need to build this test');
+	}
+
 	// **** HELPER **** //
 	static LeadStatus getConvertedStatus() {
 		return [SELECT ApiName FROM LeadStatus WHERE IsConverted = TRUE LIMIT 1] ?? null;
@@ -891,6 +911,7 @@ private class DmlTest {
 		return leadToConvert;
 	}
 
+	// **** INNER **** //
 	private class DeleteCallback extends DataSource.AsyncDeleteCallback {
 		public override void processDelete(Database.DeleteResult result) {
 			DmlTest.deleteCallbacksMade?.add(result);
@@ -902,4 +923,19 @@ private class DmlTest {
 			DmlTest.saveCallbacksMade?.add(result);
 		}
 	}
+
+	/* private class SamplePlugin implements Dml.PreProcessor, Dml.PostProcessor {
+		private Integer numPreProcessCalls = 0;
+		private Integer numPostProcessCalls = 0;
+
+		public void preProcess(Dml.Operation operation, List<SObject> records) {
+			System.debug('SamplePlugin: preProcess ' + operation + '\nRecords: ' + records);
+			this.numPreProcessCalls++; 
+		}
+
+		public void postProcess(Dml.Operation operation, List<SObject> records, List<Object> results) {
+			System.debug('SamplePlugin: postProcess ' + operation + '\nRecords: ' + records + '\nResults: ' + results);
+			this.numPostProcessCalls++; 
+		} 
+	} */
 }

--- a/force-app/main/default/classes/DmlTest.cls
+++ b/force-app/main/default/classes/DmlTest.cls
@@ -866,26 +866,6 @@ private class DmlTest {
 		Assert.areEqual(0, [SELECT COUNT() FROM Account], 'DML operation was not rolled back');
 	}
 
-	@IsTest
-	static void shouldHandleNoDefinedSettings() {
-		Assert.fail('You still need to build this test');
-	}
-
-	@IsTest
-	static void shouldHandleNoDefinedPlugin() {
-		Assert.fail('You still need to build this test');
-	}
-
-	@IsTest
-	static void shouldUseDmlPluginIfDefined() {
-		Assert.fail('You still need to build this test');
-	}
-
-	@IsTest
-	static void shouldHandleInvalidDmlPlugin() {
-		Assert.fail('You still need to build this test');
-	}
-
 	// **** HELPER **** //
 	static LeadStatus getConvertedStatus() {
 		return [SELECT ApiName FROM LeadStatus WHERE IsConverted = TRUE LIMIT 1] ?? null;
@@ -911,7 +891,6 @@ private class DmlTest {
 		return leadToConvert;
 	}
 
-	// **** INNER **** //
 	private class DeleteCallback extends DataSource.AsyncDeleteCallback {
 		public override void processDelete(Database.DeleteResult result) {
 			DmlTest.deleteCallbacksMade?.add(result);
@@ -923,19 +902,4 @@ private class DmlTest {
 			DmlTest.saveCallbacksMade?.add(result);
 		}
 	}
-
-	/* private class SamplePlugin implements Dml.PreProcessor, Dml.PostProcessor {
-		private Integer numPreProcessCalls = 0;
-		private Integer numPostProcessCalls = 0;
-
-		public void preProcess(Dml.Operation operation, List<SObject> records) {
-			System.debug('SamplePlugin: preProcess ' + operation + '\nRecords: ' + records);
-			this.numPreProcessCalls++; 
-		}
-
-		public void postProcess(Dml.Operation operation, List<SObject> records, List<Object> results) {
-			System.debug('SamplePlugin: postProcess ' + operation + '\nRecords: ' + records + '\nResults: ' + results);
-			this.numPostProcessCalls++; 
-		} 
-	} */
 }

--- a/force-app/main/default/classes/MockRecord.cls
+++ b/force-app/main/default/classes/MockRecord.cls
@@ -58,7 +58,7 @@ public class MockRecord {
 	}
 
 	public List<SObject> getRelatedList(SObjectField lookupField) {
-		Schema.ChildRelationship relationship = ChildRelationshipService.getChildRelationshipFrom(lookupField);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
 		return this.getRelatedList(relationship);
 	}
 
@@ -97,7 +97,7 @@ public class MockRecord {
 	}
 
 	public MockRecord setRelatedList(SObjectField lookupField, List<SObject> relatedRecords) {
-		Schema.ChildRelationship relationship = ChildRelationshipService.getChildRelationshipFrom(lookupField);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
 		return this.setRelatedList(relationship, relatedRecords);
 	}
 

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -1094,7 +1094,7 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 		}
 
 		public Subquery(SObjectField lookupFieldOnChildObject) {
-			this(ChildRelationshipService.getChildRelationshipFrom(lookupFieldOnChildObject));
+			this(DatabaseLayer.Utils.getChildRelationshipFrom(lookupFieldOnChildObject));
 		}
 
 		public override String getFrom() {

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -830,7 +830,7 @@ private class SoqlTest {
 
 	@IsTest
 	static void shouldGenerateSubqueryFromChildRelationship() {
-		Schema.ChildRelationship rel = ChildRelationshipService.getChildRelationshipFrom(Case.AccountId);
+		Schema.ChildRelationship rel = DatabaseLayer.Utils.getChildRelationshipFrom(Case.AccountId);
 
 		Test.startTest();
 		String result = new Soql.Subquery(rel)?.addSelect(Case.Id)?.toString();


### PR DESCRIPTION
Closes #54 by moving the child relationship logic from `ChildRelationshipService` to a new `DatabaseLayerUtils` class. This class and its public methods can only be referenced via the `DatabaseLayer.Utils` property.  

Why? For one, this better reflects the intent of the utils class as a private class, only to be accessed by the package callers - though there isn't a way to 100% enforce this (unlike `@NamespaceAccessible` public methods, as in managed packages). For two, it reduces the risk of naming collisions (it's not hard to imagine future subscribers already having a class called "ChildRelationshipService" in their org...).

The `ChildRelationshipService` class remains for now, but will be removed in #56. For now, its methods are redirected through the `DatabaseLayer.Utils`