### PR TITLE
Fix: Use heredoc syntax for multi-line GITHUB_OUTPUT in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,11 @@ jobs:
           done < <(jq -c '.packageDirectories[] | select(.package != null)' sfdx-project.json)
 
           echo "Changed packages: $PACKAGES"
-          echo "packages=$PACKAGES" >> "$GITHUB_OUTPUT"
+          {
+            echo 'packages<<EOF'
+            echo "$PACKAGES"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
 
   create-package-versions:
     name: Create Package Version


### PR DESCRIPTION
The release workflow was failing when multiple packages were detected because the `packages` output was written using the simple `key=value` format, which doesn't support multi-line values. GitHub Actions was rejecting the pretty-printed JSON array with the error `Invalid format '  {'`.

The fix switches to the heredoc delimiter syntax (`key<<EOF ... EOF`) for writing to `$GITHUB_OUTPUT`, which correctly handles multi-line strings. This was surfaced by the Repo Cleanup PR (#165), which triggered detection of two packages simultaneously.