### PR TITLE
Fix wiki sync permissions error

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -6,6 +6,11 @@ on:
     paths: ["wiki/**"]
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   sync-wiki:
     runs-on: ubuntu-latest
@@ -25,18 +30,41 @@ jobs:
       - name: Sync Wiki Files
         run: |
           # Copy the changes from the local wiki files to the *actual* wiki repository connected to Github's Wiki feature
+          set -e
+
+          # Verify wiki directory exists
+          if [ ! -d "wiki" ]; then
+            echo "❌ No wiki directory found in main repository"
+            exit 1
+          fi
+
+          # Clean and copy files
           find wiki-repo -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
           cp -r wiki/* wiki-repo/
+
           cd wiki-repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+
+          # Check if there are any changes
           if git diff --quiet && git diff --staged --quiet; then
-            echo "No changes to sync"
+            echo "ℹ️ No changes to sync"
             exit 0
           fi
+
+          # Show what's being synced
+          echo "📋 Changes detected:"
+          git status --porcelain
+
+          # Commit and push changes
           git add .
           git commit -m "Sync wiki from main repository
+
           🤖 Automated sync from main repository
           Co-Authored-By: GitHub Action <action@github.com>"
+
+          # Set up authentication and push
+          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git
           git push origin master
-          echo "📖 Wiki files have been synced from main repository to GitHub wiki"
+
+          echo "✅ Wiki files have been synced from main repository to GitHub wiki"


### PR DESCRIPTION
## Problem
The sync-wiki.yml workflow is failing with a 403 permission denied error when trying to push to the wiki repository:

```
remote: {"auth_status":"access_denied_to_user","body":"Permission to jasonsiders/apex-database-layer.wiki.git denied to github-actions[bot]."}
fatal: unable to access 'https://github.com/jasonsiders/apex-database-layer.wiki/': The requested URL returned error: 403
```

## Solution
1. **Added proper workflow permissions**: `contents: write`, `pages: write`, `id-token: write`
2. **Enhanced authentication**: Sets explicit remote URL with token authentication for wiki repository
3. **Better error handling**: Added validation and clearer logging with emojis
4. **Improved reliability**: Added `set -e` for fail-fast behavior and status reporting

## Changes
- Added `permissions` block to workflow with necessary write permissions
- Enhanced error handling with directory validation
- Added detailed logging of changes being synced
- Set explicit authentication URL for wiki repository push
- Improved commit message formatting

## Testing
- Workflow syntax is valid
- Added proper error handling for missing wiki directory
- Enhanced logging shows exactly what changes are being synced

The added permissions should resolve the authentication issue with the wiki repository.