### PR TITLE
Fix: MockDml Now Respects Lead Convert/Opportunity Flag

### DIFF
--- a/source/classes/MockDml.cls
+++ b/source/classes/MockDml.cls
@@ -520,7 +520,9 @@ global class MockDml extends Dml {
 			Lead leadRecord = new Lead(Id = leadToConvert?.getLeadId());
 			Account accountRecord = new Account(Id = leadToConvert?.getAccountId());
 			Contact contactRecord = new Contact(Id = leadToConvert?.getContactId());
-			Opportunity opportunityRecord = new Opportunity(Id = leadToConvert?.getOpportunityId());
+			Opportunity opportunityRecord = leadToConvert?.isDoNotCreateOpportunity() == false
+				? new Opportunity(Id = leadToConvert?.getOpportunityId())
+				: null;
 			try {
 				// Note: Process resulting records using allOrNone=true, regardless of its original value
 				// This allows injected errors for Accounts/Contacts/Opps to be caught and handled appropriately
@@ -564,7 +566,7 @@ global class MockDml extends Dml {
 
 		private void simulateInsertIfNew(SObject record) {
 			// If the provided record does not already have an Id, simulate an insert operation
-			if (record?.Id == null) {
+			if (record != null && record?.Id == null) {
 				SObjectType objectType = record?.getSObjectType();
 				record.Id = MockRecord.initRecordId(objectType);
 				this.generateMockResult(MockDml.INSERTED, record, true);

--- a/source/classes/MockDmlTest.cls
+++ b/source/classes/MockDmlTest.cls
@@ -47,6 +47,22 @@ private class MockDmlTest {
 		}
 	}
 
+	@IsTest 
+	private static void shouldMockConvertWithNoOpportunity() {
+		Lead lead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
+		Database.LeadConvert leadToConvert = new Database.LeadConvert();
+		leadToConvert?.setConvertedStatus('Foo');
+		leadToConvert?.setLeadId(lead?.Id);
+		leadToConvert?.setDoNotCreateOpportunity(true);
+
+		Test.startTest();
+		Database.LeadConvertResult result = DatabaseLayer.Dml.doConvert(leadToConvert);
+		Test.stopTest();
+
+		Assert.isTrue(result?.isSuccess(), 'Did not succeed');
+		Assert.isNull(result?.getOpportunityId(), 'Should not have a ConvertedOpportunityId');
+	}
+
 	@IsTest
 	private static void shouldMockLeadConvertWithExistingRecords() {
 		Account account = (Account) new MockRecord(Account.SObjectType)?.withId()?.toSObject();


### PR DESCRIPTION
Bug fix. Previously, the `MockDml.doConvert` method _always_ inserted a new Opportunity, regardless of the `Database.LeadConvert`'s `isDoNotCreateOpportunity` flag. 

Now, when this flag returns true, `MockDml` will skip creating an Opportunity, as is expected. 