### PR TITLE
Version/2.4.0

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -10,3 +10,7 @@ package.xml
 
 # LWC Jest
 **/__tests__/**
+
+# Unrelated Metadata
+force-app/main/default/objectTranslations/**
+force-app/main/default/profiles/**

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ $RECYCLE.BIN/
 
 # VS Code Settings
 .vscode/settings.json
+
+# Unrelated Metadata
+force-app/main/default/objectTranslations/**
+force-app/main/default/profiles/**

--- a/README.md
+++ b/README.md
@@ -47,18 +47,17 @@ DatabaseLayer.Dml.doInsert(account);
 Assert.isNotNull(account?.Id, 'Was not inserted');
 ```
 
-To simulate DML failures, use the `fail()` method:
+To simulate DML failures, use the `Dml.shouldFail()` method:
 
 ```java
 DatabaseLayer.useMocks();
 Account account = new Account(Name = 'Test Account');
-MockDml dml = (MockDml) DatabaseLayer.Dml;
-dml?.fail();
+MockDml.shouldFail();
 // All subsuquent dml operations should fail
-dml?.doInsert(account);
+DatabaseLayer.Dml.doInsert(account);
 ```
 
-If necessary, you can inject "smarter" failure logic via the `MockDml.ConditionalFailure` interface and the `failIf()` method:
+If necessary, you can inject "smarter" failure logic via the `MockDml.ConditionalFailure` interface and the `DatabaseLayer.shouldFailIf()` method:
 
 ```java
 public class ExampleFailure implements MockDml.ConditionalFailure {
@@ -78,13 +77,12 @@ public class ExampleFailure implements MockDml.ConditionalFailure {
 ```
 
 ```java
-// Inject the conditional logic via the failIf() method
+// Inject the conditional logic via the shouldFailIf() method
 DatabaseLayer.useMocks();
-MockDml dml = (MockDml) DatabaseLayer.Dml;
 MockDml.ConditionalFailure logic = new ExampleFailure();
-dml?.failIf(logic);
+MockDml.shouldFailIf(logic);
 // This won't fail, because it's not an update!
-dml?.doInsert();
+DatabaseLayer.Dml.doInsert(someRecord);
 ```
 
 `MockDml` does not actually modify records in the database, so you cannot use SOQL to retrieve changes and perform assertions against them. Instead, use history objects, like `MockDml.INSERTED` to retrieve modified SObject records in memory:

--- a/docs/DML.md
+++ b/docs/DML.md
@@ -62,6 +62,159 @@ DatabaseLayer.Dml.rollback(savepoint);
 Assert.isTrue(MockDml.SAVEPOINTS.get(0).wasRolledBack);
 ```
 
+### Public Inner Types
+
+#### The `Dml.Operation` Enum
+
+Enumerates all of the supported DML operations. The framework uses this in the `Dml.Request` class to determine what type operation is being processed. Values include:
+
+- `DO_CONVERT`
+- `DO_DELETE`
+- `DO_INSERT`
+- `DO_PUBLISH`
+- `DO_PURGE`
+- `DO_UNDELETE`
+- `DO_UPDATE`
+- `DO_UPSERT`
+
+> :warning: Note: This enum was introduced in v2.4.0, and will eventually replace the `MockDml.Operation` enum, which will be removed in v3.0.0.
+
+#### The `Dml.PreAndPostProcessor` Interface
+
+You can use this interface in conjunction with the plugin framework to define logic that runs just before, and/or just after DML operations are run. You can use this for logging, or other specialized use cases.
+
+Read more about how DML Plugins work [**here**](#dml-plugins).
+
+The interface contains two required methods:
+
+- `void processPreDml(Dml.Request request)`
+- `void processPostDml(Dml.Request request, List<Object> databaseResults)`
+
+The `processPreDml` method is called just _before_ processing DML; `processPostDml` is called just _after_ processing DML.
+
+Both methods include a `Dml.Request` parameter, which includes information about the DML operation, including the records being processed, the type of DML operation, any special behavior - like `allOrNone`, whether the request will be processed via mocks, and more. See the [`Dml.Request`](#the-dmlrequest-class) class for the full list of parameters.
+
+The `processPostDml` also includes a `List<Object>`, which represents the Database results (ie., `Database.SaveResult`, `Database.DeleteResult`, `Database.UpsertResult`, etc) produced by the DML operation. Since these objects do not share a common interface, the return type must be a generic `List<Object>`. You can cast the results to the appropriate type based on the `operation` being processed:
+
+<table>
+	<tr>
+		<th>DML Operation</th>
+		<th>Database Result Type</th>
+	</tr>
+	<tr>
+		<td><code>DO_CONVERT</code></td>
+		<td><code>Database.ConvertResult</code></td>
+	</tr>
+	<tr>
+		<td><code>DO_INSERT</code>, <code>DO_PUBLISH</code>, <code>DO_UPDATE</code></td>
+		<td><code>Database.SaveResult</code></td>
+	</tr>
+	<tr>
+		<td><code>DO_PURGE</code></td>
+		<td><code>Database.EmptyRecycleBinResult</code></td>
+	</tr>
+	<tr>
+		<td><code>DO_UNDELETE</code></td>
+		<td><code>Database.UndeleteResult</code></td>
+	</tr>
+	<tr>
+		<td><code>DO_UPSERT</code></td>
+		<td><code>Database.UpsertResult</code></td>
+	</tr>
+</table>
+
+Example:
+
+```java
+public class MyPlugin implements Dml.PreAndPostProcessor {
+	// This sample PreAndPostProcessor logs DML operations, using Nebula Logger:
+	public void processPreDml(Dml.Request request) {
+		Logger.finest('About to process ' + this.getLogSuffix(request))?.setRecord(request?.records);
+
+		Logger.finest(msg)?.setRecord(request?.records);
+	}
+
+	public void processPostDml(Dml.Request request, List<Object> results) {
+		Logger.finest('Processed ' + this.getLogSuffix(request))?.setRecord(request?.records);
+	}
+
+	private String getLogSuffix(Dml.Request req) {
+		return req?.numRecords + ' ' + req?.sObjectType + ' records. Operation: ' + req?.operation;
+	}
+}
+```
+
+#### The `Dml.Request` Class
+
+The `Dml.Request` represents the parameters that the framework uses to process each DML statement. All requests include the records being processed, the DML operation being processed, and additional/optional configuration details.
+
+This type cannot be manually constructed, and all of its properties are read-only. The framework auto-generates a `Dml.Request` object whenever you call a `DatabaseLayer.Dml` method.
+
+##### Properties:
+
+All properties are read-only, and optional unless otherwise otherwise listed:
+
+- `System.AccessLevel accessLevel`: Determines if the DML operation is processed via SYSTEM_MODE or USER_MODE. Defaults to USER_MODE.
+- `String accessLevelName`: Outputs the name of the _accessLevel_ property in JSON, since `System.AccessLevel` objects are not supported in JSON.
+- `String deleteCallback`: Prints the string-value of the _deleteCallback_ property, which is omitted from JSON since its implementation may or may not be supported in JSON.
+- `String saveCallback`: Prints the string-value of the _saveCallback_ property, which is omitted from JSON since its implementation may or may not be supported in JSON.
+- `DataSource.AsyncDeleteCallback asyncDeleteCallback`: A callback object that can optionally be passed to async DML delete methods that support external objects, ex. `DatabaseLayer.Dml.doDeleteAsync()`.
+- `String externalIdFieldName`: Prints the API Name of the _externalIdField_.
+- `SObjectField externalIdField`: An optional primary key field to be used in upsert operations.
+- `Boolean isMockDml`: True if the request was processed using `DatabaseLayer.useMocks()`. Else, always False.
+- `Boolean isOperationAsync`: True for async DML methods that support external objects, like `DatabaseLayer.Dml.doInsertAsync()`. Else, always False.
+- `Boolean isOperationImmediate`: True for synchronous DML methods that support external objects, like `DatabaseLayer.Dml.doInsertImmediate()`. Else, always False.
+- `List<Database.LeadConvert> leadsToConvert`: Leads to be converted; only present in a DO_CONVERT operation.
+- `Integer numRecords`: Outputs the number of records being processed. This can be useful, since _records_ and _leadsToConvert_ are always omitted from JSON output to conserve resources.
+- `Dml.Operation operation`: The type of DML operation being processed. This is always present.
+- `Database.DmlOptions options`: Stores advanced configuration options for the DML operation. The most common property is _OptAllOrNone_, which determines if partial failures are allowed.
+- `List<SObject> records`: The record(s) being processed. This is present in all operations, except DO_CONVERT.
+- `DataSource.AsyncSaveCallback asyncSaveCallback`: A callback object that can optionally be passed to async DML insert/update methods that support external objects, ex. `DatabaseLayer.Dml.doInsertAsync()`.
+- `String sObjectType`: Outputs the API Name of the SObjectType being processed, if known. For DO_CONVERT, outputs "Database.LeadConvert". When unknown, outputs "SObject".
+
+For logging purposes, you can safely JSON-serialize the `Dml.Request`, though Some of the properties of this class may be omitted to save on resources, or because they are not supported in JSON. Example:
+
+```json
+{
+	"sObjectType": "Account",
+	"options": {
+		"OptAllOrNone": true,
+		"EmailHeader": {},
+		"DuplicateRuleHeader": {},
+		"AssignmentRuleHeader": {}
+	},
+	"operation": "DO_INSERT",
+	"numRecords": 1,
+	"isOperationImmediate": false,
+	"isOperationAsync": false,
+	"isMockDml": false,
+	"saveCallback": "EmptySaveCallback:[]",
+	"deleteCallback": "EmptyDeleteCallback:[]",
+	"accessLevelName": "USER_MODE"
+}
+```
+
+Note: The _records_ and _leadsToConvert_ properties are _never_ printed in JSON, but can still be accessed by referencing them directly, ex., `request?.records`.
+
+## DML Plugins
+
+You can optionally define an Apex class which can perform pre/post processing tasks on your DML operations. For example, logging via your logging framework of choice.
+
+Plugins are handled by a Custom Metadata Type, and the `Dml.PreAndPostProcessor` interface. Read more about this interface [**here**](#the-dmlpreandpostprocessor-interface).
+
+Follow these steps to create your own DML plugin:
+
+1. Create an Apex Class that includes your desired logic. Requirements:
+
+- This class must implement `Dml.PreAndPostProcessor`.
+- This class must be `public` or `global`, and have an accessible 0-arg constructor (either implicit or explicit).
+
+2. Create a `DatabaseLayerSetting__mdt` record, if one doesn't already exist.
+
+- Note: There may only be a single record at a time; this is enforced by a validation rule.
+
+3. Set the _DML: Pre & Post Processor_ field to the fully qualified API name of your Apex Class, including namespace if applicable.
+
 ## Mocking DML Operations
 
 The `MockDml` class can be used in placed of a normal `Dml` class in the `@IsTest` context. The `MockDml` class manipulates the SObject records in memory, instead of actually inserting, modifying or deleting records in the Salesforce database.
@@ -73,17 +226,17 @@ In `@IsTest` context, mock DML operations by calling the `DatabaseLayer.useMocks
 ```java
 @IsTest
 static void example() {
-	DatabaseLayer.useMocks();
-	Case testCase = new Case();
+  DatabaseLayer.useMocks();
+  Case testCase = new Case();
 
-	Test.startTest();
-	DatabaseLayer.Dml.doInsert(testCase);
-	Assert.areEqual(0, Limits.getDmlStatements(), 'DML was processed?');
-	Test.stopTest();
+  Test.startTest();
+  DatabaseLayer.Dml.doInsert(testCase);
+  Assert.areEqual(0, Limits.getDmlStatements(), 'DML was processed?');
+  Test.stopTest();
 
-	Integer numInserted = MockDml.INSERTED?.getRecords(Case.SObjectType)?.size();
-	Assert.areEqual(1, numInserted, 'Wrong # of cases inserted');
-	Assert.isNotNull(testCase?.Id, 'Test Case was not inserted');
+  Integer numInserted = MockDml.INSERTED?.getRecords(Case.SObjectType)?.size();
+  Assert.areEqual(1, numInserted, 'Wrong # of cases inserted');
+  Assert.isNotNull(testCase?.Id, 'Test Case was not inserted');
 }
 ```
 
@@ -99,27 +252,27 @@ Assert.isTrue(result?.isSuccess(), 'DML did not succeed');
 Assert.isNotNull(account?.Id, 'Account was not inserted');
 ```
 
-To simulate failed DML operations, you must first indicate to the `MockDml` class that it should fail. Most use cases can be handled by calling the `fail()` method, which will cause all subsuquent DML operations to fail:
+To simulate failed DML operations, you must first inject failure(s) into the framework. Most use cases can be handled by calling `MockDml.shouldFail()`, which causes all subsuquent DML operations to fail:
 
 ```java
 DatabaseLayer.useMocks();
+MockDml.shouldFail();
 Account account = new Account(Name = 'John Doe');
-MockDml dml = (MockDml) DatabaseLayer.Dml;
-dml?.fail();
 try {
-	dml?.doInsert(account);
-	Assert.fail('DML operation did not fail');
+  DatabaseLayer.Dml?.doInsert(account);
+  Assert.fail('DML operation did not fail');
 } catch (System.DmlException error) {
-	// As expected!
+  // As expected!
 }
 ```
 
-You can inject more precise failure logic by passing an instance of [`MockDml.ConditionalLogic`](#the-mockdmlconditionalfailure-interface) to the `failIf()` method. This can be useful if only one of multiple DML operations, or subset of records within the same DML operation should fail:
+You can inject more precise failure logic by passing an instance of [`MockDml.ConditionalLogic`](#the-mockdmlconditionalfailure-interface) to `MockDml.shouldFailIf()` method. This can be useful if only one of multiple DML operations, or subset of records within the same DML operation should fail:
 
 ```java
+DatabaseLayer.useMockDml();
 // The "ExampleFailure" class will only fail on DML updates
 MockDml.ConditionalFailure logic = new ExampleFailure();
-DatabaseLayer.useMockDml()?.failIf(logic);
+MockDml?.shouldFailIf(logic);
 Database.SaveResult result = DatabaseLayer.Dml.doInsert(account);
 Assert.isFalse(result?.isSuccess, 'DML Operation did not fail');
 Assert.isNull(account?.Id, 'Account was inserted');
@@ -183,15 +336,15 @@ Example:
 ```java
 @IsTest
 static void someTest() {
-	DatabaseLayer.useMocks();
-	Account acc = new Account(Name = 'John Doe');
+  DatabaseLayer.useMocks();
+  Account acc = new Account(Name = 'John Doe');
 
-	Test.startTest();
-	DatabaseLayer.Dml.doInsert(acc);
-	Test.stopTest();
+  Test.startTest();
+  DatabaseLayer.Dml.doInsert(acc);
+  Test.stopTest();
 
-	List<Account> insertedAccs = MockDml.INSERTED.getRecords(Account.SObjectType);
-	Assert.areEqual(1, insertedAccs?.size(), 'Account was not inserted');
+  List<Account> insertedAccs = MockDml.INSERTED.getRecords(Account.SObjectType);
+  Assert.areEqual(1, insertedAccs?.size(), 'Account was not inserted');
 }
 ```
 
@@ -222,17 +375,19 @@ Example:
 
 ```java
 public class ExampleFailure implements MockDml.ConditionalFailure {
-	public Exception checkFailure(MockDml.Operation operation, SObject record) {
-		// Fail any operations that manipulate Account records
-		if (record?.getSObjectType() == Account.SObjectType) {
-			return new System.DmlException();
-		} else {
-			// Success!
-			return null;
-		}
-	}
+  public Exception checkFailure(MockDml.Operation operation, SObject record) {
+    // Fail any operations that manipulate Account records
+    if (record?.getSObjectType() == Account.SObjectType) {
+      return new System.DmlException();
+    } else {
+      // Success!
+      return null;
+    }
+  }
 }
 ```
+
+:warning: **IMPORTANT**: Starting in version 3.0.0, the `MockDml.Operation` enum will be replaced with the `Dml.Operation` enum. These enums have the same values. To prepare for the transition, add a _duplicate_ method to your classes that include `Dml.Operation`. Then in a subsequent release, the `MockDml.Operation` enum will be removed entirely.
 
 #### The `MockDml.Database` Class
 
@@ -309,15 +464,15 @@ Example:
 ```java
 @IsTest
 static void someTest() {
-	DatabaseLayer.useMocks();
-	Account acc = new Account(Name = 'John Doe');
+  DatabaseLayer.useMocks();
+  Account acc = new Account(Name = 'John Doe');
 
-	Test.startTest();
-	DatabaseLayer.Dml.doInsert(acc);
-	Test.stopTest();
+  Test.startTest();
+  DatabaseLayer.Dml.doInsert(acc);
+  Test.stopTest();
 
-	List<Account> insertedAccs = MockDml.INSERTED.getRecords(Account.SObjectType);
-	Assert.areEqual(1, insertedAccs?.size(), 'Account was not inserted');
+  List<Account> insertedAccs = MockDml.INSERTED.getRecords(Account.SObjectType);
+  Assert.areEqual(1, insertedAccs?.size(), 'Account was not inserted');
 }
 ```
 

--- a/docs/DML.md
+++ b/docs/DML.md
@@ -21,26 +21,11 @@ Assert.isInstanceOfType(DatabaseLayer.Dml, MockDml.class, 'Not a mock');
 
 ## Performing DML
 
-The `Dml` class contains methods which mirror the functionality of DML methods in the standard [`Database` class](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_database.htm), including its numerous method overloads:
-
-```java
-// Specify allOrNone and access level
-DatabaseLayer.Dml.doUpdate(account, false, System.AccessLevel.USER_MODE);
-// Use the default implementation
-DatabaseLayer.Dml.doUpdate(account);
-```
+The `Dml` class contains methods which mirror the functionality of DML methods in the standard [`Database` class](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_database.htm), including its numerous method overloads.
 
 Since DML keywords (like `insert`, `update`, and `delete`) are reserved, the `Dml` class's methods are prefixed with the "do" predicate. For example, `doInsert`, `doUpdate`, and `doDelete`.
 
-You can also control `System.Savepoint`s via the Dml class. This allows you to reference `MockDml.Savepoint`s in tests, which can be used to assert how a savepoint behaved during a given transaction (ie., if a savepoint(s) were set, rolled back and/or released). Read more about this [here](#simulating-savepoints--rollbacks).
-
-```java
-System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
-DatabaseLayer.Dml.rollback(savepoint);
-Assert.isTrue(MockDml.SAVEPOINTS.get(0).wasRolledBack);
-```
-
-### Public Methods
+All public methods:
 
 - `doConvert`
 - `doDelete`
@@ -59,6 +44,23 @@ Assert.isTrue(MockDml.SAVEPOINTS.get(0).wasRolledBack);
 - `releaseSavepoint`
 - `rollback`
 - `setSavepoint`
+
+Example:
+
+```java
+// Specify allOrNone and access level
+DatabaseLayer.Dml.doUpdate(account, false, System.AccessLevel.USER_MODE);
+// Use the default implementation
+DatabaseLayer.Dml.doUpdate(account);
+```
+
+You can also control `System.Savepoint`s via the Dml class. This allows you to reference `MockDml.Savepoint`s in tests, which can be used to assert how a savepoint behaved during a given transaction (ie., if a savepoint(s) were set, rolled back and/or released). Read more about this [here](#simulating-savepoints--rollbacks).
+
+```java
+System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
+DatabaseLayer.Dml.rollback(savepoint);
+Assert.isTrue(MockDml.SAVEPOINTS.get(0).wasRolledBack);
+```
 
 ## Mocking DML Operations
 

--- a/force-app/main/default/classes/ChildRelationshipService.cls
+++ b/force-app/main/default/classes/ChildRelationshipService.cls
@@ -1,69 +1,12 @@
 @SuppressWarnings('PMD.ApexDoc')
 public abstract class ChildRelationshipService {
-	/**
-	 * This small service aims to make it easier to retrieve Schema.ChildRelationship objects from their linked SObjectField.
-	 * Unlike SObjectTypes/SObjectFields, they do not have a declarable token, ex. Account.Contacts.
-	 * Callers typically have to perform expensive & verbose describe operations to retrieve this object.
-	 * By using this class, callers can retrieve a relationship object with a single line, ex:
-	 * `Schema.ChildRelationship rel = ChildRelationshipService.getChildRelationshipFrom(Contact.AccountId);`
-	 * As an added bonus, the relationship information for the lookup field's referenceTo object is cached,
-	 * so that successive calls to the same object do not take the same processing time.
-	 **/
-	private static final Map<SObjectType, CachedDescribe> DESCRIBES = new Map<SObjectType, CachedDescribe>();
-
+	// ! Deprecated: This class & all its methods will be removed in future versions
+	// ! Replace all uses of this class with DatabaseLayer.Utils methods w/the same name
 	public static Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
-		// Returns the Schema.ChildRelationshp on the referenceTo SObjectType, that the provided lookupField points to.
-		// Ex., getChildRelationshipFrom(Task.WhoId, Lead.SObjectType) -> Lead.Tasks
-		return ChildRelationshipService.getDescribeFromCache(referenceTo)?.get(lookupField);
+		return DatabaseLayer.Utils.getChildRelationshipFrom(lookupField, referenceTo);
 	}
 
 	public static Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
-		// Overload that uses the first SObjectType in the getReferenceTo() list to find the child relationship.
-		// Use this overload when you know the field in question is not polymorphic; ex., Contact.AccountId.
-		// * Note: the Schema.getReferenceTo() method returns a List<SObjectType>, not a single SObjectType.
-		// Typically, a field is only be related to a single SObjectType; exceptions include polymorphic fields (ie, Task.WhatId).
-		List<SObjectType> references = lookupField?.getDescribe()?.getReferenceTo();
-		SObjectType referenceTo = references?.isEmpty() == false ? references?.get(0) : null;
-		return ChildRelationshipService.getChildRelationshipFrom(lookupField, referenceTo);
-	}
-
-	// **** PRIVATE **** //
-	private static ChildRelationshipService.CachedDescribe getDescribeFromCache(SObjectType objectType) {
-		// Retrieves a CachedDescribe object that represents cached Schema.ChildRelationships for the SObjectType
-		ChildRelationshipService.CachedDescribe repo = DESCRIBES?.containsKey(objectType)
-			? DESCRIBES?.get(objectType)
-			: new ChildRelationshipService.CachedDescribe(objectType);
-		DESCRIBES?.put(objectType, repo);
-		return repo;
-	}
-
-	// **** INNER **** //
-	private class CachedDescribe {
-		// Object used to map & cache Schema.ChildRelationships by their lookup field.
-		// Useful since the operation to retrieve Schema.ChildRelationships from an object can be expensive,
-		// and Salesforce's built in Schema caching mechanism doesn't seem to handle this.
-		// Note: In the future, consider upgrading this to use actual System.Cache.
-		private Map<SObjectField, Schema.ChildRelationship> relationshipMap;
-
-		public CachedDescribe(SObjectType objectType) {
-			this.mapRelationships(objectType);
-		}
-
-		public Schema.ChildRelationship get(SObjectField field) {
-			return this.relationshipMap?.get(field);
-		}
-
-		private List<Schema.ChildRelationship> getRelationshipList(SObjectType objectType) {
-			return objectType?.getDescribe(Schema.SObjectDescribeOptions.DEFERRED)?.getChildRelationships() ??
-				new List<Schema.ChildRelationship>();
-		}
-
-		private void mapRelationships(SObjectType objectType) {
-			this.relationshipMap = new Map<SObjectField, Schema.ChildRelationship>();
-			for (Schema.ChildRelationship relationship : this.getRelationshipList(objectType)) {
-				SObjectField field = relationship?.getField();
-				this.relationshipMap?.put(field, relationship);
-			}
-		}
+		return DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
 	}
 }

--- a/force-app/main/default/classes/ChildRelationshipService.cls
+++ b/force-app/main/default/classes/ChildRelationshipService.cls
@@ -3,10 +3,10 @@ public abstract class ChildRelationshipService {
 	// ! Deprecated: This class & all its methods will be removed in future versions
 	// ! Replace all uses of this class with DatabaseLayer.Utils methods w/the same name
 	public static Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
-		return DatabaseLayer.Utils.getChildRelationshipFrom(lookupField, referenceTo);
+		return DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(lookupField, referenceTo);
 	}
 
 	public static Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
-		return DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
+		return DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(lookupField);
 	}
 }

--- a/force-app/main/default/classes/DatabaseLayer.cls
+++ b/force-app/main/default/classes/DatabaseLayer.cls
@@ -6,7 +6,13 @@ public class DatabaseLayer {
 	 * Automatically inject mock versions of these classes via the `useMocks()` method.
 	 **/
 	// **** CONSTANTS **** //
-	private static final DatabaseLayer INSTANCE = new DatabaseLayer();
+	public static final DatabaseLayerUtils UTILS;
+	private static final DatabaseLayer INSTANCE;
+
+	static {
+		INSTANCE = new DatabaseLayer();
+		UTILS = new DatabaseLayerUtils(INSTANCE);
+	}
 
 	// **** MEMBER **** //
 	private Dml currentDml;

--- a/force-app/main/default/classes/DatabaseLayerUtils.cls
+++ b/force-app/main/default/classes/DatabaseLayerUtils.cls
@@ -1,0 +1,97 @@
+public class DatabaseLayerUtils {
+	private static final DatabaseLayerUtils.ChildRelationshipUtility CHILD_RELATIONSHIPS;
+
+	static {
+		CHILD_RELATIONSHIPS = new DatabaseLayerUtils.ChildRelationshipUtility();
+	}
+
+	@SuppressWarnings('PMD.EmptyStatementBlock')
+	public DatabaseLayerUtils(DatabaseLayer factory) {
+		// The utility class can't be manually constructed outside of this package
+		// Necessary in the absence of @NamespaceAccessible-like annotation for unlocked packages
+	}
+
+	public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
+		// Returns the Schema.ChildRelationshp on the referenceTo SObjectType, that the provided lookupField points to.
+		// Ex., getChildRelationshipFrom(Task.WhoId, Lead.SObjectType) -> Lead.Tasks
+		return CHILD_RELATIONSHIPS?.getChildRelationshipFrom(lookupField, referenceTo);
+	}
+
+	public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
+		// Overload that uses the first SObjectType in the getReferenceTo() list to find the child relationship.
+		// Use this overload when you know the field in question is not polymorphic; ex., Contact.AccountId.
+		return CHILD_RELATIONSHIPS?.getChildRelationshipFrom(lookupField);
+	}
+
+	// **** INNER **** //
+	private class CachedDescribe {
+		// Object used to map & cache Schema.ChildRelationships by their lookup field.
+		// Useful since the operation to retrieve Schema.ChildRelationships from an object can be expensive,
+		// and Salesforce's built in Schema caching mechanism doesn't seem to handle this.
+		// Note: In the future, consider upgrading this to use actual System.Cache.
+		private Map<SObjectField, Schema.ChildRelationship> relationshipMap;
+
+		public CachedDescribe(SObjectType objectType) {
+			this.mapRelationships(objectType);
+		}
+
+		public Schema.ChildRelationship get(SObjectField field) {
+			return this.relationshipMap?.get(field);
+		}
+
+		private List<Schema.ChildRelationship> getRelationshipList(SObjectType objectType) {
+			return objectType?.getDescribe(Schema.SObjectDescribeOptions.DEFERRED)?.getChildRelationships() ??
+				new List<Schema.ChildRelationship>();
+		}
+
+		private void mapRelationships(SObjectType objectType) {
+			this.relationshipMap = new Map<SObjectField, Schema.ChildRelationship>();
+			for (Schema.ChildRelationship relationship : this.getRelationshipList(objectType)) {
+				SObjectField field = relationship?.getField();
+				this.relationshipMap?.put(field, relationship);
+			}
+		}
+	}
+
+	private class ChildRelationshipUtility {
+		/**
+		 * This small utility aims to make it easier to retrieve Schema.ChildRelationship objects from their linked SObjectField.
+		 * Unlike SObjectTypes/SObjectFields, they do not have a declarable token, ex. Account.Contacts.
+		 * Callers typically have to perform expensive & verbose describe operations to retrieve this object.
+		 * Using this utility, callers can retrieve a relationship object with a single line, ex:
+		 * `Schema.ChildRelationship rel = DatabaseLayer.Utils.getChildRelationshipFrom(Contact.AccountId);`
+		 * As an added bonus, the relationship information for the lookup field's referenceTo object is cached,
+		 * so that successive calls to the same object do not take the same processing time.
+		 **/
+		private Map<SObjectType, DatabaseLayerUtils.CachedDescribe> describes;
+
+		private ChildRelationshipUtility() {
+			this.describes = new Map<SObjectType, DatabaseLayerUtils.CachedDescribe>();
+		}
+
+		public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
+			// Returns the Schema.ChildRelationshp on the referenceTo SObjectType, that the provided lookupField points to.
+			// Ex., getChildRelationshipFrom(Task.WhoId, Lead.SObjectType) -> Lead.Tasks
+			return this.getDescribeFromCache(referenceTo)?.get(lookupField);
+		}
+
+		public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
+			// Overload that uses the first SObjectType in the getReferenceTo() list to find the child relationship.
+			// Use this overload when you know the field in question is not polymorphic; ex., Contact.AccountId.
+			List<SObjectType> references = lookupField?.getDescribe()?.getReferenceTo();
+			// Note: the Schema.getReferenceTo() method returns a List<SObjectType>, not a single SObjectType.
+			// Typically, a field is only be related to a single SObjectType; excluding polymorphic fields (ie, Task.WhatId).
+			SObjectType referenceTo = references?.isEmpty() == false ? references?.get(0) : null;
+			return this.getChildRelationshipFrom(lookupField, referenceTo);
+		}
+
+		private DatabaseLayerUtils.CachedDescribe getDescribeFromCache(SObjectType objectType) {
+			// Retrieves a CachedDescribe object, which represents a cached Schema.ChildRelationships for the SObjectType
+			DatabaseLayerUtils.CachedDescribe describe = this.describes?.containsKey(objectType)
+				? this.describes?.get(objectType)
+				: new DatabaseLayerUtils.CachedDescribe(objectType);
+			this.describes?.put(objectType, describe);
+			return describe;
+		}
+	}
+}

--- a/force-app/main/default/classes/DatabaseLayerUtils.cls
+++ b/force-app/main/default/classes/DatabaseLayerUtils.cls
@@ -1,71 +1,39 @@
+@SuppressWarnings('PMD.PropertyNamingConventions')
 public class DatabaseLayerUtils {
-	private static final DatabaseLayerUtils.ChildRelationshipUtility CHILD_RELATIONSHIPS;
-
-	static {
-		CHILD_RELATIONSHIPS = new DatabaseLayerUtils.ChildRelationshipUtility();
-	}
+	/**
+	 * This class contains utilities used by the framework internally
+	 * It uses a factory pattern to enforce access in a pseudo-namespace fashion;
+	 * Ex., DatabaseLayer.Utils.MetadataSelector.get()
+	 * This helps communicate the intent that these utils are really only designed to be used by the framework itself
+	 * Necessary since there isn't a way to *actually* enforce this, like @NamespaceAccessible for managed packages
+	 */
+	public final DatabaseLayerUtils.ChildRelationships ChildRelationships { get; private set; }
+	public final DatabaseLayerUtils.MetadataSelector MetadataSelector { get; private set; }
+	public final DatabaseLayerUtils.Plugins Plugins { get; private set; }
 
 	@SuppressWarnings('PMD.EmptyStatementBlock')
 	public DatabaseLayerUtils(DatabaseLayer factory) {
 		// The utility class can't be manually constructed outside of this package
 		// Necessary in the absence of @NamespaceAccessible-like annotation for unlocked packages
-	}
-
-	public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField, SObjectType referenceTo) {
-		// Returns the Schema.ChildRelationshp on the referenceTo SObjectType, that the provided lookupField points to.
-		// Ex., getChildRelationshipFrom(Task.WhoId, Lead.SObjectType) -> Lead.Tasks
-		return CHILD_RELATIONSHIPS?.getChildRelationshipFrom(lookupField, referenceTo);
-	}
-
-	public Schema.ChildRelationship getChildRelationshipFrom(SObjectField lookupField) {
-		// Overload that uses the first SObjectType in the getReferenceTo() list to find the child relationship.
-		// Use this overload when you know the field in question is not polymorphic; ex., Contact.AccountId.
-		return CHILD_RELATIONSHIPS?.getChildRelationshipFrom(lookupField);
+		this.ChildRelationships = new DatabaseLayerUtils.ChildRelationships();
+		this.MetadataSelector = new DatabaseLayerUtils.MetadataSelector();
+		this.Plugins = new DatabaseLayerUtils.Plugins();
 	}
 
 	// **** INNER **** //
-	private class CachedDescribe {
-		// Object used to map & cache Schema.ChildRelationships by their lookup field.
-		// Useful since the operation to retrieve Schema.ChildRelationships from an object can be expensive,
-		// and Salesforce's built in Schema caching mechanism doesn't seem to handle this.
-		// Note: In the future, consider upgrading this to use actual System.Cache.
-		private Map<SObjectField, Schema.ChildRelationship> relationshipMap;
-
-		public CachedDescribe(SObjectType objectType) {
-			this.mapRelationships(objectType);
-		}
-
-		public Schema.ChildRelationship get(SObjectField field) {
-			return this.relationshipMap?.get(field);
-		}
-
-		private List<Schema.ChildRelationship> getRelationshipList(SObjectType objectType) {
-			return objectType?.getDescribe(Schema.SObjectDescribeOptions.DEFERRED)?.getChildRelationships() ??
-				new List<Schema.ChildRelationship>();
-		}
-
-		private void mapRelationships(SObjectType objectType) {
-			this.relationshipMap = new Map<SObjectField, Schema.ChildRelationship>();
-			for (Schema.ChildRelationship relationship : this.getRelationshipList(objectType)) {
-				SObjectField field = relationship?.getField();
-				this.relationshipMap?.put(field, relationship);
-			}
-		}
-	}
-
-	private class ChildRelationshipUtility {
+	public class ChildRelationships {
 		/**
-		 * This small utility aims to make it easier to retrieve Schema.ChildRelationship objects from their linked SObjectField.
-		 * Unlike SObjectTypes/SObjectFields, they do not have a declarable token, ex. Account.Contacts.
+		 * This class makes it easier to retrieve Schema.ChildRelationship objects from their linked SObjectField.
+		 * Unlike SObjectTypes/SObjectFields, ChildRelationships do not have a declarable token, ex. Account.Contacts.
 		 * Callers typically have to perform expensive & verbose describe operations to retrieve this object.
 		 * Using this utility, callers can retrieve a relationship object with a single line, ex:
-		 * `Schema.ChildRelationship rel = DatabaseLayer.Utils.getChildRelationshipFrom(Contact.AccountId);`
+		 * `Schema.ChildRelationship rel = DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(Contact.AccountId);`
 		 * As an added bonus, the relationship information for the lookup field's referenceTo object is cached,
 		 * so that successive calls to the same object do not take the same processing time.
 		 **/
 		private Map<SObjectType, DatabaseLayerUtils.CachedDescribe> describes;
 
-		private ChildRelationshipUtility() {
+		private ChildRelationships() {
 			this.describes = new Map<SObjectType, DatabaseLayerUtils.CachedDescribe>();
 		}
 
@@ -92,6 +60,71 @@ public class DatabaseLayerUtils {
 				: new DatabaseLayerUtils.CachedDescribe(objectType);
 			this.describes?.put(objectType, describe);
 			return describe;
+		}
+	}
+
+	public class MetadataSelector {
+		/**
+		 * This utility class is used to retrieve DatabaseLayerSetting__mdt settings from the org.
+		 * It also provides a seam for mock settings to be injected.
+		 * Note: The framework will *always* use the first defined record;
+		 * There is a validation rule which helps enforce only 1x DatabaseLayerSetting__mdt per org
+		 */
+		@TestVisible
+		private List<DatabaseLayerSetting__mdt> settings;
+
+		public DatabaseLayerSetting__mdt get() {
+			// Retrieve the first/default settings record; if none defined, returns null
+			this.settings = this.settings ?? DatabaseLayerSetting__mdt.getAll()?.values();
+			return this.settings?.isEmpty() == false ? this.settings?.get(0) : null;
+		}
+	}
+
+	public class Plugins {
+		/**
+		 * This class contains utility methods re: the plugin framework
+		 */
+		public Object initPlugin(SObjectField field) {
+			// Constructs a new object of a type listed in the field on the CMDT using Type.forName:
+			String className;
+			try {
+				className = (String) DatabaseLayer.Utils.MetadataSelector.get()?.get(field);
+				return Type.forName(className)?.newInstance();
+			} catch (Exception error) {
+				String source = DatabaseLayerUtils.Plugin.class.getName();
+				String msg = source + ': Invalid ' + field + ': "' + className + '". Details: ' + error;
+				System.debug(System.LoggingLevel.WARN, msg);
+				return null;
+			}
+		}
+	}
+
+	private class CachedDescribe {
+		// Object used to map & cache Schema.ChildRelationships by their lookup field.
+		// Useful since the operation to retrieve Schema.ChildRelationships from an object can be expensive,
+		// and Salesforce's built in Schema caching mechanism doesn't seem to handle this.
+		// Note: In the future, consider upgrading this to use actual System.Cache.
+		private Map<SObjectField, Schema.ChildRelationship> relationshipMap;
+
+		public CachedDescribe(SObjectType objectType) {
+			this.mapRelationships(objectType);
+		}
+
+		public Schema.ChildRelationship get(SObjectField field) {
+			return this.relationshipMap?.get(field);
+		}
+
+		private List<Schema.ChildRelationship> getRelationshipList(SObjectType objectType) {
+			return objectType?.getDescribe(Schema.SObjectDescribeOptions.DEFERRED)?.getChildRelationships() ??
+				new List<Schema.ChildRelationship>();
+		}
+
+		private void mapRelationships(SObjectType objectType) {
+			this.relationshipMap = new Map<SObjectField, Schema.ChildRelationship>();
+			for (Schema.ChildRelationship relationship : this.getRelationshipList(objectType)) {
+				SObjectField field = relationship?.getField();
+				this.relationshipMap?.put(field, relationship);
+			}
 		}
 	}
 }

--- a/force-app/main/default/classes/DatabaseLayerUtils.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseLayerUtils.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/DatabaseLayerUtilsTest.cls
+++ b/force-app/main/default/classes/DatabaseLayerUtilsTest.cls
@@ -1,0 +1,59 @@
+@SuppressWarnings('PMD.ApexDoc')
+@IsTest
+private class DatabaseLayerUtilsTest {
+	@IsTest
+	static void shouldGetChildRelationshipFromLookupField() {
+		SObjectField field = Contact.AccountId;
+
+		Test.startTest();
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Test.stopTest();
+
+		Assert.areEqual(field, relationship?.getField(), 'Relationship does not point to ' + field);
+	}
+
+	@IsTest
+	static void shouldGetChildRelationshipFromPolymorphicLookupField() {
+		SObjectField field = Task.WhoId; // Polymorphic! Can be a reference to Contact.Tasks OR Lead.Tasks
+		SObjectType referenceTo = Lead.SObjectType; // ...in this case, we want Lead.Tasks
+
+		Test.startTest();
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field, referenceTo);
+		Test.stopTest();
+
+		Assert.areEqual(field, relationship?.getField(), 'Relationship does not point to ' + field);
+	}
+
+	@IsTest
+	static void shouldReturnChildRelationshipsUnderHighStress() {
+		// The operation to retrieve Schema.ChildRelationships from an object can be expensive,
+		// so the class internally caches these results via an inner class.
+		// Successive calls to retrieve the same SObjectType's relationships
+		// should have similar performance implications as calling it once.
+		SObjectField field = Contact.AccountId;
+		DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Integer firstTime = Limits.getCpuTime();
+
+		for (Integer i = 0; i < 10; i++) {
+			Integer start = Limits.getCpuTime();
+			DatabaseLayer.Utils.getChildRelationshipFrom(field);
+			Integer thisTime = Limits.getCpuTime() - start;
+			Assert.areEqual(
+				true,
+				thisTime < firstTime,
+				'Took longer than initial call: ' + new List<Integer>{ firstTime, thisTime }
+			);
+		}
+	}
+
+	@IsTest
+	static void shouldReturnNullChildRelationshipIfNotLookupField() {
+		SObjectField field = Contact.CreatedDate;
+
+		Test.startTest();
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Test.stopTest();
+
+		Assert.areEqual(null, relationship, 'Non-lookup field returned a relationship anyways');
+	}
+}

--- a/force-app/main/default/classes/DatabaseLayerUtilsTest.cls
+++ b/force-app/main/default/classes/DatabaseLayerUtilsTest.cls
@@ -6,7 +6,7 @@ private class DatabaseLayerUtilsTest {
 		SObjectField field = Contact.AccountId;
 
 		Test.startTest();
-		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(field);
 		Test.stopTest();
 
 		Assert.areEqual(field, relationship?.getField(), 'Relationship does not point to ' + field);
@@ -18,7 +18,10 @@ private class DatabaseLayerUtilsTest {
 		SObjectType referenceTo = Lead.SObjectType; // ...in this case, we want Lead.Tasks
 
 		Test.startTest();
-		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field, referenceTo);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(
+			field,
+			referenceTo
+		);
 		Test.stopTest();
 
 		Assert.areEqual(field, relationship?.getField(), 'Relationship does not point to ' + field);
@@ -31,12 +34,12 @@ private class DatabaseLayerUtilsTest {
 		// Successive calls to retrieve the same SObjectType's relationships
 		// should have similar performance implications as calling it once.
 		SObjectField field = Contact.AccountId;
-		DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(field);
 		Integer firstTime = Limits.getCpuTime();
 
 		for (Integer i = 0; i < 10; i++) {
 			Integer start = Limits.getCpuTime();
-			DatabaseLayer.Utils.getChildRelationshipFrom(field);
+			DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(field);
 			Integer thisTime = Limits.getCpuTime() - start;
 			Assert.areEqual(
 				true,
@@ -51,9 +54,112 @@ private class DatabaseLayerUtilsTest {
 		SObjectField field = Contact.CreatedDate;
 
 		Test.startTest();
-		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(field);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(field);
 		Test.stopTest();
 
 		Assert.areEqual(null, relationship, 'Non-lookup field returned a relationship anyways');
+	}
+
+	@IsTest
+	static void shouldReturnWhateverMetadataIsDefinedInOrg() {
+		// A validation rule enforces that at most, 1 settings record will exist in an org
+		// This ensures the get() method will return the 1st (and only) record, if one is defined:
+		Map<String, DatabaseLayerSetting__mdt> all = DatabaseLayerSetting__mdt.getAll();
+		DatabaseLayerSetting__mdt firstSetting = (all?.isEmpty() == false) ? all?.values()?.get(0) : null;
+
+		Test.startTest();
+		DatabaseLayerSetting__mdt results = DatabaseLayer.Utils.MetadataSelector.get();
+		Assert.areEqual(0, Limits.getQueries(), 'Should not retrieve CMDT via SOQL');
+		Test.stopTest();
+
+		Assert.areEqual(firstSetting?.DeveloperName, results?.DeveloperName, 'Wrong DatabaseLayerSetting__mdt value');
+	}
+
+	@IsTest
+	static void shouldReturnMockedMetadata() {
+		// To force your test to use a specific DatabaseLayerSetting__mdt record, add ito the `settings` list:
+		DatabaseLayerSetting__mdt mockSetting = new DatabaseLayerSetting__mdt(DeveloperName = 'Test_123');
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{ mockSetting };
+
+		Test.startTest();
+		DatabaseLayerSetting__mdt results = DatabaseLayer.Utils.MetadataSelector.get();
+		Assert.areEqual(0, Limits.getQueries(), 'Should not retrieve CMDT via SOQL');
+		Test.stopTest();
+
+		Assert.areEqual(mockSetting?.DeveloperName, results?.DeveloperName, 'Wrong DatabaseLayerSetting__mdt value');
+	}
+
+	@IsTest
+	static void shouldReturnNullIfMockedEmtpyList() {
+		// Define `settings` as an empty list to ignore any defined DatabaseLayerSetting__mdt records in an org:
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{};
+
+		Test.startTest();
+		DatabaseLayerSetting__mdt results = DatabaseLayer.Utils.MetadataSelector.get();
+		Assert.areEqual(0, Limits.getQueries(), 'Should not retrieve CMDT via SOQL');
+		Test.stopTest();
+
+		Assert.isNull(results, 'Should not have returned a CMDT value');
+	}
+
+	@IsTest
+	static void shouldInitPluginObjectFromCustomMetadata() {
+		DatabaseLayerSetting__mdt mockSetting = new DatabaseLayerSetting__mdt(
+			DeveloperName = 'Test_123',
+			DmlPreAndPostProcessor__c = 'Schema.Account' // For example...
+		);
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{ mockSetting };
+		SObjectField field = DatabaseLayerSetting__mdt.DmlPreAndPostProcessor__c;
+
+		Test.startTest();
+		// Account would never *actually* be a plugin; this is just an example:
+		Account example = (Account) DatabaseLayer.Utils.Plugins.initPlugin(field);
+		Test.stopTest();
+
+		Assert.isNotNull(example, 'Did not generate an object from CMDT');
+	}
+
+	@IsTest
+	static void shouldReturnNullPluginIfPluginInvalid() {
+		DatabaseLayerSetting__mdt mockSetting = new DatabaseLayerSetting__mdt(
+			DeveloperName = 'Test_123',
+			DmlPreAndPostProcessor__c = 'not a real object name'
+		);
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{ mockSetting };
+		SObjectField field = DatabaseLayerSetting__mdt.DmlPreAndPostProcessor__c;
+
+		Test.startTest();
+		Object plugin = DatabaseLayer.Utils.Plugins.initPlugin(field);
+		Test.stopTest();
+
+		Assert.isNull(plugin, 'Did not return null plugin');
+	}
+
+	@IsTest
+	static void shouldReturnNullPluginIfMissingPluginName() {
+		DatabaseLayerSetting__mdt mockSetting = new DatabaseLayerSetting__mdt(
+			DeveloperName = 'Test_123',
+			DmlPreAndPostProcessor__c = null
+		);
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{ mockSetting };
+		SObjectField field = DatabaseLayerSetting__mdt.DmlPreAndPostProcessor__c;
+
+		Test.startTest();
+		Object plugin = DatabaseLayer.Utils.Plugins.initPlugin(field);
+		Test.stopTest();
+
+		Assert.isNull(plugin, 'Did not return null plugin');
+	}
+
+	@IsTest
+	static void shouldReturnNullPluginIfMissingSettingsRecords() {
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{};
+		SObjectField field = DatabaseLayerSetting__mdt.DmlPreAndPostProcessor__c;
+
+		Test.startTest();
+		Object plugin = DatabaseLayer.Utils.Plugins.initPlugin(field);
+		Test.stopTest();
+
+		Assert.isNull(plugin, 'Did not return null plugin');
 	}
 }

--- a/force-app/main/default/classes/DatabaseLayerUtilsTest.cls-meta.xml
+++ b/force-app/main/default/classes/DatabaseLayerUtilsTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>64.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/force-app/main/default/classes/Dml.cls
+++ b/force-app/main/default/classes/Dml.cls
@@ -39,7 +39,7 @@ public with sharing virtual class Dml {
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return this.doConvert(leadsToConvert, this.initOptions(allOrNone), accessLevel);
+		return this.doConvert(leadsToConvert, this.initDmlOptions(allOrNone), accessLevel);
 	}
 
 	public List<Database.LeadConvertResult> doConvert(
@@ -57,7 +57,7 @@ public with sharing virtual class Dml {
 	}
 
 	public List<Database.LeadConvertResult> doConvert(List<Database.LeadConvert> leadsToConvert, Boolean allOrNone) {
-		return this.doConvert(leadsToConvert, this.initOptions(allOrNone));
+		return this.doConvert(leadsToConvert, this.initDmlOptions(allOrNone));
 	}
 
 	public List<Database.LeadConvertResult> doConvert(List<Database.LeadConvert> leadsToConvert) {
@@ -98,32 +98,11 @@ public with sharing virtual class Dml {
 
 	// ** Delete Methods
 	public virtual List<Database.DeleteResult> doDelete(
-		List<Id> recordIds,
-		Boolean allOrNone,
-		System.AccessLevel accessLevel
-	) {
-		return Database.delete(recordIds, allOrNone, accessLevel);
-	}
-
-	public List<Database.DeleteResult> doDelete(List<Id> recordIds, Boolean allOrNone) {
-		return this.doDelete(recordIds, allOrNone, DEFAULT_ACCESS_LEVEL);
-	}
-
-	public List<Database.DeleteResult> doDelete(List<Id> recordIds, System.AccessLevel accessLevel) {
-		return this.doDelete(recordIds, true, accessLevel);
-	}
-
-	public List<Database.DeleteResult> doDelete(List<Id> recordIds) {
-		return this.doDelete(recordIds, DEFAULT_ACCESS_LEVEL);
-	}
-
-	public List<Database.DeleteResult> doDelete(
 		List<SObject> records,
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		List<Id> recordIds = this.getListOfIds(records);
-		return this.doDelete(recordIds, allOrNone, accessLevel);
+		return Database.delete(records, allOrNone, accessLevel);
 	}
 
 	public List<Database.DeleteResult> doDelete(List<SObject> records, Boolean allOrNone) {
@@ -138,20 +117,21 @@ public with sharing virtual class Dml {
 		return this.doDelete(records, DEFAULT_ACCESS_LEVEL);
 	}
 
-	public Database.DeleteResult doDelete(Id recordId, Boolean allOrNone, System.AccessLevel accessLevel) {
-		return this.doDelete(new List<Id>{ recordId }, allOrNone, accessLevel)?.get(0);
+	public List<Database.DeleteResult> doDelete(List<Id> recordIds, Boolean allOrNone, System.AccessLevel accessLevel) {
+		List<SObject> records = this.initRecordsFromIds(recordIds);
+		return this.doDelete(records, allOrNone, accessLevel);
 	}
 
-	public Database.DeleteResult doDelete(Id recordId, Boolean allOrNone) {
-		return this.doDelete(new List<Id>{ recordId }, allOrNone)?.get(0);
+	public List<Database.DeleteResult> doDelete(List<Id> recordIds, Boolean allOrNone) {
+		return this.doDelete(recordIds, allOrNone, DEFAULT_ACCESS_LEVEL);
 	}
 
-	public Database.DeleteResult doDelete(Id recordId, System.AccessLevel accessLevel) {
-		return this.doDelete(new List<Id>{ recordId }, accessLevel)?.get(0);
+	public List<Database.DeleteResult> doDelete(List<Id> recordIds, System.AccessLevel accessLevel) {
+		return this.doDelete(recordIds, true, accessLevel);
 	}
 
-	public Database.DeleteResult doDelete(Id recordId) {
-		return this.doDelete(new List<Id>{ recordId })?.get(0);
+	public List<Database.DeleteResult> doDelete(List<Id> recordIds) {
+		return this.doDelete(recordIds, DEFAULT_ACCESS_LEVEL);
 	}
 
 	public Database.DeleteResult doDelete(SObject record, Boolean allOrNone, System.AccessLevel accessLevel) {
@@ -168,6 +148,22 @@ public with sharing virtual class Dml {
 
 	public Database.DeleteResult doDelete(SObject record) {
 		return this.doDelete(new List<SObject>{ record })?.get(0);
+	}
+
+	public Database.DeleteResult doDelete(Id recordId, Boolean allOrNone, System.AccessLevel accessLevel) {
+		return this.doDelete(new List<Id>{ recordId }, allOrNone, accessLevel)?.get(0);
+	}
+
+	public Database.DeleteResult doDelete(Id recordId, Boolean allOrNone) {
+		return this.doDelete(new List<Id>{ recordId }, allOrNone)?.get(0);
+	}
+
+	public Database.DeleteResult doDelete(Id recordId, System.AccessLevel accessLevel) {
+		return this.doDelete(new List<Id>{ recordId }, accessLevel)?.get(0);
+	}
+
+	public Database.DeleteResult doDelete(Id recordId) {
+		return this.doDelete(new List<Id>{ recordId })?.get(0);
 	}
 
 	// ** DeleteAsync Methods
@@ -245,7 +241,7 @@ public with sharing virtual class Dml {
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return this.doInsert(records, this.initOptions(allOrNone), accessLevel);
+		return this.doInsert(records, this.initDmlOptions(allOrNone), accessLevel);
 	}
 
 	public List<Database.SaveResult> doInsert(List<SObject> records, Database.DmlOptions options) {
@@ -359,32 +355,11 @@ public with sharing virtual class Dml {
 
 	// ** Undelete Methods
 	public virtual List<Database.UndeleteResult> doUndelete(
-		List<Id> recordIds,
-		Boolean allOrNone,
-		System.AccessLevel accessLevel
-	) {
-		return Database.undelete(recordIds, allOrNone, accessLevel);
-	}
-
-	public List<Database.UndeleteResult> doUndelete(List<Id> recordIds, Boolean allOrNone) {
-		return this.doUndelete(recordIds, allOrNone, DEFAULT_ACCESS_LEVEL);
-	}
-
-	public List<Database.UndeleteResult> doUndelete(List<Id> recordIds, System.AccessLevel accessLevel) {
-		return this.doUndelete(recordIds, true, accessLevel);
-	}
-
-	public List<Database.UndeleteResult> doUndelete(List<Id> recordIds) {
-		return this.doUndelete(recordIds, DEFAULT_ACCESS_LEVEL);
-	}
-
-	public List<Database.UndeleteResult> doUndelete(
 		List<SObject> records,
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		List<Id> recordIds = this.getListOfIds(records);
-		return this.doUndelete(recordIds, allOrNone, accessLevel);
+		return Database.undelete(records, allOrNone, accessLevel);
 	}
 
 	public List<Database.UndeleteResult> doUndelete(List<SObject> records, Boolean allOrNone) {
@@ -399,20 +374,25 @@ public with sharing virtual class Dml {
 		return this.doUndelete(records, DEFAULT_ACCESS_LEVEL);
 	}
 
-	public Database.UndeleteResult doUndelete(Id recordId, Boolean allOrNone, System.AccessLevel accessLevel) {
-		return this.doUndelete(new List<Id>{ recordId }, allOrNone, accessLevel)?.get(0);
+	public List<Database.UndeleteResult> doUndelete(
+		List<Id> recordIds,
+		Boolean allOrNone,
+		System.AccessLevel accessLevel
+	) {
+		List<SObject> records = this.initRecordsFromIds(recordIds);
+		return this.doUndelete(records, allOrNone, accessLevel);
 	}
 
-	public Database.UndeleteResult doUndelete(Id recordId, Boolean allOrNone) {
-		return this.doUndelete(new List<Id>{ recordId }, allOrNone)?.get(0);
+	public List<Database.UndeleteResult> doUndelete(List<Id> recordIds, Boolean allOrNone) {
+		return this.doUndelete(recordIds, allOrNone, DEFAULT_ACCESS_LEVEL);
 	}
 
-	public Database.UndeleteResult doUndelete(Id recordId, System.AccessLevel accessLevel) {
-		return this.doUndelete(new List<Id>{ recordId }, accessLevel)?.get(0);
+	public List<Database.UndeleteResult> doUndelete(List<Id> recordIds, System.AccessLevel accessLevel) {
+		return this.doUndelete(recordIds, true, accessLevel);
 	}
 
-	public Database.UndeleteResult doUndelete(Id recordId) {
-		return this.doUndelete(new List<Id>{ recordId })?.get(0);
+	public List<Database.UndeleteResult> doUndelete(List<Id> recordIds) {
+		return this.doUndelete(recordIds, DEFAULT_ACCESS_LEVEL);
 	}
 
 	public Database.UndeleteResult doUndelete(SObject record, Boolean allOrNone, System.AccessLevel accessLevel) {
@@ -431,6 +411,22 @@ public with sharing virtual class Dml {
 		return this.doUndelete(new List<SObject>{ record })?.get(0);
 	}
 
+	public Database.UndeleteResult doUndelete(Id recordId, Boolean allOrNone, System.AccessLevel accessLevel) {
+		return this.doUndelete(new List<Id>{ recordId }, allOrNone, accessLevel)?.get(0);
+	}
+
+	public Database.UndeleteResult doUndelete(Id recordId, Boolean allOrNone) {
+		return this.doUndelete(new List<Id>{ recordId }, allOrNone)?.get(0);
+	}
+
+	public Database.UndeleteResult doUndelete(Id recordId, System.AccessLevel accessLevel) {
+		return this.doUndelete(new List<Id>{ recordId }, accessLevel)?.get(0);
+	}
+
+	public Database.UndeleteResult doUndelete(Id recordId) {
+		return this.doUndelete(new List<Id>{ recordId })?.get(0);
+	}
+
 	// ** Update Methods
 	public virtual List<Database.SaveResult> doUpdate(
 		List<SObject> records,
@@ -445,7 +441,7 @@ public with sharing virtual class Dml {
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return this.doUpdate(records, this.initOptions(allOrNone), accessLevel);
+		return this.doUpdate(records, this.initDmlOptions(allOrNone), accessLevel);
 	}
 
 	public List<Database.SaveResult> doUpdate(List<SObject> records, Database.DmlOptions options) {
@@ -642,21 +638,21 @@ public with sharing virtual class Dml {
 	}
 
 	// ** EmptyRecycleBin Methods
-	public virtual List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<Id> recordIds) {
-		return Database.emptyRecycleBin(recordIds);
+	public virtual List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<SObject> records) {
+		return Database.emptyRecycleBin(records);
 	}
 
-	public List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<SObject> records) {
-		List<Id> recordIds = this.getListOfIds(records);
-		return this.emptyRecycleBin(recordIds);
-	}
-
-	public Database.EmptyRecycleBinResult emptyRecycleBin(Id recordId) {
-		return this.emptyRecycleBin(new List<Id>{ recordId })?.get(0);
+	public List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<Id> recordIds) {
+		List<SObject> records = this.initRecordsFromIds(recordIds);
+		return this.emptyRecycleBin(records);
 	}
 
 	public Database.EmptyRecycleBinResult emptyRecycleBin(SObject record) {
 		return this.emptyRecycleBin(new List<SObject>{ record })?.get(0);
+	}
+
+	public Database.EmptyRecycleBinResult emptyRecycleBin(Id recordId) {
+		return this.emptyRecycleBin(new List<Id>{ recordId })?.get(0);
 	}
 
 	// ** Savepoint Methods
@@ -678,15 +674,20 @@ public with sharing virtual class Dml {
 	}
 
 	// **** PRIVATE **** //
-	private List<Id> getListOfIds(List<SObject> records) {
-		// Converts a List<SObject> into a List<Id>
-		return new List<Id>(new Map<Id, SObject>(records)?.keySet());
-	}
-
-	private Database.DmlOptions initOptions(Boolean allOrNone) {
+	private Database.DmlOptions initDmlOptions(Boolean allOrNone) {
 		Database.DmlOptions options = new Database.DmlOptions();
 		options.OptAllOrNone = allOrNone;
 		return options;
+	}
+
+	private List<SObject> initRecordsFromIds(List<Id> recordIds) {
+		// Converts a List<Id> into a List<SObject> with those Ids:
+		List<SObject> records = new List<SObject>();
+		for (Id recordId : recordIds) {
+			SObject record = recordId?.getSObjectType()?.newSObject(recordId);
+			records?.add(record);
+		}
+		return records;
 	}
 
 	// **** INNER **** //

--- a/force-app/main/default/classes/Dml.cls
+++ b/force-app/main/default/classes/Dml.cls
@@ -20,6 +20,7 @@ public with sharing virtual class Dml {
 	private static final DataSource.AsyncDeleteCallback DEFAULT_DELETE_CALLBACK = new Dml.EmptyDeleteCallback();
 	private static final DataSource.AsyncSaveCallback DEFAULT_SAVE_CALLBACK = new Dml.EmptySaveCallback();
 
+	@SuppressWarnings('PMD.EmptyStatementBlock')
 	public Dml(DatabaseLayer factory) {
 		// Dml classes can't be constructed manually
 		// Instead, use the DatabaseLayer.Dml static property

--- a/force-app/main/default/classes/Dml.cls
+++ b/force-app/main/default/classes/Dml.cls
@@ -10,29 +10,29 @@ public with sharing virtual class Dml {
 	 * or the corresponding Database methods [ex., `Database.insert()`].
 	 * Each of this class's methods eventually ties back to an underlying `Database` method,
 	 * ex., `new Dml().doInsert()` -> `Database.insert()`.
-	 * To mock this instance, use the included `MockDml` class, or your own class which extends `Dml`.
-	 * - NOTE: This class is intentionally set to API 59.0
-	 * More recent versions do not support using "normal" SObjects in Database.*async/immediate methods
-	 * This functionality is necessary for us to be able to properly cover these methods in tests,
-	 * since we cannot introduce external objects as a part of this package.
+	 * Use the included `MockDml` class to perform Mock DML
 	 **/
 	private static final System.AccessLevel DEFAULT_ACCESS_LEVEL = System.AccessLevel.USER_MODE;
 	private static final DataSource.AsyncDeleteCallback DEFAULT_DELETE_CALLBACK = new Dml.EmptyDeleteCallback();
 	private static final DataSource.AsyncSaveCallback DEFAULT_SAVE_CALLBACK = new Dml.EmptySaveCallback();
+	private static final SObjectField PLUGIN_FIELD = DatabaseLayerSetting__mdt.DmlPreAndPostProcessor__c;
+	private static Dml.PreAndPostProcessor preAndPostPlugin;
 
-	@SuppressWarnings('PMD.EmptyStatementBlock')
 	public Dml(DatabaseLayer factory) {
-		// Dml classes can't be constructed manually
-		// Instead, use the DatabaseLayer.Dml static property
+		// Note: Dml classes can't be constructed manually; instead, use the DatabaseLayer.Dml static property
+		this.initPlugins();
 	}
 
 	// ** Convert Methods
-	public virtual List<Database.LeadConvertResult> doConvert(
+	public List<Database.LeadConvertResult> doConvert(
 		List<Database.LeadConvert> leadsToConvert,
 		Database.DmlOptions options,
 		System.AccessLevel accessLevel
 	) {
-		return Database.convertLead(leadsToConvert, options, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_CONVERT, leadsToConvert);
+		request.options = options;
+		request.accessLevel = accessLevel;
+		return (List<Database.LeadConvertResult>) request?.process();
 	}
 
 	public List<Database.LeadConvertResult> doConvert(
@@ -40,7 +40,7 @@ public with sharing virtual class Dml {
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return this.doConvert(leadsToConvert, this.initDmlOptions(allOrNone), accessLevel);
+		return this.doConvert(leadsToConvert, Dml.initDmlOptions(allOrNone), accessLevel);
 	}
 
 	public List<Database.LeadConvertResult> doConvert(
@@ -58,7 +58,7 @@ public with sharing virtual class Dml {
 	}
 
 	public List<Database.LeadConvertResult> doConvert(List<Database.LeadConvert> leadsToConvert, Boolean allOrNone) {
-		return this.doConvert(leadsToConvert, this.initDmlOptions(allOrNone));
+		return this.doConvert(leadsToConvert, Dml.initDmlOptions(allOrNone));
 	}
 
 	public List<Database.LeadConvertResult> doConvert(List<Database.LeadConvert> leadsToConvert) {
@@ -98,12 +98,15 @@ public with sharing virtual class Dml {
 	}
 
 	// ** Delete Methods
-	public virtual List<Database.DeleteResult> doDelete(
+	public List<Database.DeleteResult> doDelete(
 		List<SObject> records,
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return Database.delete(records, allOrNone, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_DELETE, records);
+		request.allOrNone = allOrNone;
+		request.accessLevel = accessLevel;
+		return (List<Database.DeleteResult>) request?.process();
 	}
 
 	public List<Database.DeleteResult> doDelete(List<SObject> records, Boolean allOrNone) {
@@ -168,12 +171,16 @@ public with sharing virtual class Dml {
 	}
 
 	// ** DeleteAsync Methods
-	public virtual List<Database.DeleteResult> doDeleteAsync(
+	public List<Database.DeleteResult> doDeleteAsync(
 		List<SObject> records,
 		DataSource.AsyncDeleteCallback callback,
 		System.AccessLevel accessLevel
 	) {
-		return Database.deleteAsync(records, callback, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_DELETE, records);
+		request.accessLevel = accessLevel;
+		request.asyncDeleteCallback = callback;
+		request.isOperationAsync = true;
+		return (List<Database.DeleteResult>) request?.process();
 	}
 
 	public List<Database.DeleteResult> doDeleteAsync(List<SObject> records, DataSource.AsyncDeleteCallback callback) {
@@ -209,11 +216,11 @@ public with sharing virtual class Dml {
 	}
 
 	// ** DeleteImmediate Methods
-	public virtual List<Database.DeleteResult> doDeleteImmediate(
-		List<SObject> records,
-		System.AccessLevel accessLevel
-	) {
-		return Database.deleteImmediate(records, accessLevel);
+	public List<Database.DeleteResult> doDeleteImmediate(List<SObject> records, System.AccessLevel accessLevel) {
+		Dml.Request request = this.initRequest(Dml.Operation.DO_DELETE, records);
+		request.accessLevel = accessLevel;
+		request.isOperationImmediate = true;
+		return (List<Database.DeleteResult>) request?.process();
 	}
 
 	public List<Database.DeleteResult> doDeleteImmediate(List<SObject> records) {
@@ -229,12 +236,15 @@ public with sharing virtual class Dml {
 	}
 
 	// ** Insert Methods
-	public virtual List<Database.SaveResult> doInsert(
+	public List<Database.SaveResult> doInsert(
 		List<SObject> records,
 		Database.DmlOptions options,
 		System.AccessLevel accessLevel
 	) {
-		return Database.insert(records, options, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_INSERT, records);
+		request.accessLevel = accessLevel;
+		request.options = options;
+		return (List<Database.SaveResult>) request?.process();
 	}
 
 	public List<Database.SaveResult> doInsert(
@@ -242,7 +252,7 @@ public with sharing virtual class Dml {
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return this.doInsert(records, this.initDmlOptions(allOrNone), accessLevel);
+		return this.doInsert(records, Dml.initDmlOptions(allOrNone), accessLevel);
 	}
 
 	public List<Database.SaveResult> doInsert(List<SObject> records, Database.DmlOptions options) {
@@ -286,12 +296,16 @@ public with sharing virtual class Dml {
 	}
 
 	// ** InsertAsync Methods
-	public virtual List<Database.SaveResult> doInsertAsync(
+	public List<Database.SaveResult> doInsertAsync(
 		List<SObject> records,
 		DataSource.AsyncSaveCallback callback,
 		System.AccessLevel accessLevel
 	) {
-		return Database.insertAsync(records, callback, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_INSERT, records);
+		request.accessLevel = accessLevel;
+		request.asyncSaveCallback = callback;
+		request.isOperationAsync = true;
+		return (List<Database.SaveResult>) request?.process();
 	}
 
 	public List<Database.SaveResult> doInsertAsync(List<SObject> records, DataSource.AsyncSaveCallback callback) {
@@ -327,8 +341,11 @@ public with sharing virtual class Dml {
 	}
 
 	// ** InsertImmediate Methods
-	public virtual List<Database.SaveResult> doInsertImmediate(List<SObject> records, System.AccessLevel accessLevel) {
-		return Database.insertImmediate(records, accessLevel);
+	public List<Database.SaveResult> doInsertImmediate(List<SObject> records, System.AccessLevel accessLevel) {
+		Dml.Request request = this.initRequest(Dml.Operation.DO_INSERT, records);
+		request.accessLevel = accessLevel;
+		request.isOperationImmediate = true;
+		return (List<Database.SaveResult>) request?.process();
 	}
 
 	public List<Database.SaveResult> doInsertImmediate(List<SObject> records) {
@@ -344,10 +361,10 @@ public with sharing virtual class Dml {
 	}
 
 	// ** Publish Methods
-	public virtual List<Database.SaveResult> doPublish(List<SObject> events) {
+	public List<Database.SaveResult> doPublish(List<SObject> events) {
 		// Callback: "An Apex class that implements the EventPublishFailureCallback Interface or EventPublishSuccessCallback Interface."
 		// https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_System_eventbus.htm#apex_System_eventbus_publish_4
-		return EventBus.publish(events);
+		return (List<Database.SaveResult>) this.initRequest(Dml.Operation.DO_PUBLISH, events)?.process();
 	}
 
 	public Database.SaveResult doPublish(SObject event) {
@@ -355,12 +372,15 @@ public with sharing virtual class Dml {
 	}
 
 	// ** Undelete Methods
-	public virtual List<Database.UndeleteResult> doUndelete(
+	public List<Database.UndeleteResult> doUndelete(
 		List<SObject> records,
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return Database.undelete(records, allOrNone, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_UNDELETE, records);
+		request.accessLevel = accessLevel;
+		request.allOrNone = allOrNone;
+		return (List<Database.UndeleteResult>) request?.process();
 	}
 
 	public List<Database.UndeleteResult> doUndelete(List<SObject> records, Boolean allOrNone) {
@@ -429,12 +449,15 @@ public with sharing virtual class Dml {
 	}
 
 	// ** Update Methods
-	public virtual List<Database.SaveResult> doUpdate(
+	public List<Database.SaveResult> doUpdate(
 		List<SObject> records,
 		Database.DmlOptions options,
 		System.AccessLevel accessLevel
 	) {
-		return Database.update(records, options, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_UPDATE, records);
+		request.accessLevel = accessLevel;
+		request.options = options;
+		return (List<Database.SaveResult>) request?.process();
 	}
 
 	public List<Database.SaveResult> doUpdate(
@@ -442,7 +465,7 @@ public with sharing virtual class Dml {
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		return this.doUpdate(records, this.initDmlOptions(allOrNone), accessLevel);
+		return this.doUpdate(records, Dml.initDmlOptions(allOrNone), accessLevel);
 	}
 
 	public List<Database.SaveResult> doUpdate(List<SObject> records, Database.DmlOptions options) {
@@ -486,12 +509,16 @@ public with sharing virtual class Dml {
 	}
 
 	// ** UpdateAsync Methods
-	public virtual List<Database.SaveResult> doUpdateAsync(
+	public List<Database.SaveResult> doUpdateAsync(
 		List<SObject> records,
 		DataSource.AsyncSaveCallback callback,
 		System.AccessLevel accessLevel
 	) {
-		return Database.updateAsync(records, callback, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_UPDATE, records);
+		request.accessLevel = accessLevel;
+		request.asyncSaveCallback = callback;
+		request.isOperationAsync = true;
+		return (List<Database.SaveResult>) request?.process();
 	}
 
 	public List<Database.SaveResult> doUpdateAsync(List<SObject> records, DataSource.AsyncSaveCallback callback) {
@@ -527,8 +554,11 @@ public with sharing virtual class Dml {
 	}
 
 	// ** UpdateImmediate Methods
-	public virtual List<Database.SaveResult> doUpdateImmediate(List<SObject> records, System.AccessLevel accessLevel) {
-		return Database.updateImmediate(records, accessLevel);
+	public List<Database.SaveResult> doUpdateImmediate(List<SObject> records, System.AccessLevel accessLevel) {
+		Dml.Request request = this.initRequest(Dml.Operation.DO_UPDATE, records);
+		request.accessLevel = accessLevel;
+		request.isOperationImmediate = true;
+		return (List<Database.SaveResult>) request?.process();
 	}
 
 	public List<Database.SaveResult> doUpdateImmediate(List<SObject> records) {
@@ -544,17 +574,17 @@ public with sharing virtual class Dml {
 	}
 
 	// ** Upsert Methods
-	public virtual List<Database.UpsertResult> doUpsert(
+	public List<Database.UpsertResult> doUpsert(
 		List<SObject> records,
 		SObjectField externalIdField,
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
-		// Note: Supplying a null ExternalIdField value to Database.upsert will result in an Exception
-		// To avoid this, call the correct overload depending on the supplied field value
-		return (externalIdField != null)
-			? Database.upsert(records, externalIdField, allOrNone, accessLevel)
-			: Database.upsert(records, allOrNone, accessLevel);
+		Dml.Request request = this.initRequest(Dml.Operation.DO_UPSERT, records);
+		request.accessLevel = accessLevel;
+		request.allOrNone = allOrNone;
+		request.externalIdField = externalIdField;
+		return (List<Database.UpsertResult>) request?.process();
 	}
 
 	public List<Database.UpsertResult> doUpsert(
@@ -639,8 +669,9 @@ public with sharing virtual class Dml {
 	}
 
 	// ** EmptyRecycleBin Methods
-	public virtual List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<SObject> records) {
-		return Database.emptyRecycleBin(records);
+	public List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<SObject> records) {
+		Dml.Request request = this.initRequest(Dml.Operation.DO_PURGE, records);
+		return (List<Database.EmptyRecycleBinResult>) request?.process();
 	}
 
 	public List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<Id> recordIds) {
@@ -675,10 +706,10 @@ public with sharing virtual class Dml {
 	}
 
 	// **** PRIVATE **** //
-	private Database.DmlOptions initDmlOptions(Boolean allOrNone) {
-		Database.DmlOptions options = new Database.DmlOptions();
-		options.OptAllOrNone = allOrNone;
-		return options;
+	@TestVisible
+	protected virtual Dml.Request initRequest(Dml.Operation operation, List<Object> records) {
+		// Initialize a Dml.Request; mocks can override this method to return their own implementation which does not perform DML
+		return new Dml.Request(operation, records);
 	}
 
 	private List<SObject> initRecordsFromIds(List<Id> recordIds) {
@@ -689,6 +720,23 @@ public with sharing virtual class Dml {
 			records?.add(record);
 		}
 		return records;
+	}
+
+	@TestVisible
+	private void initPlugins() {
+		// Initializes plugins based on the related custom metadata record
+		// In production use cases, this will only happen once per transaction
+		// In @IsTest uses cases, this happens every time the caller switches from Dml/MockDml
+		// Test callers can also call this method directly to recalculate the plugins after injecting mock metadata:
+		Dml.preAndPostPlugin = (Dml.PreAndPostProcessor) DatabaseLayer.Utils?.Plugins?.initPlugin(PLUGIN_FIELD);
+		// ... may add more plugins here in the future!
+	}
+
+	// **** STATIC **** //
+	private static Database.DmlOptions initDmlOptions(Boolean allOrNone) {
+		Database.DmlOptions options = new Database.DmlOptions();
+		options.OptAllOrNone = allOrNone;
+		return options;
 	}
 
 	// **** INNER **** //
@@ -709,6 +757,228 @@ public with sharing virtual class Dml {
 		 **/
 		public override void processSave(Database.SaveResult result) {
 			// Do nothing
+		}
+	}
+
+	public enum Operation {
+		DO_CONVERT,
+		DO_DELETE,
+		DO_INSERT,
+		DO_PUBLISH,
+		DO_PURGE,
+		DO_UNDELETE,
+		DO_UPDATE,
+		DO_UPSERT
+	}
+
+	public interface PreAndPostProcessor {
+		void processPreDml(Dml.Request request);
+		void processPostDml(Dml.Request request, List<Object> databaseResults);
+	}
+
+	public virtual class Request {
+		/**
+		 * Represents a single call to one of the above DML methods, plus all its parameters
+		 * Centralizing this information allows us to output information about the operation taking place
+		 */
+		// ** Always Required:
+		public Dml.Operation operation { get; protected set; }
+		// ** Conditionally Required:
+		public transient List<SObject> records { get; protected set; }
+		public transient List<Database.LeadConvert> leadsToConvert { get; protected set; }
+		// ** Optional Parameters:
+		public transient System.AccessLevel accessLevel { get; protected set; }
+		public transient DataSource.AsyncDeleteCallback asyncDeleteCallback { get; protected set; }
+		public transient DataSource.AsyncSaveCallback asyncSaveCallback { get; protected set; }
+		public transient SObjectField externalIdField { get; protected set; }
+		public Boolean isMockDml { get; protected set; }
+		public Boolean isOperationAsync { get; protected set; }
+		public Boolean isOperationImmediate { get; protected set; }
+		public Database.DmlOptions options { get; protected set; }
+		// ** Getters
+		// These properties are read-only, and are used for JSON/output purposes,
+		// ex., since some of the main class properties are not JSON-serializable
+		public String accessLevelName {
+			// System.AccessLevel is not JSON serializable
+			// Unlike other enums, it does not have a name() property, and toString() does not output its name either:
+			get {
+				return (this.accessLevel == System.AccessLevel.SYSTEM_MODE) ? 'SYSTEM_MODE' : 'USER_MODE';
+			}
+		}
+		public transient Boolean allOrNone {
+			get {
+				// Is not actually stored as a value; mirrors the DmlOptions' OptAllOrNone value
+				this.options = this.options ?? Dml.initDmlOptions(true);
+				return this.options?.OptAllOrNone;
+			}
+			protected set {
+				// Ensure the DmlOptions' OptAllOrNone value matches:
+				this.options.OptAllOrNone = value;
+			}
+		}
+		public String deleteCallback {
+			// The DataSource.AsyncDeleteCallback may/may not be serializable, based on its implementation
+			// Prevent serialization errors by outputting the raw toString() value for logs:
+			get {
+				return String.valueOf(this.asyncDeleteCallback);
+			}
+		}
+		public String externalIdFieldName {
+			// SObjectFields are not JSON-serializable
+			get {
+				return this.externalIdField?.toString();
+			}
+		}
+		public Integer numRecords {
+			// Output the number of records being operated on:
+			get {
+				return this.getNumRecords();
+			}
+		}
+		public String saveCallback {
+			// The DataSource.AsyncSaveCallback may/may not be serializable, based on its implementation
+			// Prevent serialization errors by outputting the raw toString() value for logs:
+			get {
+				return String.valueOf(this.asyncSaveCallback);
+			}
+		}
+		public String sObjectType {
+			// Output the name of the SObjectType being operated on, if known:
+			get {
+				return this.getSObjectTypeName();
+			}
+		}
+
+		// ** Methods:
+		protected Request(Dml.Operation operation, List<Object> records) {
+			this.operation = operation;
+			this.accessLevel = DEFAULT_ACCESS_LEVEL;
+			this.asyncDeleteCallback = DEFAULT_DELETE_CALLBACK;
+			this.isMockDml = false;
+			this.isOperationAsync = false;
+			this.isOperationImmediate = false;
+			this.options = Dml.initDmlOptions(true);
+			this.asyncSaveCallback = DEFAULT_SAVE_CALLBACK;
+			this.setRecordCollection(records);
+		}
+
+		protected List<Object> process() {
+			// Main method called by the Dml class; processes DML, and calls the Pre/Post DML plugins:
+			Dml.preAndPostPlugin?.processPreDml(this);
+			List<Object> results = this.doDml();
+			Dml.preAndPostPlugin?.processPostDml(this, results);
+			return results;
+		}
+
+		protected List<Object> doDml() {
+			// Perform the correct DML method based on the Dml.Operation
+			List<Object> results;
+			if (this.operation == Dml.Operation.DO_CONVERT) {
+				results = this.doConvert();
+			} else if (this.operation == Dml.Operation.DO_DELETE) {
+				results = this.doDelete();
+			} else if (this.operation == Dml.Operation.DO_INSERT) {
+				results = this.doInsert();
+			} else if (this.operation == Dml.Operation.DO_PUBLISH) {
+				results = this.doPublish();
+			} else if (this.operation == Dml.Operation.DO_PURGE) {
+				results = this.emptyRecycleBin();
+			} else if (this.operation == Dml.Operation.DO_UNDELETE) {
+				results = this.doUndelete();
+			} else if (this.operation == Dml.Operation.DO_UPDATE) {
+				results = this.doUpdate();
+			} else if (this.operation == Dml.Operation.DO_UPSERT) {
+				results = this.doUpsert();
+			}
+			return results;
+		}
+
+		// ** Virtual:
+		protected virtual List<Database.LeadConvertResult> doConvert() {
+			return Database.convertLead(this.leadsToConvert, this.options, this.accessLevel);
+		}
+
+		protected virtual List<Database.DeleteResult> doDelete() {
+			if (this.isOperationAsync == true) {
+				return Database.deleteAsync(this.records, this.asyncDeleteCallback, this.accessLevel);
+			} else if (this.isOperationImmediate == true) {
+				return Database.deleteImmediate(this.records, this.accessLevel);
+			} else {
+				return Database.delete(this.records, this.allOrNone, this.accessLevel);
+			}
+		}
+
+		protected virtual List<Database.SaveResult> doInsert() {
+			if (this.isOperationAsync == true) {
+				return Database.insertAsync(this.records, this.asyncSaveCallback, this.accessLevel);
+			} else if (this.isOperationImmediate == true) {
+				return Database.insertImmediate(this.records, this.accessLevel);
+			} else {
+				return Database.insert(this.records, this.allOrNone, this.accessLevel);
+			}
+		}
+
+		protected virtual List<Database.SaveResult> doPublish() {
+			return EventBus.publish(this.records);
+		}
+
+		protected virtual List<Database.UndeleteResult> doUndelete() {
+			return Database.undelete(this.records, this.allOrNone, this.accessLevel);
+		}
+
+		protected virtual List<Database.SaveResult> doUpdate() {
+			if (this.isOperationAsync == true) {
+				return Database.updateAsync(this.records, this.asyncSaveCallback, this.accessLevel);
+			} else if (this.isOperationImmediate == true) {
+				return Database.updateImmediate(this.records, this.accessLevel);
+			} else {
+				return Database.update(this.records, this.allOrNone, this.accessLevel);
+			}
+		}
+
+		protected virtual List<Database.UpsertResult> doUpsert() {
+			// Note: Supplying a null ExternalIdField value to Database.upsert will result in an Exception
+			// To avoid this, call the correct overload depending on the supplied field value
+			if (this.externalIdField != null) {
+				return Database.upsert(this.records, this.externalIdField, this.allOrNone, this.accessLevel);
+			} else {
+				return Database.upsert(this.records, this.allOrNone, this.accessLevel);
+			}
+		}
+
+		protected virtual List<Database.EmptyRecycleBinResult> emptyRecycleBin() {
+			return Database.emptyRecycleBin(this.records);
+		}
+
+		// ** Private:
+		private Integer getNumRecords() {
+			Integer num = (this.operation == Dml.Operation.DO_CONVERT)
+				? this.leadsToConvert?.size()
+				: this.records?.size();
+			return num ?? 0;
+		}
+
+		private String getSObjectTypeName() {
+			// Output the name of the SObjectType, if known:
+			if (this.operation == Dml.Operation.DO_CONVERT) {
+				return Database.LeadConvert.class.getName();
+			} else if (this.records?.size() == 1) {
+				// Single records are always passed to a generic List<SObject>
+				// Multiple records shouldn't use this method, since they could contain multiple SObjectTypes
+				return this.records?.get(0)?.getSObjectType()?.toString();
+			} else {
+				// Return the List type, or "SObject" if unknown:
+				return this.records?.toString() ?? SObject.class.getName();
+			}
+		}
+
+		private void setRecordCollection(List<Object> objs) {
+			// Set the appropriate record collection, based on the operation:
+			if (this.operation == Dml.Operation.DO_CONVERT) {
+				this.leadsToConvert = (List<Database.LeadConvert>) objs;
+			} else {
+				this.records = (List<SObject>) objs;
+			}
 		}
 	}
 }

--- a/force-app/main/default/classes/DmlTest.cls
+++ b/force-app/main/default/classes/DmlTest.cls
@@ -2,9 +2,21 @@
 @IsTest
 private class DmlTest {
 	// **** VARIABLES **** //
-	private static final LeadStatus CONVERTED_STATUS = DmlTest.getConvertedStatus();
-	private static List<Database.DeleteResult> deleteCallbacksMade = new List<Database.DeleteResult>();
-	private static List<Database.SaveResult> saveCallbacksMade = new List<Database.SaveResult>();
+	private static final LeadStatus CONVERTED_STATUS;
+	private static List<Database.DeleteResult> deleteCallbacksMade;
+	private static Integer numPostDmlPluginCalls;
+	private static Integer numPreDmlPluginCalls;
+	private static List<Database.SaveResult> saveCallbacksMade;
+
+	static {
+		CONVERTED_STATUS = DmlTest.getConvertedStatus();
+		deleteCallbacksMade = new List<Database.DeleteResult>();
+		saveCallbacksMade = new List<Database.SaveResult>();
+		numPostDmlPluginCalls = 0;
+		numPreDmlPluginCalls = 0;
+		// Custom metadata actually defined in the org should not interfere with this test:
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{};
+	}
 
 	// **** TESTS **** //
 	@IsTest
@@ -866,31 +878,136 @@ private class DmlTest {
 		Assert.areEqual(0, [SELECT COUNT() FROM Account], 'DML operation was not rolled back');
 	}
 
+	@IsTest
+	static void shouldRunPreAndPostProcessorPluginLogic() {
+		DatabaseLayerSetting__mdt settings = DmlTest.initSettings();
+		settings.DmlPreAndPostProcessor__c = DmlTest.TestPlugin.class.getName();
+		// Re-initialize the plugins, now that the field has been set:
+		DatabaseLayer.Dml.initPlugins();
+		Account account = DmlTest.initAccount();
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(account);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(1, DmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(1, DmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
+	@IsTest
+	static void shouldNotRunProcessorLogicIfInvalidApexClassDefined() {
+		DatabaseLayerSetting__mdt settings = DmlTest.initSettings();
+		settings.DmlPreAndPostProcessor__c = 'an obviously invalid apex class name';
+		// Re-initialize the plugins, now that the field has been set:
+		DatabaseLayer.Dml.initPlugins();
+		Account account = DmlTest.initAccount();
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(account);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(0, DmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(0, DmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
+	@IsTest
+	static void shouldNotRunProcessorLogicIfNoValueDefined() {
+		DatabaseLayerSetting__mdt settings = DmlTest.initSettings();
+		settings.DmlPreAndPostProcessor__c = null;
+		DatabaseLayer.Dml.initPlugins();
+		Account account = DmlTest.initAccount();
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(account);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(0, DmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(0, DmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
+	@IsTest
+	static void shouldNotRunProcessorLogicIfNoSettingsDefined() {
+		// Without calling DmlTest.initSettings(), no settings are defined:
+		DatabaseLayer.Dml.initPlugins();
+		Account account = DmlTest.initAccount();
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(account);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(0, DmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(0, DmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
+	@IsTest
+	static void shouldSerializeDmlRequestForRecords() {
+		// The Dml.Request may be used in plugins for a variety of purposes, including logging
+		// For this reason, we should make sure the request is JSON-serializable,
+		// despite containing several fields that are not typically allowed in JSON
+		Lead lead = DmlTest.initLead();
+		List<Lead> leads = new List<Lead>{ lead };
+		Dml.Request request = DatabaseLayer.Dml.initRequest(Dml.Operation.DO_INSERT, leads);
+
+		Test.startTest();
+		String requestJson = JSON.serialize(request);
+		Test.stopTest();
+
+		Assert.isNotNull(requestJson, 'Is not JSON serializable');
+	}
+
+	@IsTest
+	static void shouldSerializeDmlRequestForLeadConverts() {
+		// The Dml.Request may be used in plugins for a variety of purposes, including logging
+		// For this reason, we should make sure the request is JSON-serializable,
+		// despite containing several fields that are not typically allowed in JSON
+		Lead lead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
+		Database.LeadConvert leadToConvert = DmlTest.initLeadConvert(lead);
+		List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>{ leadToConvert };
+		Dml.Request request = DatabaseLayer.Dml.initRequest(Dml.Operation.DO_CONVERT, leadsToConvert);
+
+		Test.startTest();
+		String requestJson = JSON.serialize(request);
+		Test.stopTest();
+
+		Assert.isNotNull(requestJson, 'Is not JSON serializable');
+	}
+
 	// **** HELPER **** //
-	static LeadStatus getConvertedStatus() {
+	private static LeadStatus getConvertedStatus() {
 		return [SELECT ApiName FROM LeadStatus WHERE IsConverted = TRUE LIMIT 1] ?? null;
 	}
 
-	static Account initAccount() {
+	private static Account initAccount() {
 		return new Account(Name = 'Robinson Industries');
 	}
 
-	static List<Account> initAccountList() {
+	private static List<Account> initAccountList() {
 		Account account = DmlTest.initAccount();
 		return new List<Account>{ account };
 	}
 
-	static Lead initLead() {
+	private static Lead initLead() {
 		return new Lead(Company = 'Tharsis Inc.', FirstName = 'John', LastName = 'Doe');
 	}
 
-	static Database.LeadConvert initLeadConvert(Lead lead) {
+	private static Database.LeadConvert initLeadConvert(Lead lead) {
 		Database.LeadConvert leadToConvert = new Database.LeadConvert();
 		leadToConvert?.setLeadId(lead?.Id);
 		leadToConvert?.setConvertedStatus(CONVERTED_STATUS?.ApiName);
 		return leadToConvert;
 	}
 
+	private static DatabaseLayerSetting__mdt initSettings() {
+		DatabaseLayerSetting__mdt settings = new DatabaseLayerSetting__mdt();
+		DatabaseLayer.Utils.MetadataSelector.settings?.add(settings);
+		return settings;
+	}
+
+	// **** INNER **** //
 	private class DeleteCallback extends DataSource.AsyncDeleteCallback {
 		public override void processDelete(Database.DeleteResult result) {
 			DmlTest.deleteCallbacksMade?.add(result);
@@ -900,6 +1017,18 @@ private class DmlTest {
 	private class SaveCallback extends DataSource.AsyncSaveCallback {
 		public override void processSave(Database.SaveResult result) {
 			DmlTest.saveCallbacksMade?.add(result);
+		}
+	}
+
+	public class TestPlugin implements Dml.PreAndPostProcessor {
+		// Note: Class has to be public to work properly:
+		public void processPreDml(Dml.Request request) {
+			System.debug(JSON.serialize(request, true));
+			DmlTest.numPreDmlPluginCalls += 1;
+		}
+
+		public void processPostDml(Dml.Request request, List<Object> databaseResults) {
+			DmlTest.numPostDmlPluginCalls += 1;
 		}
 	}
 }

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -116,13 +116,12 @@ public class MockDml extends Dml {
 	}
 
 	public override List<Database.DeleteResult> doDelete(
-		List<Id> recordIds,
+		List<SObject> records,
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
 		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (Id recordId : recordIds) {
-			SObject record = recordId?.getSObjectType()?.newSObject(recordId);
+		for (SObject record : records) {
 			MockDml.Result result = this.generateMockResult(MockDml.DELETED, record, allOrNone);
 			results?.add(result);
 		}
@@ -150,10 +149,9 @@ public class MockDml extends Dml {
 		return this.doDelete(records, accessLevel);
 	}
 
-	public override List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<Id> recordIds) {
+	public override List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<SObject> records) {
 		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (Id recordId : recordIds) {
-			SObject record = recordId?.getSObjectType()?.newSObject(recordId);
+		for (SObject record : records) {
 			MockDml.Result result = this.generateMockResult(MockDml.PURGED, record, true);
 			results?.add(result);
 		}
@@ -203,13 +201,12 @@ public class MockDml extends Dml {
 	}
 
 	public override List<Database.UndeleteResult> doUndelete(
-		List<Id> recordIds,
+		List<SObject> records,
 		Boolean allOrNone,
 		System.AccessLevel accessLevel
 	) {
 		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (Id recordId : recordIds) {
-			SObject record = recordId?.getSObjectType()?.newSObject(recordId);
+		for (SObject record : records) {
 			MockDml.Result result = this.generateMockResult(MockDml.UNDELETED, record, allOrNone);
 			results?.add(result);
 		}

--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -13,6 +13,7 @@ public class MockDml extends Dml {
 	// **** CONSTANT **** //
 	public static final MockDml.SavepointHistory SAVEPOINTS;
 	private static final String EVENT_UUID_FIELD;
+	public static List<MockDml.ConditionalFailure> FAILURES;
 	private static final String MOCK_STATUS_CODE;
 
 	// **** STATIC **** //
@@ -61,6 +62,7 @@ public class MockDml extends Dml {
 
 	static {
 		EVENT_UUID_FIELD = 'EventUuid';
+		FAILURES = new List<MockDml.ConditionalFailure>{};
 		MOCK_STATUS_CODE = 'MOCK_DML';
 		SAVEPOINTS = new MockDml.SavepointHistory();
 		MockDatabase = new MockDml.Database();
@@ -72,190 +74,54 @@ public class MockDml extends Dml {
 		MockDml.MockDatabase = new MockDml.Database();
 	}
 
-	// **** MEMBER **** //
-	private List<MockDml.ConditionalFailure> failures;
+	public static void shouldFail() {
+		// Adds a BaseFailure the list of failures - all DML operations will now fail.
+		MockDml.shouldSucceed();
+		MockDml.ConditionalFailure failure = new MockDml.BaseFailure();
+		MockDml.shouldFailIf(failure);
+	}
 
+	public static void shouldFailIf(MockDml.ConditionalFailure failure) {
+		// Adds the ConditionalFailure object to a list of failures.
+		// The ConditionalLogic interface defines if/when an error should be thrown during a DML operation.
+		// Each dml operation will iterate through the list of failures and call its interface method for each record.
+		MockDml.FAILURES?.add(failure);
+	}
+
+	public static void shouldSucceed() {
+		// Clears the list of failures - all mock DML operations should now succeed.
+		MockDml.FAILURES?.clear();
+	}
+
+	// **** MEMBER **** //
 	public MockDml(DatabaseLayer factory) {
 		super(factory);
-		this.failures = new List<MockDml.ConditionalFailure>();
 	}
 
 	public MockDml clearFailures() {
-		// Clears the list of failures from the current instance.
-		// As a result, all mock DML operations should now succeed.
-		this.failures?.clear();
+		// ! Deprecated - this method will be removed in a future release
+		// ! Replace all instances with the `MockDml.shouldSucceed()` static method
+		MockDml.shouldSucceed();
 		return this;
 	}
 
 	public MockDml fail() {
-		// Adds a BaseFailure to the current instance; all DML operations will now fail.
-		MockDml.ConditionalFailure failure = new MockDml.BaseFailure();
-		return this.failIf(failure);
-	}
-
-	public MockDml failIf(MockDml.ConditionalFailure failure) {
-		// Adds the ConditionalFailure object to a list of failures.
-		// The ConditionalLogic interface defines if/when an error should be thrown during a DML operation.
-		// Each dml operation will iterate through the list of failures and call its interface method for each record.
-		this.failures?.add(failure);
+		// ! Deprecated - this method will be removed in a future release
+		// ! Replace all instances with the `MockDml.shouldFail()` static method
+		MockDml.shouldFail();
 		return this;
 	}
 
-	// **** OVERRIDES **** //
-	public override List<Database.LeadConvertResult> doConvert(
-		List<Database.LeadConvert> leadsToConvert,
-		Database.DmlOptions options,
-		System.AccessLevel accessLevel
-	) {
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (Database.LeadConvert leadToConvert : leadsToConvert) {
-			MockDml.Result result = this.generateMockResult(leadToConvert, options?.OptAllOrNone);
-			results?.add(result);
-		}
-		return this.toConvertResults(results);
+	public MockDml failIf(MockDml.ConditionalFailure failure) {
+		// ! Deprecated - this method will be removed in a future release
+		// ! Replace all instances with the `MockDml.shouldFailIf()` static method
+		MockDml.shouldFailIf(failure);
+		return this;
 	}
 
-	public override List<Database.DeleteResult> doDelete(
-		List<SObject> records,
-		Boolean allOrNone,
-		System.AccessLevel accessLevel
-	) {
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (SObject record : records) {
-			MockDml.Result result = this.generateMockResult(MockDml.DELETED, record, allOrNone);
-			results?.add(result);
-		}
-		return this.toDeleteResults(results);
-	}
-
-	public override List<Database.DeleteResult> doDeleteAsync(
-		List<SObject> records,
-		DataSource.AsyncDeleteCallback callback,
-		System.AccessLevel accessLevel
-	) {
-		// For mocking purposes, process the same as a "normal" doDelete operation, but w/callbacks
-		List<Database.DeleteResult> results = this.doDelete(records, accessLevel);
-		for (Database.DeleteResult result : results) {
-			callback?.processDelete(result);
-		}
-		return results;
-	}
-
-	public override List<Database.DeleteResult> doDeleteImmediate(
-		List<SObject> records,
-		System.AccessLevel accessLevel
-	) {
-		// For mocking purposes, process the same as a "normal" doDelete operation,
-		return this.doDelete(records, accessLevel);
-	}
-
-	public override List<Database.EmptyRecycleBinResult> emptyRecycleBin(List<SObject> records) {
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (SObject record : records) {
-			MockDml.Result result = this.generateMockResult(MockDml.PURGED, record, true);
-			results?.add(result);
-		}
-		return this.toEmptyRecycleBinResults(results);
-	}
-
-	public override List<Database.SaveResult> doInsert(
-		List<SObject> records,
-		Database.DmlOptions options,
-		System.AccessLevel accessLevel
-	) {
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (SObject record : records) {
-			MockDml.Result result = this.generateMockResult(MockDml.INSERTED, record, options?.OptAllOrNone);
-			results?.add(result);
-		}
-		return this.toSaveResults(results);
-	}
-
-	public override List<Database.SaveResult> doInsertAsync(
-		List<SObject> records,
-		DataSource.AsyncSaveCallback callback,
-		System.AccessLevel accessLevel
-	) {
-		// For mocking purposes, process the same as a "normal" doInsert operation, but w/callbacks
-		List<Database.SaveResult> results = this.doInsert(records, accessLevel);
-		for (Database.SaveResult result : results) {
-			callback?.processSave(result);
-		}
-		return results;
-	}
-
-	public override List<Database.SaveResult> doInsertImmediate(List<SObject> records, System.AccessLevel accessLevel) {
-		// For mocking purposes, process the same as a "normal" doInsert operation
-		return this.doInsert(records, accessLevel);
-	}
-
-	public override List<Database.SaveResult> doPublish(List<SObject> events) {
-		// Ensure the callback is set; if null, use the default value
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (SObject event : events) {
-			// Note: EventBus.publish() always runs in allOrNone=false context
-			MockDml.Result result = this.generateMockResult(MockDml.PUBLISHED, event, false);
-			results?.add(result);
-		}
-		return this.toSaveResults(results);
-	}
-
-	public override List<Database.UndeleteResult> doUndelete(
-		List<SObject> records,
-		Boolean allOrNone,
-		System.AccessLevel accessLevel
-	) {
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (SObject record : records) {
-			MockDml.Result result = this.generateMockResult(MockDml.UNDELETED, record, allOrNone);
-			results?.add(result);
-		}
-		return this.toUndeleteResults(results);
-	}
-
-	public override List<Database.SaveResult> doUpdate(
-		List<SObject> records,
-		Database.DmlOptions options,
-		System.AccessLevel accessLevel
-	) {
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (SObject record : records) {
-			MockDml.Result result = this.generateMockResult(MockDml.UPDATED, record, options?.OptAllOrNone);
-			results?.add(result);
-		}
-		return this.toSaveResults(results);
-	}
-
-	public override List<Database.SaveResult> doUpdateAsync(
-		List<SObject> records,
-		DataSource.AsyncSaveCallback callback,
-		System.AccessLevel accessLevel
-	) {
-		// For mocking purposes, process the same as a "normal" doUpdate operation, but w/callbacks
-		List<Database.SaveResult> results = this.doUpdate(records, accessLevel);
-		for (Database.SaveResult result : results) {
-			callback?.processSave(result);
-		}
-		return results;
-	}
-
-	public override List<Database.SaveResult> doUpdateImmediate(List<SObject> records, System.AccessLevel accessLevel) {
-		// For mocking purposes, process the same as a "normal" doUpdate operation
-		return this.doUpdate(records, accessLevel);
-	}
-
-	public override List<Database.UpsertResult> doUpsert(
-		List<SObject> records,
-		SObjectField externalIdField,
-		Boolean allOrNone,
-		System.AccessLevel accessLevel
-	) {
-		List<MockDml.Result> results = new List<MockDml.Result>();
-		for (SObject record : records) {
-			MockDml.Result result = this.generateMockResult(MockDml.UPSERTED, record, allOrNone);
-			results?.add(result);
-		}
-		return this.toUpsertResults(results);
+	public override Dml.Request initRequest(Dml.Operation operation, List<Object> records) {
+		// Initialize a request object that will not actually perform DML:
+		return new MockDml.Request(operation, records);
 	}
 
 	public override void releaseSavepoint(System.Savepoint savepoint) {
@@ -275,123 +141,6 @@ public class MockDml extends Dml {
 		return savepoint;
 	}
 
-	// **** PRIVATE **** //
-	private void checkFailures(MockDml.Operation operation, SObject record) {
-		// Runs all ConditionalFailures defined the current instance against each record.
-		for (MockDml.ConditionalFailure failure : this.failures) {
-			Exception error = failure?.checkFailure(operation, record);
-			if (error != null) {
-				throw error;
-			}
-		}
-	}
-
-	private MockDml.Result generateMockResult(MockDml.History history, SObject record, Boolean allOrNone) {
-		// Simulates a DML operation for a single record, returning a MockDml.Result,
-		// which calling methods can de/serialize into a Database.Save/Upsert/etc. Result.
-		try {
-			MockDml.Operation operation = history?.getOperation();
-			// Determine if the operation should fail for the specific record
-			this.checkFailures(operation, record);
-			// Simulate successful dml, return a MockDml.Result w/out errors
-			return history?.registerDml(record);
-		} catch (System.DmlException error) {
-			// Return a MockDml.Result w/errors
-			return history?.handleDmlError(record, error, allOrNone);
-		}
-	}
-
-	private MockDml.LeadConvertResult generateMockResult(Database.LeadConvert leadToConvert, Boolean allOrNone) {
-		// Simulate a Lead Conversion, which typically also involves inserting Account/Contact/Opportunity records
-		Lead leadRecord = new Lead(Id = leadToConvert?.getLeadId());
-		Account accountRecord = new Account(Id = leadToConvert?.getAccountId());
-		Contact contactRecord = new Contact(Id = leadToConvert?.getContactId());
-		Opportunity opportunityRecord = new Opportunity(Id = leadToConvert?.getOpportunityId());
-		try {
-			// Note: Process resulting records using allOrNone=true, regardless of its original value
-			// This allows injected errors for Accounts/Contacts/Opps to be caught and handled appropriately
-			// 1. Simulate converting the lead
-			this.validateConvertedLead(leadToConvert);
-			this.generateMockResult(MockDml.CONVERTED, leadRecord, true);
-			// 2. Simulate creating an Account/Contact/Opportunity, if their Id wasn't already provided
-			this.simulateInsertIfNew(accountRecord);
-			this.simulateInsertIfNew(contactRecord);
-			this.simulateInsertIfNew(opportunityRecord);
-			// 3. Build & return the LeadConvertResult w/the resulting record ids
-			return (MockDml.LeadConvertResult) new MockDml.LeadConvertResult(leadRecord)
-				?.setId(accountRecord)
-				?.setId(contactRecord)
-				?.setId(opportunityRecord);
-		} catch (System.DmlException error) {
-			// Deregister any of successful related records up to this point
-			MockDml.INSERTED?.deregisterDml(accountRecord);
-			MockDml.INSERTED?.deregisterDml(contactRecord);
-			MockDml.INSERTED?.deregisterDml(opportunityRecord);
-			MockDml.CONVERTED?.deregisterDml(leadRecord);
-			return (MockDml.LeadConvertResult) MockDml.CONVERTED?.handleDmlError(leadRecord, error, allOrNone);
-		}
-	}
-
-	private void simulateInsertIfNew(SObject record) {
-		// If the provided record does not already have an Id, simulate an insert operation
-		if (record?.Id == null) {
-			SObjectType objectType = record?.getSObjectType();
-			record.Id = MockRecord.initRecordId(objectType);
-			this.generateMockResult(MockDml.INSERTED, record, true);
-		}
-	}
-
-	private List<Database.LeadConvertResult> toConvertResults(List<MockDml.Result> results) {
-		return (List<Database.LeadConvertResult>) this.toDatabaseResults(
-			results,
-			List<Database.LeadConvertResult>.class
-		);
-	}
-
-	private List<Database.EmptyRecycleBinResult> toEmptyRecycleBinResults(List<MockDml.Result> results) {
-		return (List<Database.EmptyRecycleBinResult>) this.toDatabaseResults(
-			results,
-			List<Database.EmptyRecycleBinResult>.class
-		);
-	}
-
-	private List<Database.DeleteResult> toDeleteResults(List<MockDml.Result> results) {
-		return (List<Database.DeleteResult>) this.toDatabaseResults(results, List<Database.DeleteResult>.class);
-	}
-
-	private List<Database.SaveResult> toSaveResults(List<MockDml.Result> results) {
-		return (List<Database.SaveResult>) this.toDatabaseResults(results, List<Database.SaveResult>.class);
-	}
-
-	private List<Database.UndeleteResult> toUndeleteResults(List<MockDml.Result> results) {
-		// Note: For some reason, we can't directly deserialize into a List<Database.UndeleteResult> like the other methods.
-		// Attempting to do so will result in the "success" parameter always being set to false.
-		// Don't ask me why -- but deserializing to an untyped Object first solves this issue.
-		Object untyped = JSON.deserializeUntyped(JSON.serialize(results));
-		return (List<Database.UndeleteResult>) JSON.deserialize(
-			JSON.serialize(untyped),
-			List<Database.UndeleteResult>.class
-		);
-	}
-
-	private List<Database.UpsertResult> toUpsertResults(List<MockDml.Result> results) {
-		return (List<Database.UpsertResult>) this.toDatabaseResults(results, List<Database.UpsertResult>.class);
-	}
-
-	private Object toDatabaseResults(List<MockDml.Result> results, Type returnType) {
-		return JSON.deserialize(JSON.serialize(results), returnType);
-	}
-
-	private void validateConvertedLead(Database.LeadConvert leadToConvert) {
-		// Mimicks the stock behavior of Database.LeadConvert objects.
-		// These will always throw an error if you are missing a leadId or converted status.
-		if (leadToConvert?.getLeadId() == null) {
-			throw new System.DmlException('valid leadId is required');
-		} else if (leadToConvert?.getConvertedStatus() == null) {
-			throw new System.DmlException('convertedStatus is required');
-		}
-	}
-
 	// **** INNER: PUBLIC **** //
 	public interface ConditionalFailure {
 		/**
@@ -399,6 +148,9 @@ public class MockDml extends Dml {
 		 * Its method should return an exception to be thrown in case of a DML failure, or null in case of success.
 		 * Pass objects that implement this interface to MockDml's `failIf()` method.
 		 **/
+		// ! Deprecated - this method will be altered in a future release,
+		// ! Specifically, the `MockDml.Operation` enum will be replaced with the `Dml.Operation` enum
+		// ! For now, you can create a duplicate method in your class as an intermediary step
 		Exception checkFailure(MockDml.Operation operation, SObject record);
 	}
 
@@ -561,6 +313,8 @@ public class MockDml extends Dml {
 	}
 
 	public enum Operation {
+		// ! Deprecated: This will be removed in a future release
+		// ! Replace all uses of this enum with the Dml.Operation enum
 		DO_CONVERT,
 		DO_DELETE,
 		DO_INSERT,
@@ -569,6 +323,231 @@ public class MockDml extends Dml {
 		DO_UNDELETE,
 		DO_UPDATE,
 		DO_UPSERT
+	}
+
+	public class Request extends Dml.Request {
+		/**
+		 * Contains overrides for each DML operation, and is responsible for mocking DML
+		 * An instance of this class (instead of the super type)
+		 * is initialized via the overridden `initRequest` method
+		 */
+		private Request(Dml.Operation operation, List<Object> records) {
+			super(operation, records);
+			this.isMockDml = true;
+		}
+
+		// ** OVERRIDES
+		protected override List<Database.LeadConvertResult> doConvert() {
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (Database.LeadConvert leadToConvert : this.leadsToConvert) {
+				MockDml.Result result = this.generateMockResult(leadToConvert, this.options?.OptAllOrNone);
+				mockResults?.add(result);
+			}
+			return this.toConvertResults(mockResults);
+		}
+
+		protected override List<Database.DeleteResult> doDelete() {
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (SObject record : this.records) {
+				MockDml.Result result = this.generateMockResult(MockDml.DELETED, record, this.allOrNone);
+				mockResults?.add(result);
+			}
+			List<Database.DeleteResult> results = this.toDeleteResults(mockResults);
+			this.runDeleteCallbackIfAsync(results);
+			return results;
+		}
+
+		protected override List<Database.SaveResult> doInsert() {
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (SObject record : this.records) {
+				MockDml.Result result = this.generateMockResult(MockDml.INSERTED, record, this.options?.OptAllOrNone);
+				mockResults?.add(result);
+			}
+			List<Database.SaveResult> results = this.toSaveResults(mockResults);
+			this.runSaveCallbackIfAsync(results);
+			return results;
+		}
+
+		protected override List<Database.SaveResult> doPublish() {
+			// Ensure the callback is set; if null, use the default value
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (SObject event : this.records) {
+				// Note: EventBus.publish() always runs in allOrNone=false context
+				MockDml.Result result = this.generateMockResult(MockDml.PUBLISHED, event, false);
+				mockResults?.add(result);
+			}
+			return this.toSaveResults(mockResults);
+		}
+
+		protected override List<Database.UndeleteResult> doUndelete() {
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (SObject record : records) {
+				MockDml.Result result = this.generateMockResult(MockDml.UNDELETED, record, allOrNone);
+				mockResults?.add(result);
+			}
+			return this.toUndeleteResults(mockResults);
+		}
+
+		protected override List<Database.SaveResult> doUpdate() {
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (SObject record : this.records) {
+				MockDml.Result result = this.generateMockResult(MockDml.UPDATED, record, this.options?.OptAllOrNone);
+				mockResults?.add(result);
+			}
+			List<Database.SaveResult> results = this.toSaveResults(mockResults);
+			this.runSaveCallbackIfAsync(results);
+			return results;
+		}
+
+		protected override List<Database.UpsertResult> doUpsert() {
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (SObject record : this.records) {
+				MockDml.Result result = this.generateMockResult(MockDml.UPSERTED, record, this.allOrNone);
+				mockResults?.add(result);
+			}
+			return this.toUpsertResults(mockResults);
+		}
+
+		protected override List<Database.EmptyRecycleBinResult> emptyRecycleBin() {
+			List<MockDml.Result> mockResults = new List<MockDml.Result>();
+			for (SObject record : this.records) {
+				MockDml.Result result = this.generateMockResult(MockDml.PURGED, record, true);
+				mockResults?.add(result);
+			}
+			return this.toEmptyRecycleBinResults(mockResults);
+		}
+
+		// ** PRIVATE
+		private void checkFailures(MockDml.Operation operation, SObject record) {
+			// Runs all ConditionalFailures defined the current instance against each record.
+			for (MockDml.ConditionalFailure failure : MockDml.FAILURES) {
+				Exception error = failure?.checkFailure(operation, record);
+				if (error != null) {
+					throw error;
+				}
+			}
+		}
+
+		private MockDml.Result generateMockResult(MockDml.History history, SObject record, Boolean allOrNone) {
+			// Simulates a DML operation for a single record, returning a MockDml.Result,
+			// which calling methods can de/serialize into a Database.Save/Upsert/etc. Result.
+			try {
+				MockDml.Operation operation = history?.getOperation();
+				// Determine if the operation should fail for the specific record
+				this.checkFailures(operation, record);
+				// Simulate successful dml, return a MockDml.Result w/out errors
+				return history?.registerDml(record);
+			} catch (System.DmlException error) {
+				// Return a MockDml.Result w/errors
+				return history?.handleDmlError(record, error, allOrNone);
+			}
+		}
+
+		private MockDml.LeadConvertResult generateMockResult(Database.LeadConvert leadToConvert, Boolean allOrNone) {
+			// Simulate a Lead Conversion, which typically also involves inserting Account/Contact/Opportunity records
+			Lead leadRecord = new Lead(Id = leadToConvert?.getLeadId());
+			Account accountRecord = new Account(Id = leadToConvert?.getAccountId());
+			Contact contactRecord = new Contact(Id = leadToConvert?.getContactId());
+			Opportunity opportunityRecord = new Opportunity(Id = leadToConvert?.getOpportunityId());
+			try {
+				// Note: Process resulting records using allOrNone=true, regardless of its original value
+				// This allows injected errors for Accounts/Contacts/Opps to be caught and handled appropriately
+				// 1. Simulate converting the lead
+				this.validateConvertedLead(leadToConvert);
+				this.generateMockResult(MockDml.CONVERTED, leadRecord, true);
+				// 2. Simulate creating an Account/Contact/Opportunity, if their Id wasn't already provided
+				this.simulateInsertIfNew(accountRecord);
+				this.simulateInsertIfNew(contactRecord);
+				this.simulateInsertIfNew(opportunityRecord);
+				// 3. Build & return the LeadConvertResult w/the resulting record ids
+				return (MockDml.LeadConvertResult) new MockDml.LeadConvertResult(leadRecord)
+					?.setId(accountRecord)
+					?.setId(contactRecord)
+					?.setId(opportunityRecord);
+			} catch (System.DmlException error) {
+				// Deregister any of successful related records up to this point
+				MockDml.INSERTED?.deregisterDml(accountRecord);
+				MockDml.INSERTED?.deregisterDml(contactRecord);
+				MockDml.INSERTED?.deregisterDml(opportunityRecord);
+				MockDml.CONVERTED?.deregisterDml(leadRecord);
+				return (MockDml.LeadConvertResult) MockDml.CONVERTED?.handleDmlError(leadRecord, error, allOrNone);
+			}
+		}
+
+		private void runDeleteCallbackIfAsync(List<Database.DeleteResult> results) {
+			if (this.isOperationAsync == true) {
+				for (Database.DeleteResult result : results) {
+					this.asyncDeleteCallback?.processDelete(result);
+				}
+			}
+		}
+
+		private void runSaveCallbackIfAsync(List<Database.SaveResult> results) {
+			if (this.isOperationAsync == true) {
+				for (Database.SaveResult result : results) {
+					this.asyncSaveCallback?.processSave(result);
+				}
+			}
+		}
+
+		private void simulateInsertIfNew(SObject record) {
+			// If the provided record does not already have an Id, simulate an insert operation
+			if (record?.Id == null) {
+				SObjectType objectType = record?.getSObjectType();
+				record.Id = MockRecord.initRecordId(objectType);
+				this.generateMockResult(MockDml.INSERTED, record, true);
+			}
+		}
+
+		private List<Database.LeadConvertResult> toConvertResults(List<MockDml.Result> results) {
+			return (List<Database.LeadConvertResult>) this.toDatabaseResults(
+				results,
+				List<Database.LeadConvertResult>.class
+			);
+		}
+
+		private List<Database.EmptyRecycleBinResult> toEmptyRecycleBinResults(List<MockDml.Result> results) {
+			Type returnType = List<Database.EmptyRecycleBinResult>.class;
+			return (List<Database.EmptyRecycleBinResult>) this.toDatabaseResults(results, returnType);
+		}
+
+		private List<Database.DeleteResult> toDeleteResults(List<MockDml.Result> results) {
+			Type returnType = List<Database.DeleteResult>.class;
+			return (List<Database.DeleteResult>) this.toDatabaseResults(results, returnType);
+		}
+
+		private List<Database.SaveResult> toSaveResults(List<MockDml.Result> results) {
+			Type returnType = List<Database.SaveResult>.class;
+			return (List<Database.SaveResult>) this.toDatabaseResults(results, returnType);
+		}
+
+		private List<Database.UndeleteResult> toUndeleteResults(List<MockDml.Result> results) {
+			// Note: For some reason, we can't directly deserialize into a List<Database.UndeleteResult> like the other methods.
+			// Attempting to do so will result in the "success" parameter always being set to false.
+			// Don't ask me why -- but deserializing to an untyped Object first solves this issue.
+			Object untyped = JSON.deserializeUntyped(JSON.serialize(results));
+			Type returnType = List<Database.UndeleteResult>.class;
+			return (List<Database.UndeleteResult>) JSON.deserialize(JSON.serialize(untyped), returnType);
+		}
+
+		private List<Database.UpsertResult> toUpsertResults(List<MockDml.Result> results) {
+			Type returnType = List<Database.UpsertResult>.class;
+			return (List<Database.UpsertResult>) this.toDatabaseResults(results, returnType);
+		}
+
+		private Object toDatabaseResults(List<MockDml.Result> results, Type returnType) {
+			return JSON.deserialize(JSON.serialize(results), returnType);
+		}
+
+		private void validateConvertedLead(Database.LeadConvert leadToConvert) {
+			// Mimicks the stock behavior of Database.LeadConvert objects.
+			// These will always throw an error if you are missing a leadId or converted status.
+			if (leadToConvert?.getLeadId() == null) {
+				throw new System.DmlException('valid leadId is required');
+			} else if (leadToConvert?.getConvertedStatus() == null) {
+				throw new System.DmlException('convertedStatus is required');
+			}
+		}
 	}
 
 	public virtual class PlatformEventHistory extends MockDml.History {

--- a/force-app/main/default/classes/MockDmlTest.cls
+++ b/force-app/main/default/classes/MockDmlTest.cls
@@ -1,13 +1,24 @@
 @SuppressWarnings('PMD.ApexDoc, PMD.CyclomaticComplexity, PMD.EmptyCatchBlock')
 @IsTest
 private class MockDmlTest {
-	// **** CONSTANTS **** //
-	private static final Integer TEST_SIZE = 20;
+	// **** VARIABLES **** //
+	private static final Integer TEST_SIZE;
+	private static Integer numPostDmlPluginCalls;
+	private static Integer numPreDmlPluginCalls;
+
+	static {
+		numPostDmlPluginCalls = 0;
+		numPreDmlPluginCalls = 0;
+		TEST_SIZE = 20;
+		// Custom metadata actually defined in the org should not interfere with this test:
+		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{};
+		// Use Mock DML:
+		DatabaseLayer.useMockDml();
+	}
 
 	// **** TESTS **** //
 	@IsTest
 	static void shouldMockLeadConvert() {
-		DatabaseLayer.useMockDml();
 		Map<Id, Lead> leads = new Map<Id, Lead>();
 		List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>();
 		for (Integer i = 0; i < TEST_SIZE; i++) {
@@ -43,7 +54,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockLeadConvertWithExistingRecords() {
-		DatabaseLayer.useMockDml();
 		Account account = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
 		Map<Id, Lead> leads = new Map<Id, Lead>();
 		List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>();
@@ -81,7 +91,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldThrowExceptionIfMissingLeadIdOnConvert() {
-		DatabaseLayer.useMockDml();
 		List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>();
 		for (Integer i = 0; i < TEST_SIZE; i++) {
 			Lead lead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
@@ -105,7 +114,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldThrowExceptionIfMissingLeadStatusConvert() {
-		DatabaseLayer.useMockDml();
 		List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>();
 		for (Integer i = 0; i < TEST_SIZE; i++) {
 			Lead lead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
@@ -129,6 +137,7 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldThrowExceptionIfErrorInjectedOnConvert() {
+		DatabaseLayer.useMockDml()?.fail();
 		List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>();
 		for (Integer i = 0; i < TEST_SIZE; i++) {
 			Lead lead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
@@ -137,7 +146,6 @@ private class MockDmlTest {
 			leadToConvert?.setConvertedStatus('Some Status');
 			leadsToConvert?.add(leadToConvert);
 		}
-		DatabaseLayer.useMockDml()?.fail();
 
 		Test.startTest();
 		try {
@@ -177,7 +185,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockDelete() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -198,7 +205,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockDeleteAsync() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -219,7 +225,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockDeleteImmediate() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -240,7 +245,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockEmptyRecycleBin() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 		DatabaseLayer.Dml?.doDelete(leads);
 
@@ -293,7 +297,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockInsert() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType);
 
 		Test.startTest();
@@ -315,7 +318,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockInsertAsync() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType);
 
 		Test.startTest();
@@ -337,7 +339,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockInsertImmediate() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType);
 
 		Test.startTest();
@@ -394,7 +395,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockPublish() {
-		DatabaseLayer.useMockDml();
 		List<BatchApexErrorEvent> events = MockDmlTest.initRecords(BatchApexErrorEvent.SObjectType);
 
 		Test.startTest();
@@ -455,7 +455,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockUndelete() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -512,7 +511,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockUpdate() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -534,7 +532,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockUpdateAsync() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -556,7 +553,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockUpdateImmediate() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -613,7 +609,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldMockUpsert() {
-		DatabaseLayer.useMockDml();
 		List<Lead> leads = MockDmlTest.initRecords(Lead.SObjectType, true);
 
 		Test.startTest();
@@ -670,7 +665,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldProvideUsefulInformationAboutProcessedRecords() {
-		DatabaseLayer.useMockDml();
 		Lead testLead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
 		// Pre-test asserts
 		Assert.isFalse(MockDml.UPDATED.wasProcessed(testLead), 'Pre-test: Should not have been processed');
@@ -749,7 +743,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldGetAllRecordsFromHistory() {
-		DatabaseLayer.useMockDml();
 		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
 		DatabaseLayer.Dml.doInsert(accounts);
 
@@ -763,7 +756,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldGetSpecificRecordFromHistory() {
-		DatabaseLayer.useMockDml();
 		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
 		Account firstAccount = accounts?.get(0);
 		DatabaseLayer.Dml.doInsert(accounts);
@@ -780,7 +772,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldCreateSnapshotOfMockDatabase() {
-		DatabaseLayer.useMockDml();
 		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
 		DatabaseLayer.Dml.doInsert(accounts);
 
@@ -801,8 +792,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldHandleSetSavepoints() {
-		DatabaseLayer.useMockDml();
-
 		Test.startTest();
 		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
 		Test.stopTest();
@@ -817,8 +806,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldHandleReleasedSavepoints() {
-		DatabaseLayer.useMockDml();
-
 		Test.startTest();
 		System.Savepoint savepoint = DatabaseLayer.Dml.setSavepoint();
 		DatabaseLayer.Dml.releaseSavepoint(savepoint);
@@ -834,7 +821,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldHandleRolledBackSavepoints() {
-		DatabaseLayer.useMockDml();
 		MockDml.MockDatabase.resetOnRollback = true;
 
 		Test.startTest();
@@ -854,7 +840,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldHandleRolledBackSavepointsWithoutResettingMockDatabase() {
-		DatabaseLayer.useMockDml();
 		MockDml.MockDatabase.resetOnRollback = false;
 
 		Test.startTest();
@@ -874,7 +859,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldGetASpecificSavepoint() {
-		DatabaseLayer.useMockDml();
 		System.Savepoint sp1 = DatabaseLayer.Dml.setSavepoint();
 		System.Savepoint sp2 = DatabaseLayer.Dml.setSavepoint();
 		// Roll back the second savepoint, to distinguish the two:
@@ -895,8 +879,73 @@ private class MockDmlTest {
 		Assert.isNotNull(MockDml.Savepoints.get(spInfo2?.index), 'No Savepoint matching ' + spInfo2?.index);
 	}
 
+	@IsTest
+	static void shouldRunPreAndPostProcessorPluginLogic() {
+		DatabaseLayerSetting__mdt settings = MockDmlTest.initSettings();
+		settings.DmlPreAndPostProcessor__c = MockDmlTest.TestPlugin.class.getName();
+		// Re-initialize the plugins, now that the field has been set:
+		DatabaseLayer.Dml.initPlugins();
+		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(accounts)?.get(0);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(1, MockDmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(1, MockDmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
+	@IsTest
+	static void shouldNotRunProcessorLogicIfInvalidApexClassDefined() {
+		DatabaseLayerSetting__mdt settings = MockDmlTest.initSettings();
+		settings.DmlPreAndPostProcessor__c = 'an obviously invalid apex class name';
+		// Re-initialize the plugins, now that the field has been set:
+		DatabaseLayer.Dml.initPlugins();
+		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(accounts)?.get(0);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(0, MockDmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(0, MockDmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
+	@IsTest
+	static void shouldNotRunProcessorLogicIfNoValueDefined() {
+		DatabaseLayerSetting__mdt settings = MockDmlTest.initSettings();
+		settings.DmlPreAndPostProcessor__c = null;
+		DatabaseLayer.Dml.initPlugins();
+		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(accounts)?.get(0);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(0, MockDmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(0, MockDmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
+	@IsTest
+	static void shouldNotRunProcessorLogicIfNoSettingsDefined() {
+		// Without calling MockDmlTest.initSettings(), no settings are defined:
+		DatabaseLayer.Dml.initPlugins();
+		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
+
+		Test.startTest();
+		Database.SaveResult result = DatabaseLayer.Dml.doInsert(accounts)?.get(0);
+		Test.stopTest();
+
+		Assert.areEqual(true, result?.isSuccess(), 'DML failed: ' + result?.getErrors());
+		Assert.areEqual(0, MockDmlTest.numPreDmlPluginCalls, 'Wrong number of pre-dml plugin calls');
+		Assert.areEqual(0, MockDmlTest.numPostDmlPluginCalls, 'Wrong number of post-dml plugin calls');
+	}
+
 	// **** HELPER **** //
-	static List<SObject> initRecords(SObjectType objectType, Boolean withId) {
+	private static List<SObject> initRecords(SObjectType objectType, Boolean withId) {
 		List<SObject> records = new List<SObject>();
 		for (Integer i = 0; i < TEST_SIZE; i++) {
 			MockRecord mock = new MockRecord(objectType);
@@ -909,8 +958,14 @@ private class MockDmlTest {
 		return records;
 	}
 
-	static List<SObject> initRecords(SObjectType objectType) {
+	private static List<SObject> initRecords(SObjectType objectType) {
 		return MockDmlTest.initRecords(objectType, false);
+	}
+
+	private static DatabaseLayerSetting__mdt initSettings() {
+		DatabaseLayerSetting__mdt settings = new DatabaseLayerSetting__mdt();
+		DatabaseLayer.Utils.MetadataSelector.settings?.add(settings);
+		return settings;
 	}
 
 	// **** INNER **** //
@@ -929,6 +984,18 @@ private class MockDmlTest {
 				operation == this.failingOperation &&
 				record?.getSObjectType() == this.failingSObjectType;
 			return (shouldFail) ? new System.DmlException() : null;
+		}
+	}
+
+	public class TestPlugin implements Dml.PreAndPostProcessor {
+		// Note: Class has to be public to work properly:
+		public void processPreDml(Dml.Request dmlRequest) {
+			System.debug('Request: ' + JSON.serialize(dmlRequest));
+			MockDmlTest.numPreDmlPluginCalls += 1;
+		}
+
+		public void processPostDml(Dml.Request dmlRequest, List<Object> databaseResults) {
+			MockDmlTest.numPostDmlPluginCalls += 1;
 		}
 	}
 }

--- a/force-app/main/default/classes/MockRecord.cls
+++ b/force-app/main/default/classes/MockRecord.cls
@@ -58,7 +58,7 @@ public class MockRecord {
 	}
 
 	public List<SObject> getRelatedList(SObjectField lookupField) {
-		Schema.ChildRelationship relationship = ChildRelationshipService.getChildRelationshipFrom(lookupField);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
 		return this.getRelatedList(relationship);
 	}
 
@@ -97,7 +97,7 @@ public class MockRecord {
 	}
 
 	public MockRecord setRelatedList(SObjectField lookupField, List<SObject> relatedRecords) {
-		Schema.ChildRelationship relationship = ChildRelationshipService.getChildRelationshipFrom(lookupField);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
 		return this.setRelatedList(relationship, relatedRecords);
 	}
 

--- a/force-app/main/default/classes/MockRecord.cls
+++ b/force-app/main/default/classes/MockRecord.cls
@@ -58,7 +58,9 @@ public class MockRecord {
 	}
 
 	public List<SObject> getRelatedList(SObjectField lookupField) {
-		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(
+			lookupField
+		);
 		return this.getRelatedList(relationship);
 	}
 
@@ -97,7 +99,9 @@ public class MockRecord {
 	}
 
 	public MockRecord setRelatedList(SObjectField lookupField, List<SObject> relatedRecords) {
-		Schema.ChildRelationship relationship = DatabaseLayer.Utils.getChildRelationshipFrom(lookupField);
+		Schema.ChildRelationship relationship = DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(
+			lookupField
+		);
 		return this.setRelatedList(relationship, relatedRecords);
 	}
 

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -1094,7 +1094,7 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 		}
 
 		public Subquery(SObjectField lookupFieldOnChildObject) {
-			this(ChildRelationshipService.getChildRelationshipFrom(lookupFieldOnChildObject));
+			this(DatabaseLayer.Utils.getChildRelationshipFrom(lookupFieldOnChildObject));
 		}
 
 		public override String getFrom() {

--- a/force-app/main/default/classes/Soql.cls
+++ b/force-app/main/default/classes/Soql.cls
@@ -1094,7 +1094,7 @@ public inherited sharing virtual class Soql extends Soql.Builder {
 		}
 
 		public Subquery(SObjectField lookupFieldOnChildObject) {
-			this(DatabaseLayer.Utils.getChildRelationshipFrom(lookupFieldOnChildObject));
+			this(DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(lookupFieldOnChildObject));
 		}
 
 		public override String getFrom() {

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -830,7 +830,7 @@ private class SoqlTest {
 
 	@IsTest
 	static void shouldGenerateSubqueryFromChildRelationship() {
-		Schema.ChildRelationship rel = DatabaseLayer.Utils.getChildRelationshipFrom(Case.AccountId);
+		Schema.ChildRelationship rel = DatabaseLayer.Utils.ChildRelationships.getChildRelationshipFrom(Case.AccountId);
 
 		Test.startTest();
 		String result = new Soql.Subquery(rel)?.addSelect(Case.Id)?.toString();

--- a/force-app/main/default/classes/SoqlTest.cls
+++ b/force-app/main/default/classes/SoqlTest.cls
@@ -830,7 +830,7 @@ private class SoqlTest {
 
 	@IsTest
 	static void shouldGenerateSubqueryFromChildRelationship() {
-		Schema.ChildRelationship rel = ChildRelationshipService.getChildRelationshipFrom(Case.AccountId);
+		Schema.ChildRelationship rel = DatabaseLayer.Utils.getChildRelationshipFrom(Case.AccountId);
 
 		Test.startTest();
 		String result = new Soql.Subquery(rel)?.addSelect(Case.Id)?.toString();

--- a/force-app/main/default/layouts/DatabaseLayerSetting__mdt-Database Layer Setting Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/DatabaseLayerSetting__mdt-Database Layer Setting Layout.layout-meta.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<Layout xmlns="http://soap.sforce.com/2006/04/metadata">
+    <layoutSections>
+        <customLabel>false</customLabel>
+        <detailHeading>false</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Information</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Required</behavior>
+                <field>MasterLabel</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Required</behavior>
+                <field>DeveloperName</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>Plugins</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Edit</behavior>
+                <field>DmlPreAndPostProcessor__c</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns />
+        <style>TwoColumnsLeftToRight</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>false</customLabel>
+        <detailHeading>true</detailHeading>
+        <editHeading>true</editHeading>
+        <label>System Information</label>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>CreatedById</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>IsProtected</field>
+            </layoutItems>
+        </layoutColumns>
+        <layoutColumns>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>LastModifiedById</field>
+            </layoutItems>
+            <layoutItems>
+                <behavior>Readonly</behavior>
+                <field>NamespacePrefix</field>
+            </layoutItems>
+        </layoutColumns>
+        <style>TwoColumnsTopToBottom</style>
+    </layoutSections>
+    <layoutSections>
+        <customLabel>true</customLabel>
+        <detailHeading>false</detailHeading>
+        <editHeading>false</editHeading>
+        <label>Custom Links</label>
+        <layoutColumns />
+        <layoutColumns />
+        <layoutColumns />
+        <style>CustomLinks</style>
+    </layoutSections>
+    <showEmailCheckbox>false</showEmailCheckbox>
+    <showHighlightsPanel>false</showHighlightsPanel>
+    <showInteractionLogPanel>false</showInteractionLogPanel>
+    <showRunAssignmentRulesCheckbox>false</showRunAssignmentRulesCheckbox>
+    <showSubmitAndAttachButton>false</showSubmitAndAttachButton>
+    <summaryLayout>
+        <masterLabel>00hDU000009Uplu</masterLabel>
+        <sizeX>4</sizeX>
+        <sizeY>0</sizeY>
+        <summaryLayoutStyle>Default</summaryLayoutStyle>
+    </summaryLayout>
+</Layout>

--- a/force-app/main/default/objects/DatabaseLayerSetting__mdt/DatabaseLayerSetting__mdt.object-meta.xml
+++ b/force-app/main/default/objects/DatabaseLayerSetting__mdt/DatabaseLayerSetting__mdt.object-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomObject xmlns="http://soap.sforce.com/2006/04/metadata">
+    <description>Optional configuration options for the apex-database-layer package.
+There may only be a single record, called &quot;Default&quot;, or no records defined.</description>
+    <label>Database Layer Setting</label>
+    <pluralLabel>DatabaseLayerSettings</pluralLabel>
+    <visibility>Public</visibility>
+</CustomObject>

--- a/force-app/main/default/objects/DatabaseLayerSetting__mdt/fields/DmlPreAndPostProcessor__c.field-meta.xml
+++ b/force-app/main/default/objects/DatabaseLayerSetting__mdt/fields/DmlPreAndPostProcessor__c.field-meta.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>DmlPreAndPostProcessor__c</fullName>
+    <externalId>false</externalId>
+    <fieldManageability>SubscriberControlled</fieldManageability>
+    <inlineHelpText
+	>The name of an Apex Class that runs special processing before &amp; after DML is processed. You can use this for things like automatic login. 
+
+Must be the fully qualified API Name (including namespace, if applicable) of an Apex Class that implements the Dml.PreAndPostProcessor interface, and has a public 0-arg constructor.</inlineHelpText>
+    <label>DML: Pre &amp; Post Processor</label>
+    <length>255</length>
+    <required>false</required>
+    <type>Text</type>
+    <unique>false</unique>
+</CustomField>

--- a/force-app/main/default/objects/DatabaseLayerSetting__mdt/validationRules/EnforceSingleRecord.validationRule-meta.xml
+++ b/force-app/main/default/objects/DatabaseLayerSetting__mdt/validationRules/EnforceSingleRecord.validationRule-meta.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<ValidationRule xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>EnforceSingleRecord</fullName>
+    <active>true</active>
+    <description>There may only be a single record, and it must be called &quot;Default&quot;</description>
+    <errorConditionFormula>LOWER(DeveloperName) &lt;&gt; &quot;default&quot;</errorConditionFormula>
+    <errorDisplayField>DeveloperName</errorDisplayField>
+    <errorMessage
+	>There may only be a single Database Layer Setting record, and it must be called &quot;Default&quot;.</errorMessage>
+</ValidationRule>

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,9 +4,9 @@
 			"path": "force-app",
 			"default": true,
 			"package": "apex-database-layer",
-			"versionName": "ver 2.3.0",
-			"versionNumber": "2.3.0.NEXT",
-			"versionDescription": "Adds support for System.Savepoint operations"
+			"versionName": "ver 2.4.0",
+			"versionNumber": "2.4.0.NEXT",
+			"versionDescription": "New plugin framework; static MockDml failure methods"
 		}
 	],
 	"name": "apex-database-layer",
@@ -22,6 +22,7 @@
 		"apex-database-layer@2.2.0-1": "04tDn0000011OQJIA2",
 		"apex-database-layer@2.2.1-1": "04tDn0000011OQYIA2",
 		"apex-database-layer@2.2.2-1": "04tDn0000011OQdIAM",
-		"apex-database-layer@2.3.0-1": "04tDn0000011OQsIAM"
+		"apex-database-layer@2.3.0-1": "04tDn0000011OQsIAM",
+		"apex-database-layer@2.4.0-1": "04tDn0000011OR7IAM"
 	}
 }


### PR DESCRIPTION
Package Version ID: `04tDn0000011OR7IAM`

```sh
sf package install --package 04tDn0000011OR7IAM --wait 10
```

---

## What Changed?

### 🔌 New Plugin Framework & `Dml.PreAndPostProcessor` Plugin
Closes #51 - Subscribers can now create their own plugins, to inject custom logic into the application, via a new `DatabaseLayerSetting__mdt` custom metadata type. 

The first use case for this is the `Dml.PreAndPostProcessor` plugin. This plugin defines logic to be run immediately before/after DML operation (for example, logging) via its interface methods:

```java
public interface PreAndPostProocessor {
  void processPreDml(Dml.Request request);
  void processPostDml(Dml.Request request, List<Object> databaseResults);
}
```

The `Dml.Request` class contains contextual information about the DML operation, including details about the records & operation being processed, any special configuration (like `accessLevel` and `allOrNone`), and more.

To support this change, we revamped `Dml` and `MockDml` to incorporate this new request class, and relocated virtual methods from the top-level class to the new `Dml.Request` class.

### ✨ New static `MockDml` methods to simulate Dml failures
Closes #42 - simplifies mock DML error injection through new static methods. These methods will replace the (soon deprecated) instance methods:

```java
MockDml.ConditionalLogic logic = new SomeLogic();
// Don't do this:
MockDml instance = (MockDml) DatabaseLayer.Dml;
instance.fail();
instance.failIf(logic);
instance.clearFailures();
// Do this instead!
MockDml.shouldFail();
MockDml.shouldFailIf(logic);
MockDml.shouldSucceed();
```

The old methods still work (for now), but they call the static methods under the hood. This means you can no longer rely on multiple instances containing differing failure logic. Instead, use the `MockDml.ConditionalLogic` interface and the new `shouldFailIf` method to control complex failure logic.

The deprecated instance methods will eventually be removed entirely in v3.0.0 [#56].

### 🧹 Housekeeping
Closes #54 - Created a new `DatabaseLayerUtils` class to house all utilities shared by the package. This takes the place of the single-purpose `ChildRelationshipService` class. The old class continues to function, but its methods are rerouted to the new class. It will be removed entirely in v3.0.0 [#56]. 

This new class better reflects the stated intent as a internal utility, and it also reduces the risk of class name collisions, since it's not hard to imagine a subscriber org with an existing apex class called "ChildRelationshipService". 

### ❌ Deprecated Methods
The following methods will be deprecated in v3.0.0 [#56]. These methods remain intact for now, but it's recommended that you migrate to the newer methods as soon as possible to make the migration path easier:

- The `ChildRelationshipService` class: replace with `DatabaseLayer.Utils.ChildRelationships`
- The `MockDml` class's `clearFailures` method: Replace w/`MockDml.shouldSucceed`
- The `MockDml` class's `fail` method: Replace w/`MockDml.shouldFail`
- The `MockDml` class's `failIf` method: Replace w/`MockDml.shouldFailIf`
-  The`MockDml.Operation` enum: Replace with the new `Dml.Operation` enum

> ⚠️ _**Note:** The `MockDml.ConditionalLogic` interface still requires the old `MockDml.Operation` enum. For now, amend any classes with implement this interface to include _another_ method that uses `Dml.Operation` instead of `MockDml.Operation`. In v3.0.0, the interface will be amended to use `Dml.Operation` instead [#56]. In v3.0.1, the old  enum will be removed altogether [#63]._

