### PR TITLE
Remove MockDml.Operation enum

### DIFF
--- a/force-app/main/default/classes/MockDml.cls
+++ b/force-app/main/default/classes/MockDml.cls
@@ -401,19 +401,6 @@ global class MockDml extends Dml {
 		}
 	}
 
-	public enum Operation {
-		// ! Deprecated: This will be removed in a future release
-		// ! Replace all uses of this enum with the Dml.Operation enum
-		DO_CONVERT,
-		DO_DELETE,
-		DO_INSERT,
-		DO_PUBLISH,
-		DO_PURGE,
-		DO_UNDELETE,
-		DO_UPDATE,
-		DO_UPSERT
-	}
-
 	/**
 	 * @description Mock implementation of DML request that simulates database operations without actual DML.
 	 */


### PR DESCRIPTION
Closes #63. Removes the `MockDml.Operation` enum, which was replaced internally by the `Dml.Operation` enum in v3.0.0. 

See the [migration guide](https://github.com/jasonsiders/apex-database-layer/wiki/Migration-Guide-v3.0.0) for more details. 