### PR TITLE
Fix: Failing Tests

### DIFF
--- a/source/classes/SoqlTest.cls
+++ b/source/classes/SoqlTest.cls
@@ -1391,13 +1391,10 @@ private class SoqlTest {
 		Soql testQuery = DatabaseLayer.Soql.newQuery(Account.SObjectType)
 			?.addWhere(Account.Id, Soql.IN_COLLECTION, innerQuery)
 			?.toSoql();
+		String expected = 'SELECT Id FROM Account WHERE Id IN (SELECT AccountId FROM Case WHERE OwnerId = :ownerId)';
 
 		Test.startTest();
-		try {
-			testQuery?.query();
-		} catch (System.QueryException queryError) {
-			Assert.fail(queryError?.toString());
-		}
+		SoqlTest.validateQuery(testQuery, expected);
 		Test.stopTest();
 
 		String key = owner?.getKey();
@@ -1412,13 +1409,10 @@ private class SoqlTest {
 			?.addWhere(Opportunity.OwnerId, Soql.EQUALS, owner)
 			?.toSubquery();
 		Soql testQuery = DatabaseLayer.Soql.newQuery(Account.SObjectType)?.addSelect(subquery)?.toSoql();
+		String expected = 'SELECT Id, (SELECT Id FROM Opportunities WHERE OwnerId = :ownerId) FROM Account';
 
 		Test.startTest();
-		try {
-			testQuery?.query();
-		} catch (System.QueryException queryError) {
-			Assert.fail(queryError?.toString());
-		}
+		SoqlTest.validateQuery(testQuery, expected);
 		Test.stopTest();
 
 		String key = owner?.getKey();


### PR DESCRIPTION
Follow up to #130 , fixes two more tests that were still failing after the fix was applied, when run as a non-admin user:

```
SoqlTest.shouldAddSubqueryBindsToParent
System.AssertException: Assertion Failed: Assertion failed: System.QueryException: Didn't understand relationship 'Opportunities' in FROM part of query call. If you are attempting to use a custom relationship, be sure to append the '__r' after the custom relationship name. Please reference your WSDL or the describe call for the appropriate names. Query: [SELECT Id, (SELECT Id FROM Opportunities WHERE OwnerId = :ownerId) FROM Account]
Stack trace: | External entry point Class.SoqlTest.shouldAddSubqueryBindsToParent: line 1420, column 1

SoqlTest.shouldAddInnerQueryBindsToParent
Error message: | System.AssertException: Assertion Failed: Assertion failed: System.QueryException: No such column 'AccountId' on entity 'Case'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name. Please reference your WSDL or the describe call for the appropriate names. Query: [SELECT Id FROM Account WHERE Id IN (SELECT AccountId FROM Case WHERE OwnerId = :ownerId)]
Stack trace: | External entry point Class.SoqlTest.shouldAddInnerQueryBindsToParent: line 1399, column 1
```