### PR TITLE
Fix: MockDml correctly sets Lead fields on conversion

### DIFF
--- a/source/classes/MockDml.cls
+++ b/source/classes/MockDml.cls
@@ -537,6 +537,7 @@ global class MockDml extends Dml {
 					?.setField(Lead.ConvertedAccountId, accountRecord?.Id)
 					?.setField(Lead.ConvertedContactId, contactRecord?.Id)
 					?.setField(Lead.ConvertedOpportunityId, opportunityRecord?.Id)
+					?.setField(Lead.IsConverted, true)
 					?.setField(Lead.Status, leadToConvert?.getConvertedStatus())
 					?.toSObject();
 				this.generateMockResult(MockDml.CONVERTED, convertedLead, true);

--- a/source/classes/MockDmlTest.cls
+++ b/source/classes/MockDmlTest.cls
@@ -14,12 +14,13 @@ private class MockDmlTest {
 	// **** TESTS **** //
 	@IsTest
 	private static void shouldMockLeadConvert() {
+		String convertedStatus = 'Foo!';
 		List<Database.LeadConvert> leadsToConvert = new List<Database.LeadConvert>();
 		for (Integer i = 0; i < TEST_SIZE; i++) {
 			Lead lead = (Lead) new MockRecord(Lead.SObjectType)?.withId()?.toSObject();
 			Database.LeadConvert leadToConvert = new Database.LeadConvert();
 			leadToConvert?.setLeadId(lead?.Id);
-			leadToConvert?.setConvertedStatus('Foo!');
+			leadToConvert?.setConvertedStatus(convertedStatus);
 			leadsToConvert?.add(leadToConvert);
 		}
 
@@ -38,10 +39,12 @@ private class MockDmlTest {
 			Assert.isTrue(result?.isSuccess(), 'Did not succeed: ' + result?.getErrors());
 			Id leadId = result?.getLeadId();
 			Lead lead = (Lead) MockDml.CONVERTED.get(leadId);
-			Assert.areNotEqual(null, lead, 'Lead was not converted: ' + leadId);
+			Assert.areNotEqual(null, lead, 'Missing lead: ' + leadId);
 			Assert.areNotEqual(null, lead?.ConvertedAccountId, 'Lead: Missing ConvertedAccountId');
 			Assert.areNotEqual(null, lead?.ConvertedContactId, 'Lead: Missing ConvertedContactId');
 			Assert.areNotEqual(null, lead?.ConvertedOpportunityId, 'Lead: Missing ConvertedOpportunityId');
+			Assert.areEqual(true, lead?.IsConverted, 'Lead: Wrong IsConverted value');
+			Assert.areEqual(convertedStatus, lead?.Status, 'Lead: Wrong Status value');
 			Assert.areEqual(lead?.ConvertedAccountId, result?.getAccountId(), 'Result: Wrong AccountId');
 			Assert.areEqual(lead?.ConvertedContactId, result?.getContactId(), 'Result: Wrong ContactId');
 			Assert.areEqual(lead?.ConvertedOpportunityId, result?.getOpportunityId(), 'Result: Wrong OpportunityId');


### PR DESCRIPTION
Bug fix, similar to #152. The same `MockDml.doConvert` method was not setting the following fields on the Lead during the mock conversion process: 

- `ConvertedAccountId`
- `ConvertedContactId`
- `ConvertedOpportunityId`
- `IsConverted`
- `Status`