### PR TITLE
Changes to Accommodate new Nebula Logger Plugin

### DIFF
--- a/source/classes/DatabaseLayer.cls
+++ b/source/classes/DatabaseLayer.cls
@@ -3,16 +3,10 @@
  */
 @SuppressWarnings('PMD.AvoidGlobalModifier')
 global class DatabaseLayer {
-	public static final DatabaseLayerUtils UTILS;
-	private static final DatabaseLayer INSTANCE;
+	private static final DatabaseLayer INSTANCE = new DatabaseLayer();
 
 	private Dml currentDml;
 	private SoqlProvider currentSoql;
-
-	static {
-		INSTANCE = new DatabaseLayer();
-		UTILS = new DatabaseLayerUtils(INSTANCE);
-	}
 
 	private DatabaseLayer() {
 		this.currentDml = new Dml(this);
@@ -39,6 +33,19 @@ global class DatabaseLayer {
 		get {
 			return INSTANCE?.currentSoql;
 		}
+	}
+
+	/**
+	 * @description Provides access to utility methods for database operations and testing.
+	 * @return Singleton instance of the DatabaseLayerUtils class
+	 */
+	@SuppressWarnings('PMD.PropertyNamingConventions')
+	public static final DatabaseLayerUtils Utils {
+		get {
+			DatabaseLayer.Utils = DatabaseLayer.Utils ?? new DatabaseLayerUtils(INSTANCE);
+			return DatabaseLayer.Utils;
+		}
+		private set;
 	}
 
 	/**

--- a/source/classes/DatabaseLayerTestUtils.cls
+++ b/source/classes/DatabaseLayerTestUtils.cls
@@ -1,8 +1,9 @@
 /**
  * @description Test utility class providing common functionality and spy implementations for framework testing.
  */
+@SuppressWarnings('PMD.AvoidGlobalModifier')
 @IsTest
-public class DatabaseLayerTestUtils {
+global class DatabaseLayerTestUtils {
 	// Note: These properties do not use traditional naming conventions to support a 'namespace-like' API
 	@SuppressWarnings('PMD.FieldNamingConventions')
 	public static final PreAndPostProcessorSpy DmlPluginSpy = new PreAndPostProcessorSpy();
@@ -11,12 +12,35 @@ public class DatabaseLayerTestUtils {
 
 	/**
 	 * @description Creates a mock DatabaseLayerSetting__mdt for testing and injects it into the metadata selector.
+	 * @param setting The custom metadata record being injected.
 	 * @return The created test settings object
 	 */
-	public static DatabaseLayerSetting__mdt initSettings() {
-		DatabaseLayerSetting__mdt setting = new DatabaseLayerSetting__mdt();
+	global static DatabaseLayerSetting__mdt initSettings(DatabaseLayerSetting__mdt setting) {
 		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{ setting };
+		DatabaseLayer.Dml.initPlugins();
+		DatabaseLayer.Soql.initPlugins();
 		return setting;
+	}
+
+	/**
+	 * @description Creates an empty DatabaseLayerSetting__mdt for testing and injects it into the metadata selector.
+	 * @return The created test settings object
+	 */
+	global static DatabaseLayerSetting__mdt initSettings() {
+		return DatabaseLayerTestUtils.initSettings(new DatabaseLayerSetting__mdt());
+	}
+
+	/**
+	 * @description Creates a DatabaseLayerSetting__mdt for testing with both DML and SOQL plugins configured to use the same class.
+	 * @param className The name of the class to use for both DML and SOQL pre/post processing
+	 * @return The created test settings object with plugin configuration
+	 */
+	global static DatabaseLayerSetting__mdt initDmlAndSoqlPlugins(String className) {
+		DatabaseLayerSetting__mdt setting = new DatabaseLayerSetting__mdt(
+			DmlPreAndPostProcessor__c = className,
+			SoqlPreAndPostProcessor__c = className
+		);
+		return DatabaseLayerTestUtils.initSettings(setting);
 	}
 
 	// **** INNER **** //

--- a/source/classes/DmlTest.cls
+++ b/source/classes/DmlTest.cls
@@ -13,9 +13,7 @@ private class DmlTest {
 		// Custom metadata actually defined in the org should not interfere with this test:
 		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{};
 		// Initialize plugins
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Dml.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(DatabaseLayerTestUtils.SamplePlugin.class.getName());
 	}
 
 	// **** TESTS **** //
@@ -874,10 +872,6 @@ private class DmlTest {
 
 	@IsTest
 	static void shouldRunPreAndPostProcessorPluginLogic() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		// Re-initialize the plugins, now that the field has been set:
-		DatabaseLayer.Dml.initPlugins();
 		Account account = DmlTest.initAccount();
 
 		Test.startTest();
@@ -896,10 +890,6 @@ private class DmlTest {
 
 	@IsTest
 	static void shouldRunPluginErrorLogic() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		// Re-initialize the plugins, now that the field has been set:
-		DatabaseLayer.Dml.initPlugins();
 		Account account = DmlTest.initAccount();
 
 		Test.startTest();
@@ -925,10 +915,7 @@ private class DmlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfInvalidApexClassDefined() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = 'an obviously invalid apex class name';
-		// Re-initialize the plugins, now that the field has been set:
-		DatabaseLayer.Dml.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins('An obviously invalid apex class name');
 		Account account = DmlTest.initAccount();
 
 		Test.startTest();
@@ -947,9 +934,7 @@ private class DmlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfNoValueDefined() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = null;
-		DatabaseLayer.Dml.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(null);
 		Account account = DmlTest.initAccount();
 
 		Test.startTest();
@@ -1042,12 +1027,6 @@ private class DmlTest {
 		leadToConvert?.setLeadId(lead?.Id);
 		leadToConvert?.setConvertedStatus(CONVERTED_STATUS?.ApiName);
 		return leadToConvert;
-	}
-
-	private static DatabaseLayerSetting__mdt initSettings() {
-		DatabaseLayerSetting__mdt settings = new DatabaseLayerSetting__mdt();
-		DatabaseLayer.Utils.MetadataSelector.settings?.add(settings);
-		return settings;
 	}
 
 	// **** INNER **** //

--- a/source/classes/MockDmlTest.cls
+++ b/source/classes/MockDmlTest.cls
@@ -11,9 +11,7 @@ private class MockDmlTest {
 		// Use Mock DML:
 		DatabaseLayer.useMockDml();
 		// Initialize plugins:
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Dml.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(DatabaseLayerTestUtils.SamplePlugin.class.getName());
 	}
 
 	// **** TESTS **** //
@@ -905,10 +903,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldRunPreAndPostProcessorPluginLogic() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		// Re-initialize the plugins, now that the field has been set:
-		DatabaseLayer.Dml.initPlugins();
 		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
 
 		Test.startTest();
@@ -927,10 +921,6 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldRunPluginErrorLogic() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		// Re-initialize the plugins, now that the field has been set:
-		DatabaseLayer.Dml.initPlugins();
 		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
 		MockDml.shouldFail();
 
@@ -957,10 +947,7 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfInvalidApexClassDefined() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = 'an obviously invalid apex class name';
-		// Re-initialize the plugins, now that the field has been set:
-		DatabaseLayer.Dml.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins('An obviously invalid apex class name');
 		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
 
 		Test.startTest();
@@ -979,9 +966,7 @@ private class MockDmlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfNoValueDefined() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.DmlPreAndPostProcessor__c = null;
-		DatabaseLayer.Dml.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(null);
 		List<Account> accounts = MockDmlTest.initRecords(Account.SObjectType, false);
 
 		Test.startTest();

--- a/source/classes/MockSoqlTest.cls
+++ b/source/classes/MockSoqlTest.cls
@@ -5,19 +5,16 @@ private class MockSoqlTest {
 	private static final Integer NUM_ACCS;
 
 	static {
+		DatabaseLayer.useMocks();
 		NUM_ACCS = 10;
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Soql.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(DatabaseLayerTestUtils.SamplePlugin.class.getName());
 	}
 
 	// **** TESTS **** //
 	@IsTest
 	static void shouldMockCountQuery() {
-		// Build a query
 		Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT);
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(count);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql?.newQuery(Account.SObjectType)?.addSelect(count);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 
@@ -31,9 +28,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockCountQueryErrors() {
-		// Build a query
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/a mock error
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		soql?.setMock()?.withError();
 
 		Test.startTest();
@@ -49,8 +44,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockCursor() {
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 		Integer numToFetch = 3;
@@ -68,8 +62,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldHandleCursorFetchCallWithNegativePositionParameter() {
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 		Soql.Cursor cursor = soql?.getCursor();
@@ -88,8 +81,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldHandleCursorFetchCallWithNegativeCountParameter() {
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 		Soql.Cursor cursor = soql?.getCursor();
@@ -108,8 +100,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldHandleCursorFetchCallThatExceedsNumberOfRecords() {
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 		Soql.Cursor cursor = soql?.getCursor();
@@ -128,8 +119,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldHandleCursorFetchCallWithNullParameters() {
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 		Soql.Cursor cursor = soql?.getCursor();
@@ -148,9 +138,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockQueryLocator() {
-		// Build a query
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 
@@ -182,9 +170,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockQueryLocatorErrors() {
-		// Build a query
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/a mock error
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		soql?.setMock()?.withError();
 
 		Test.startTest();
@@ -200,9 +186,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockQuery() {
-		// Build query
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/mock results
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		List<Account> accounts = MockSoqlTest.initAccounts(NUM_ACCS);
 		soql?.setMock()?.withResults(accounts);
 
@@ -216,9 +200,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockQueryErrors() {
-		// Build a query
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType)?.addSelect(Account.Name);
-		// Inject the query w/a mock error
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(Account.Name);
 		soql?.setMock()?.withError();
 
 		Test.startTest();
@@ -234,14 +216,12 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockAggregateQuery() {
-		// Build an aggregate query
 		Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT, User.Id);
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()
 			?.newQuery(User.SObjectType)
 			?.addSelect(new Soql.ParentField(User.ProfileId, Profile.Name))
 			?.addSelect(count)
 			?.addGroupBy(new Soql.ParentField(User.ProfileId, Profile.Name));
-		// Inject results into the query
 		MockSoql.AggregateResult mockResult1 = new MockSoql.AggregateResult()
 			?.addParameter('Foo Profile')
 			?.addParameter(123);
@@ -270,14 +250,12 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockAggregateQueryErrors() {
-		// Build an aggregate query
 		Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT, User.Id);
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()
 			?.newQuery(User.SObjectType)
 			?.addSelect(new Soql.ParentField(User.ProfileId, Profile.Name))
 			?.addSelect(count)
 			?.addGroupBy(new Soql.ParentField(User.ProfileId, Profile.Name));
-		// Inject an error
 		soql?.setMock()?.withError();
 
 		Test.startTest();
@@ -293,14 +271,12 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldMockQueryAndCastToType() {
-		// Build an aggregate query
 		Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT, User.Id);
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()
 			?.newQuery(User.SObjectType)
 			?.addSelect(new Soql.ParentField(User.ProfileId, Profile.Name))
 			?.addSelect(count)
 			?.addGroupBy(new Soql.ParentField(User.ProfileId, Profile.Name));
-		// Inject results
 		MockSoqlTest.SampleWrapper mockResult1 = new MockSoqlTest.SampleWrapper()?.wrap('Foo Profile', 123);
 		MockSoqlTest.SampleWrapper mockResult2 = new MockSoqlTest.SampleWrapper()?.wrap('Bar Profile', 45);
 		List<MockSoqlTest.SampleWrapper> mockResults = new List<MockSoqlTest.SampleWrapper>{ mockResult1, mockResult2 };
@@ -324,14 +300,12 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldHandleErrorsWithMockAndCast() {
-		// Build an aggregate query
 		Soql.Aggregation count = new Soql.Aggregation(Soql.Function.COUNT, User.Id);
 		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()
 			?.newQuery(User.SObjectType)
 			?.addSelect(new Soql.ParentField(User.ProfileId, Profile.Name))
 			?.addSelect(count)
 			?.addGroupBy(new Soql.ParentField(User.ProfileId, Profile.Name));
-		// Inject an error
 		soql?.setMock()?.withError(new System.TypeException());
 
 		Test.startTest();
@@ -347,14 +321,11 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldUseCustomSimulatorMocks() {
-		// Establish Dml & Soql objects to be used
-		DatabaseLayer.useMocks();
 		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Task.SObjectType)
 			?.addSelect(Task.WhatId)
 			?.addSelect(Task.WhoId);
 		// Mock with a custom class that leverages MockDml.INSERTED to generate results
 		soql?.setMock(new MockSoqlTest.CustomTaskQueryLogic());
-		// Mock insert an account + related contact
 		Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.toSObject();
 		DatabaseLayer.Dml.doInsert(mockAccount);
 		Contact mockContact = (Contact) new MockRecord(Contact.SObjectType)
@@ -375,7 +346,6 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldSetGlobalMock() {
-		DatabaseLayer.useMocks();
 		MockSoql theQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
 		// Set a global mock - all SOQL objects will return these results by default now:
 		Account mockAccount = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
@@ -391,7 +361,6 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldIgnoreGlobalMockIfSpecificSimulatorAssignedToQuery() {
-		DatabaseLayer.useMocks();
 		MockSoql theQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
 		// Set a global mock - all SOQL objects will return these results by default now:
 		Account mockAccount1 = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();
@@ -410,7 +379,6 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldIntelligentlyReturnCorrectQueryResults() {
-		DatabaseLayer.useMocks();
 		MockSoql accountQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
 		MockSoql caseQuery = (MockSoql) DatabaseLayer.Soql.newQuery(Case.SObjectType);
 		MockSoql.Simulator simulator = new MockSoqlTest.DynamicSimulator();
@@ -430,7 +398,7 @@ private class MockSoqlTest {
 	@IsTest
 	static void shouldReturnEmptyListIfNoMocks() {
 		// If a MockSoql is ran, and no Simulator is injected, the methods will automatically return an empty List
-		MockSoql soql = (MockSoql) DatabaseLayer.useMockSoql()?.newQuery(Account.SObjectType);
+		MockSoql soql = (MockSoql) DatabaseLayer.Soql.newQuery(Account.SObjectType);
 
 		Test.startTest();
 		List<Soql.AggregateResult> aggregateResults = soql?.aggregateQuery();
@@ -452,11 +420,6 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldRunPreAndPostProcessorPluginLogic() {
-		DatabaseLayer.useMocks();
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Soql.initPlugins();
-
 		Test.startTest();
 		DatabaseLayer.Soql.newQuery(User.SObjectType)?.setRowLimit(1)?.toSoql()?.query();
 		Test.stopTest();
@@ -472,10 +435,6 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldRunPluginErrorLogic() {
-		DatabaseLayer.useMocks();
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Soql.initPlugins();
 		MockSoql.setGlobalMock()?.withError();
 
 		Test.startTest();
@@ -500,10 +459,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfInvalidApexClassDefined() {
-		DatabaseLayer.useMocks();
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = 'an obviously invalid apex class name';
-		DatabaseLayer.Soql.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins('an obviously invalid apex class name');
 
 		Test.startTest();
 		DatabaseLayer.Soql.newQuery(User.SObjectType)?.setRowLimit(1)?.toSoql()?.query();
@@ -520,10 +476,7 @@ private class MockSoqlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfNoValueDefined() {
-		DatabaseLayer.useMocks();
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = null;
-		DatabaseLayer.Soql.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(null);
 
 		Test.startTest();
 		DatabaseLayer.Soql.newQuery(User.SObjectType)?.setRowLimit(1)?.toSoql()?.query();
@@ -541,7 +494,6 @@ private class MockSoqlTest {
 	@IsTest
 	static void shouldNotRunProcessorLogicIfNoSettingsDefined() {
 		DatabaseLayer.Utils.MetadataSelector.settings = new List<DatabaseLayerSetting__mdt>{};
-		DatabaseLayer.useMocks();
 		DatabaseLayer.Soql.initPlugins();
 
 		Test.startTest();

--- a/source/classes/Soql.cls
+++ b/source/classes/Soql.cls
@@ -1430,6 +1430,11 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 	 */
 	global virtual class Cursor {
 		protected Database.Cursor cursor;
+		protected Integer numRecords {
+			get {
+				return this.cursor?.getNumRecords();
+			}
+		}
 
 		protected Cursor(Database.Cursor cursor) {
 			this.cursor = cursor;
@@ -1466,7 +1471,7 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 		 * @return The total number of records in the cursor
 		 */
 		global virtual Integer getNumRecords() {
-			return this.cursor?.getNumRecords();
+			return this.numRecords;
 		}
 	}
 
@@ -1675,7 +1680,7 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 	 * @description Mockable wrapper for Database.QueryLocator that enables testing of batch processing queries.
 	 */
 	global virtual class QueryLocator {
-		private Database.QueryLocator locator;
+		protected transient Database.QueryLocator locator;
 
 		protected QueryLocator(Database.QueryLocator locator) {
 			this.locator = locator;
@@ -1722,8 +1727,6 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 		 * @description The Soql query instance being executed.
 		 */
 		global Soql query { get; private set; }
-		protected transient System.AccessLevel accessLevel { get; private set; }
-		protected transient Map<String, Object> binds { get; private set; }
 		/**
 		 * @description The SOQL query string representation.
 		 */
@@ -1732,6 +1735,8 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 				return this.query?.toString();
 			}
 		}
+		protected transient System.AccessLevel accessLevel { get; private set; }
+		protected transient Map<String, Object> binds { get; private set; }
 
 		protected Request(Soql query, Soql.Operation operation) {
 			this.accessLevel = query?.accessLevel;

--- a/source/classes/SoqlTest.cls
+++ b/source/classes/SoqlTest.cls
@@ -4,9 +4,7 @@
 @IsTest
 private class SoqlTest {
 	static {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Soql.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(DatabaseLayerTestUtils.SamplePlugin.class.getName());
 	}
 
 	// **** TESTS **** //
@@ -1518,10 +1516,6 @@ private class SoqlTest {
 
 	@IsTest
 	static void shouldRunPreAndPostProcessorPluginLogic() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Soql.initPlugins();
-
 		Test.startTest();
 		DatabaseLayer.Soql.newQuery(User.SObjectType)?.setRowLimit(1)?.toSoql()?.query();
 		Test.stopTest();
@@ -1541,10 +1535,6 @@ private class SoqlTest {
 
 	@IsTest
 	static void shouldRunPluginErrorLogic() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = DatabaseLayerTestUtils.SamplePlugin.class.getName();
-		DatabaseLayer.Soql.initPlugins();
-
 		Test.startTest();
 		Exception caughtError;
 		try {
@@ -1572,9 +1562,7 @@ private class SoqlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfInvalidApexClassDefined() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = 'an obviously invalid apex class name';
-		DatabaseLayer.Soql.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins('an obviously invalid apex class name');
 
 		Test.startTest();
 		DatabaseLayer.Soql.newQuery(User.SObjectType)?.setRowLimit(1)?.toSoql()?.query();
@@ -1595,9 +1583,7 @@ private class SoqlTest {
 
 	@IsTest
 	static void shouldNotRunProcessorLogicIfNoValueDefined() {
-		DatabaseLayerSetting__mdt settings = DatabaseLayerTestUtils.initSettings();
-		settings.SoqlPreAndPostProcessor__c = null;
-		DatabaseLayer.Soql.initPlugins();
+		DatabaseLayerTestUtils.initDmlAndSoqlPlugins(null);
 
 		Test.startTest();
 		DatabaseLayer.Soql.newQuery(User.SObjectType)?.setRowLimit(1)?.toSoql()?.query();

--- a/source/objects/DatabaseLayerSetting__mdt/fields/SoqlPreAndPostProcessor__c.field-meta.xml
+++ b/source/objects/DatabaseLayerSetting__mdt/fields/SoqlPreAndPostProcessor__c.field-meta.xml
@@ -7,7 +7,7 @@
 	>The name of an Apex Class that runs special processing before &amp; after SOQL is processed. You can use this for things like automatic logging.
 
 Must be the fully qualified API Name (including namespace, if applicable) of an Apex Class that implements the Soql.PreAndPostProcessor interface, and has a public 0-arg constructor.</inlineHelpText>
-    <label>Soql: Pre &amp; Post Processor</label>
+    <label>SOQL: Pre &amp; Post Processor</label>
     <length>255</length>
     <required>false</required>
     <type>Text</type>


### PR DESCRIPTION
Several minor changes pave the way for #116:
- Fixes a bug with how `DatabaseLayer.Utils` was initialized, preventing the plugin framework from working.
- Promotes `DatabaseLayerTestUtils` to global, and adds several methods to simplify plugin initialization in tests
- Implemented these new methods in existing framework tests
- Other minor cleanliness changes