### PR TITLE
Fix: Add Email to Leads in DmlTest

### DIFF
--- a/source/classes/DmlTest.cls
+++ b/source/classes/DmlTest.cls
@@ -1020,9 +1020,9 @@ private class DmlTest {
 
 	private static Lead initLead() {
 		return new Lead(
-			Company = 'Tharsis Inc.', 
+			Company = 'Tharsis Inc.',
 			Email = 'jdoe@tharsis.inc.invalid',
-			FirstName = 'John', 
+			FirstName = 'John',
 			LastName = 'Doe'
 		);
 	}


### PR DESCRIPTION
While we can't tailor our package to every subscriber, subscriber orgs commonly require a `Lead.Email` value. This can lead to DML errors which can cause our package's `DmlTest` to fail, because it is asserting that real DML is performed.

As a stop-gap, adding an `Email` value to these methods. If additional issues pop up, we can explore neutering these tests so that they call the DML methods without specifically asserting for a successful operation, but that could risk introducing regressions on future changes.