### PR TITLE
Feature: SOQL Parser

### DIFF
--- a/src/core/classes/DatabaseLayer.cls
+++ b/src/core/classes/DatabaseLayer.cls
@@ -59,6 +59,15 @@ global class DatabaseLayer {
 	}
 
 	/**
+	 * @description Convenience method to create a new SOQL query from a raw query string.
+	 * @param queryString The raw SOQL query string to parse
+	 * @return A configured SOQL builder instance
+	 */
+	global static Soql newSoql(String queryString) {
+		return INSTANCE?.currentSoql?.newQuery(queryString);
+	}
+
+	/**
 	 * @description Primary access point for Duplicates operations. Returns the currently configured Duplicates instance.
 	 * @return The current Duplicates instance (real or mock based on configuration)
 	 */
@@ -171,6 +180,16 @@ global class DatabaseLayer {
 		global Soql newQuery(SObjectType objectType) {
 			Soql query = (this.useMocks == true) ? new MockSoql(INSTANCE) : new Soql(INSTANCE);
 			return query?.setFrom(objectType)?.toSoql();
+		}
+
+		/**
+		 * @description Creates a new SOQL query builder by parsing a raw SOQL string.
+		 * @param queryString The raw SOQL query string to parse
+		 * @return A configured SOQL builder instance (real or mock based on current configuration)
+		 */
+		global Soql newQuery(String queryString) {
+			Soql query = (this.useMocks == true) ? new MockSoql(INSTANCE, queryString) : new Soql(queryString);
+			return query?.toSoql();
 		}
 
 		private DatabaseLayer.SoqlProvider useMocks(Boolean value) {

--- a/src/core/classes/MockSoql.cls
+++ b/src/core/classes/MockSoql.cls
@@ -18,6 +18,7 @@ global class MockSoql extends Soql {
 
 	/**
 	 * @description Constructor for MockSoql instance with raw SOQL query string.
+	 * @param factory The DatabaseLayer factory instance
 	 * @param queryString The raw SOQL query string to parse
 	 */
 	public MockSoql(DatabaseLayer factory, String queryString) {

--- a/src/core/classes/MockSoql.cls
+++ b/src/core/classes/MockSoql.cls
@@ -18,7 +18,6 @@ global class MockSoql extends Soql {
 
 	/**
 	 * @description Constructor for MockSoql instance with raw SOQL query string.
-	 * @param factory The DatabaseLayer factory instance
 	 * @param queryString The raw SOQL query string to parse
 	 */
 	public MockSoql(DatabaseLayer factory, String queryString) {

--- a/src/core/classes/MockSoql.cls
+++ b/src/core/classes/MockSoql.cls
@@ -16,6 +16,15 @@ global class MockSoql extends Soql {
 		super(factory);
 	}
 
+	/**
+	 * @description Constructor for MockSoql instance with raw SOQL query string.
+	 * @param factory The DatabaseLayer factory instance
+	 * @param queryString The raw SOQL query string to parse
+	 */
+	public MockSoql(DatabaseLayer factory, String queryString) {
+		super(queryString);
+	}
+
 	// **** STATIC **** //
 	/**
 	 * @description Sets a global mock simulator to be used for all SOQL queries unless overridden.

--- a/src/core/classes/Soql.cls
+++ b/src/core/classes/Soql.cls
@@ -1384,11 +1384,9 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 					return value;
 				}
 			}
-			// Check for datetime literals (YYYY-MM-DD with T component)
 			if (value != null && value.length() >= 19 && value.contains('T') && this.isValidDateTimePrefix(value)) {
 				return value;
 			}
-			// Else, treat the value as a normal String:
 			return this.operator?.processStringValue(value);
 		}
 

--- a/src/core/classes/Soql.cls
+++ b/src/core/classes/Soql.cls
@@ -45,6 +45,15 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 	}
 
 	/**
+	 * @description String-based constructor: parse raw SOQL into builder state
+	 * @param queryString The raw SOQL query string to parse
+	 */
+	public Soql(String queryString) {
+		super();
+		new SoqlParser().parse(this, queryString);
+	}
+
+	/**
 	 * @description Executes an aggregate query and returns mockable AggregateResult wrappers.
 	 * @return List of Soql.AggregateResult objects wrapping Schema.AggregateResult
 	 */
@@ -877,6 +886,56 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 			return this;
 		}
 
+		/**
+		 * @description Sets the FROM clause from a string (used by parser and InnerQuery(String))
+		 * @param entityName The entity name to query from
+		 * @return This Builder instance for method chaining
+		 */
+		global Soql.Builder setFrom(String entityName) {
+			this.entity = entityName;
+			return this;
+		}
+
+		/**
+		 * @description Replace the entire WHERE criteria tree (used by parser)
+		 * @param criteria The ConditionalLogic criteria to use
+		 * @return This Builder instance for method chaining
+		 */
+		global Soql.Builder setWhereCriteria(Soql.ConditionalLogic criteria) {
+			this.whereCriteria = criteria;
+			return this;
+		}
+
+		/**
+		 * @description Replace the entire HAVING criteria tree (used by parser)
+		 * @param criteria The ConditionalLogic criteria to use
+		 * @return This Builder instance for method chaining
+		 */
+		global Soql.Builder setHavingCriteria(Soql.ConditionalLogic criteria) {
+			this.havingCriteria = criteria;
+			return this;
+		}
+
+		/**
+		 * @description Add a pre-formatted ORDER BY token verbatim (preserves round-trip fidelity)
+		 * @param rawClause The raw ORDER BY clause to add
+		 * @return This Builder instance for method chaining
+		 */
+		global Soql.Builder addRawOrderBy(String rawClause) {
+			this.orderByClauses?.add(rawClause);
+			return this;
+		}
+
+		/**
+		 * @description Set WITH clause to any value (generalizes withSecurityEnforced)
+		 * @param value The WITH clause value
+		 * @return This Builder instance for method chaining
+		 */
+		global Soql.Builder setWithClause(String value) {
+			this.withClause = value;
+			return this;
+		}
+
 		// * USING SCOPE *
 		/**
 		 * @description Sets the USING SCOPE clause.
@@ -1538,6 +1597,15 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 		global InnerQuery(SObjectType objectType) {
 			this();
 			this.setFrom(objectType);
+		}
+
+		/**
+		 * @description Constructor that sets the FROM clause to the specified entity name string.
+		 * @param entityName The entity name to query from
+		 */
+		global InnerQuery(String entityName) {
+			this();
+			this.setFrom(entityName);
 		}
 
 		global override String toString() {

--- a/src/core/classes/Soql.cls
+++ b/src/core/classes/Soql.cls
@@ -1382,8 +1382,30 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 					return value;
 				}
 			}
+			// Check for datetime literals (YYYY-MM-DD with T component)
+			if (value != null && value.length() >= 19 && value.contains('T') && this.isValidDateTimePrefix(value)) {
+				return value;
+			}
 			// Else, treat the value as a normal String:
 			return this.operator?.processStringValue(value);
+		}
+
+		private Boolean isValidDateTimePrefix(String value) {
+			if (value == null || value.length() < 10) {
+				return false;
+			}
+			String prefix = value.substring(0, 10);
+			if (prefix.substring(4, 5) != '-' || prefix.substring(7, 8) != '-') {
+				return false;
+			}
+			try {
+				Integer year = Integer.valueOf(prefix.substring(0, 4));
+				Integer month = Integer.valueOf(prefix.substring(5, 7));
+				Integer day = Integer.valueOf(prefix.substring(8, 10));
+				return month >= 1 && month <= 12 && day >= 1 && day <= 31 && year >= 1000 && year <= 9999;
+			} catch (Exception e) {
+				return false;
+			}
 		}
 	}
 

--- a/src/core/classes/Soql.cls
+++ b/src/core/classes/Soql.cls
@@ -19,6 +19,8 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 	global static final Operator NOT_ENDS_WITH = new Soql.EndsWithOperator('NOT LIKE');
 	global static final Operator CONTAINS = new Soql.ContainsOperator('LIKE');
 	global static final Operator NOT_CONTAINS = new Soql.ContainsOperator('NOT LIKE');
+	global static final Operator LIKE_RAW = new Soql.Operator('LIKE');
+	global static final Operator NOT_LIKE_RAW = new Soql.Operator('NOT LIKE');
 	// Other constants
 	private static final Soql.LogicType DEFAULT_LOGIC_TYPE = Soql.LogicType.ALL_CONDITIONS;
 	private static final String ID_REFERENCE = 'Id';
@@ -48,7 +50,7 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 	 * @description String-based constructor: parse raw SOQL into builder state
 	 * @param queryString The raw SOQL query string to parse
 	 */
-	public Soql(String queryString) {
+	protected Soql(String queryString) {
 		super();
 		new SoqlParser().parse(this, queryString);
 	}

--- a/src/core/classes/Soql.cls
+++ b/src/core/classes/Soql.cls
@@ -19,8 +19,6 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 	global static final Operator NOT_ENDS_WITH = new Soql.EndsWithOperator('NOT LIKE');
 	global static final Operator CONTAINS = new Soql.ContainsOperator('LIKE');
 	global static final Operator NOT_CONTAINS = new Soql.ContainsOperator('NOT LIKE');
-	global static final Operator LIKE_RAW = new Soql.Operator('LIKE');
-	global static final Operator NOT_LIKE_RAW = new Soql.Operator('NOT LIKE');
 	// Other constants
 	private static final Soql.LogicType DEFAULT_LOGIC_TYPE = Soql.LogicType.ALL_CONDITIONS;
 	private static final String ID_REFERENCE = 'Id';

--- a/src/core/classes/Soql.cls
+++ b/src/core/classes/Soql.cls
@@ -889,7 +889,7 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 		}
 
 		/**
-		 * @description Sets the FROM clause from a string (used by parser and InnerQuery(String))
+		 * @description Sets the FROM clause to the specified entity name string.
 		 * @param entityName The entity name to query from
 		 * @return This Builder instance for method chaining
 		 */
@@ -899,7 +899,7 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 		}
 
 		/**
-		 * @description Replace the entire WHERE criteria tree (used by parser)
+		 * @description Replaces the entire WHERE criteria tree.
 		 * @param criteria The ConditionalLogic criteria to use
 		 * @return This Builder instance for method chaining
 		 */
@@ -909,7 +909,7 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 		}
 
 		/**
-		 * @description Replace the entire HAVING criteria tree (used by parser)
+		 * @description Replaces the entire HAVING criteria tree.
 		 * @param criteria The ConditionalLogic criteria to use
 		 * @return This Builder instance for method chaining
 		 */

--- a/src/core/classes/Soql.cls
+++ b/src/core/classes/Soql.cls
@@ -50,7 +50,7 @@ global inherited sharing virtual class Soql extends Soql.Builder {
 	 * @description String-based constructor: parse raw SOQL into builder state
 	 * @param queryString The raw SOQL query string to parse
 	 */
-	protected Soql(String queryString) {
+	public Soql(String queryString) {
 		super();
 		new SoqlParser().parse(this, queryString);
 	}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -3,7 +3,9 @@
  * Handles all standard SOQL clauses including SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY,
  * LIMIT, OFFSET, USING SCOPE, WITH, FOR, and ALL ROWS.
  */
-@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.ExcessiveClassLength,PMD.PropertyNamingConventions')
+@SuppressWarnings(
+	'PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.ExcessiveClassLength,PMD.PropertyNamingConventions'
+)
 public class SoqlParser {
 	/** @description Shared OperatorLexer instance for resolving SOQL operator tokens */
 	private static final SoqlParser.OperatorLexer OPERATORS = new SoqlParser.OperatorLexer();
@@ -70,7 +72,6 @@ public class SoqlParser {
 		}
 		private set;
 	}
-
 	/**
 	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder
 	 * @param builder The {@link Soql.Builder} to populate with parsed clauses
@@ -691,8 +692,8 @@ public class SoqlParser {
 		 * @return True if the operator matches at this position with valid word boundaries
 		 */
 		private Boolean isOperatorAt(String str, Integer i, String operator) {
-			return str.substring(i, i + operator.length()).toUpperCase() == operator
-				&& this.isAtWordBoundary(str, i, operator);
+			return str.substring(i, i + operator.length()).toUpperCase() == operator &&
+				this.isAtWordBoundary(str, i, operator);
 		}
 
 		/**

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -5,32 +5,46 @@
  */
 @SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.PropertyNamingConventions')
 public class SoqlParser {
+	/** @description SOQL keyword string for the ALL ROWS clause */
 	// prettier-ignore
 	private static final String ALL_ROWS_KEYWORD { get { return 'ALL ROWS'; } }
+	/** @description SOQL keyword string for the FOR clause */
 	// prettier-ignore
 	private static final String FOR_KEYWORD { get { return 'FOR'; } }
+	/** @description SOQL keyword string for the FROM clause */
 	// prettier-ignore
 	private static final String FROM_KEYWORD { get { return 'FROM'; } }
+	/** @description SOQL keyword string for the GROUP BY clause */
 	// prettier-ignore
 	private static final String GROUP_BY_KEYWORD { get { return 'GROUP BY'; } }
+	/** @description SOQL keyword string for the HAVING clause */
 	// prettier-ignore
 	private static final String HAVING_KEYWORD { get { return 'HAVING'; } }
+	/** @description SOQL keyword string for the LIMIT clause */
 	// prettier-ignore
 	private static final String LIMIT_KEYWORD { get { return 'LIMIT'; } }
+	/** @description SOQL keyword string for the OFFSET clause */
 	// prettier-ignore
 	private static final String OFFSET_KEYWORD { get { return 'OFFSET'; } }
+	/** @description SOQL keyword string for the ORDER BY clause */
 	// prettier-ignore
 	private static final String ORDER_BY_KEYWORD { get { return 'ORDER BY'; } }
+	/** @description SOQL keyword string for the SELECT clause */
 	// prettier-ignore
 	private static final String SELECT_KEYWORD { get { return 'SELECT'; } }
+	/** @description SOQL keyword string for the USING SCOPE clause */
 	// prettier-ignore
 	private static final String USING_SCOPE_KEYWORD { get { return 'USING SCOPE'; } }
+	/** @description SOQL keyword string for the WHERE clause */
 	// prettier-ignore
 	private static final String WHERE_KEYWORD { get { return 'WHERE'; } }
+	/** @description SOQL keyword string for the WITH clause */
 	// prettier-ignore
 	private static final String WITH_KEYWORD { get { return 'WITH'; } }
+	/** @description Maximum integer value, used as a sentinel for keyword position comparisons */
 	// prettier-ignore
 	private static final Integer MAX_INT { get { return 2147483647; } }
+	/** @description Ordered list of all recognized SOQL keywords used for clause position detection */
 	// prettier-ignore
 	private static final List<String> ALL_KEYWORDS {
 		get {
@@ -52,7 +66,9 @@ public class SoqlParser {
 		}
 		private set;
 	}
+	/** @description Shared OperatorLexer instance for resolving SOQL operator tokens */
 	private static final SoqlParser.OperatorLexer OPERATORS = new SoqlParser.OperatorLexer();
+	/** @description Shared ValueParser instance for converting raw SOQL value tokens to Apex types */
 	private static final SoqlParser.ValueParser VALUE_PARSER = new SoqlParser.ValueParser();
 
 	/**
@@ -63,7 +79,7 @@ public class SoqlParser {
 	public void parse(Soql.Builder builder, String str) {
 		try {
 			Map<String, Integer> positions = new Scanner(str)?.scan();
-			ParseContext ctx = new ParseContext(str, positions);
+			SoqlParser.ParseContext ctx = new SoqlParser.ParseContext(str, positions);
 			this.applyParsers(builder, ctx);
 		} catch (Exception error) {
 			String msg = 'Invalid query: ' + str + '\n' + error + '\n' + error?.getStackTraceString();
@@ -74,9 +90,9 @@ public class SoqlParser {
 	/**
 	 * @description Dispatches each SOQL clause to its corresponding parse method.
 	 * @param builder The {@link Soql.Builder} to populate
-	 * @param ctx The {@link ParseContext} containing the query string and keyword positions
+	 * @param ctx The {@link SoqlParser.ParseContext} containing the query string and keyword positions
 	 */
-	private void applyParsers(Soql.Builder builder, ParseContext ctx) {
+	private void applyParsers(Soql.Builder builder, SoqlParser.ParseContext ctx) {
 		this.parseSelect(builder, this.extractClause(ctx, SELECT_KEYWORD));
 		this.parseFrom(builder, this.extractClause(ctx, FROM_KEYWORD));
 		this.parseWhere(builder, this.extractClause(ctx, WHERE_KEYWORD));
@@ -115,21 +131,34 @@ public class SoqlParser {
 	/**
 	 * @description Extracts the text of a clause by slicing between the start of {@code keyword}
 	 * and the start of the next keyword, trimming the keyword name and surrounding whitespace.
-	 * @param ctx The {@link ParseContext} holding the query and positions
+	 * @param ctx The {@link SoqlParser.ParseContext} holding the query and positions
 	 * @param keyword The keyword whose clause content to extract
 	 * @return The trimmed clause text, or an empty string if the keyword is absent
 	 */
-	private String extractClause(ParseContext ctx, String keyword) {
+	private String extractClause(SoqlParser.ParseContext ctx, String keyword) {
 		Integer startPos = ctx.positions?.get(keyword);
 		if (startPos != null) {
 			String nextKeyword = this.getNextKeyword(ctx.positions, keyword);
-			Integer endPos = nextKeyword == null
-				? ctx.queryString.length()
-				: (ctx.positions.get(nextKeyword) ?? ctx.queryString.length());
-			return ctx.queryString.substring(startPos + keyword.length(), endPos).trim();
+			Integer endPos = this.getClauseEndPos(ctx, nextKeyword);
+			return ctx?.queryString.substring(startPos + keyword?.length(), endPos)?.trim();
 		} else {
 			return '';
 		}
+	}
+
+	/**
+	 * @description Returns the end position of a clause: the start of {@code nextKeyword} if present,
+	 * or the end of the query string if there is no following keyword.
+	 * @param ctx The {@link SoqlParser.ParseContext} containing query and positions
+	 * @param nextKeyword The keyword immediately following the current clause, or null if none
+	 * @return The character index at which the current clause ends
+	 */
+	private Integer getClauseEndPos(SoqlParser.ParseContext ctx, String nextKeyword) {
+		if (nextKeyword == null) {
+			return ctx?.queryString?.length();
+		}
+		Integer nextPos = ctx?.positions?.get(nextKeyword);
+		return nextPos != null ? nextPos : ctx?.queryString?.length();
 	}
 
 	/**
@@ -258,7 +287,7 @@ public class SoqlParser {
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic()?.setLogicType(Soql.LogicType.ALL_CONDITIONS);
 		for (String part : andParts) {
 			Soql.Criteria factor = this.parseFactor(part);
-			logic.addCondition(factor);
+			logic?.addCondition(factor);
 		}
 		return logic;
 	}
@@ -582,6 +611,11 @@ public class SoqlParser {
 	 * @description Converts raw SOQL value tokens into their corresponding Apex types.
 	 */
 	private class ValueParser {
+		/**
+		 * @description Converts a raw SOQL token into its corresponding Apex type
+		 * @param token The raw token string from the query
+		 * @return The parsed Apex value
+		 */
 		private Object parse(String token) {
 			String trimmed = token?.trim();
 			String upper = trimmed?.toUpperCase();
@@ -606,16 +640,35 @@ public class SoqlParser {
 			}
 		}
 
+		/**
+		 * @description Returns true if {@code str} matches the YYYY-MM-DD date format
+		 * @param str The uppercase string to test
+		 * @return True if the string represents a date
+		 */
 		private Boolean isDate(String str) {
 			return str?.length() == 10 && this.isValidDatePrefix(str);
 		}
 
+		/**
+		 * @description Returns true if {@code str} matches the YYYY-MM-DDTHH:mm:ssZ datetime format
+		 * @param str The uppercase string to test
+		 * @return True if the string represents a datetime
+		 */
 		private Boolean isDateTime(String str) {
 			return str?.length() >= 10 && str?.contains('T') == true && this.isValidDatePrefix(str?.substring(0, 10));
 		}
 
+		/**
+		 * @description Validates that the first ten characters of a string form a plausible YYYY-MM-DD date
+		 * @param datePrefix The ten-character substring to validate
+		 * @return True if the prefix has valid separators and numeric month/day values
+		 */
 		private Boolean isValidDatePrefix(String datePrefix) {
-			if (datePrefix?.length() != 10 || datePrefix?.substring(4, 5) != '-' || datePrefix?.substring(7, 8) != '-') {
+			if (
+				datePrefix?.length() != 10 ||
+				datePrefix?.substring(4, 5) != '-' ||
+				datePrefix?.substring(7, 8) != '-'
+			) {
 				return false;
 			}
 			try {
@@ -627,6 +680,11 @@ public class SoqlParser {
 			}
 		}
 
+		/**
+		 * @description Parses a date string into an Apex {@link Date}, returning the raw string if parsing fails
+		 * @param trimmed The date string to parse
+		 * @return A {@link Date} or the original string on failure
+		 */
 		private Object parseDate(String trimmed) {
 			try {
 				return Date.valueOf(trimmed);
@@ -635,6 +693,11 @@ public class SoqlParser {
 			}
 		}
 
+		/**
+		 * @description Parses a datetime string into an Apex {@link DateTime}, returning the raw string if parsing fails
+		 * @param trimmed The datetime string to parse
+		 * @return A {@link DateTime} or the original string on failure
+		 */
 		private Object parseDateTime(String trimmed) {
 			try {
 				return DateTime.valueOfGmt(trimmed);
@@ -643,6 +706,12 @@ public class SoqlParser {
 			}
 		}
 
+		/**
+		 * @description Parses a parenthesized list token into a {@link List} of string values,
+		 * or returns the raw token if the list body contains a subquery
+		 * @param trimmed The parenthesized list string, e.g. {@code ('a', 'b')}
+		 * @return A {@link List<String>} of values, or the original token for subqueries
+		 */
 		private Object parseList(String trimmed) {
 			String body = trimmed.substring(1, trimmed.length() - 1);
 			if (body.toUpperCase().contains('SELECT')) {
@@ -657,7 +726,11 @@ public class SoqlParser {
 			return result;
 		}
 
-		// String-aware comma split for list bodies (no paren tracking needed for IN list items)
+		/**
+		 * @description Splits a comma-delimited list body on top-level commas, respecting string literals
+		 * @param str The list body string to split (without surrounding parentheses)
+		 * @return A list of raw item strings
+		 */
 		private List<String> splitList(String str) {
 			List<String> parts = new List<String>();
 			Boolean inString = false;
@@ -675,6 +748,11 @@ public class SoqlParser {
 			return parts;
 		}
 
+		/**
+		 * @description Parses a numeric string as an Integer, then as a Decimal, falling back to the raw string
+		 * @param trimmed The numeric string to parse
+		 * @return An {@link Integer}, {@link Decimal}, or the original string
+		 */
 		private Object parseNumeric(String trimmed) {
 			try {
 				return Integer.valueOf(trimmed);
@@ -687,6 +765,11 @@ public class SoqlParser {
 			}
 		}
 
+		/**
+		 * @description Unquotes and unescapes a single-quoted SOQL string literal
+		 * @param trimmed The quoted string literal, including surrounding single quotes
+		 * @return The unquoted string value with escaped single quotes resolved
+		 */
 		private Object parseStringLiteral(String trimmed) {
 			return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
 		}
@@ -697,11 +780,20 @@ public class SoqlParser {
 	 * ordered by precedence (multi-word and longer tokens first to prevent partial matches).
 	 */
 	private class OperatorLexer {
+		/**
+		 * @description Returns SOQL operator symbols ordered by matching precedence, longest first
+		 * @return An ordered list of operator symbol strings
+		 */
 		private List<String> precedence() {
 			// prettier-ignore
 			return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
 		}
 
+		/**
+		 * @description Resolves an operator symbol string to its {@link Soql.Operator} enum value
+		 * @param symbol The operator symbol (e.g. {@code !=}, {@code IN}, {@code LIKE})
+		 * @return The corresponding {@link Soql.Operator}, or null if unrecognized
+		 */
 		private Soql.Operator resolve(String symbol) {
 			// prettier-ignore
 			return new Map<String, Soql.Operator>{
@@ -718,6 +810,13 @@ public class SoqlParser {
 			}.get(symbol);
 		}
 
+		/**
+		 * @description Finds the character index of the first top-level occurrence of {@code operator}
+		 * in {@code str}, skipping occurrences inside parentheses or string literals
+		 * @param str The expression string to search
+		 * @param operator The operator symbol to find
+		 * @return The index of the operator, or -1 if not found
+		 */
 		private Integer findPosition(String str, String operator) {
 			String strUpper = str.toUpperCase();
 			Integer parenDepth = 0;
@@ -727,15 +826,8 @@ public class SoqlParser {
 				if (character == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
 					inString = (inString == false);
 				} else if (inString == false) {
-					if (character == '(') {
-						parenDepth++;
-					} else if (character == ')') {
-						parenDepth--;
-					} else if (
-						parenDepth == 0 &&
-						strUpper.substring(i, i + operator.length()) == operator &&
-						this.isAtWordBoundary(str, i, operator)
-					) {
+					parenDepth += character == '(' ? 1 : character == ')' ? -1 : 0;
+					if (parenDepth == 0 && this.isOperatorAt(strUpper, str, i, operator)) {
 						return i;
 					}
 				}
@@ -743,6 +835,28 @@ public class SoqlParser {
 			return -1;
 		}
 
+		/**
+		 * @description Returns true if {@code operator} appears at position {@code i} in {@code strUpper}
+		 * and is at a valid word boundary
+		 * @param strUpper The uppercase version of the expression string
+		 * @param str The original expression string (used for boundary check)
+		 * @param i The position to test
+		 * @param operator The operator symbol to match
+		 * @return True if the operator matches at this position with valid word boundaries
+		 */
+		private Boolean isOperatorAt(String strUpper, String str, Integer i, String operator) {
+			return strUpper.substring(i, i + operator.length()) == operator
+				&& this.isAtWordBoundary(str, i, operator);
+		}
+
+		/**
+		 * @description Returns true if the substring at position {@code i} is surrounded by spaces
+		 * or string boundaries, ensuring it is a standalone operator token
+		 * @param str The expression string
+		 * @param i The start index of the potential operator match
+		 * @param operator The operator symbol being tested
+		 * @return True if the match is at a word boundary
+		 */
 		private Boolean isAtWordBoundary(String str, Integer i, String operator) {
 			Integer afterPos = i + operator.length();
 			Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
@@ -762,7 +876,7 @@ public class SoqlParser {
 		private final Map<String, Integer> positions;
 
 		/**
-		 * @description Constructs a ParseContext with the given query and positions.
+		 * @description Constructs a SoqlParser.ParseContext with the given query and positions.
 		 * @param queryString The raw SOQL query string
 		 * @param positions The keyword position map produced by {@link Scanner#scan}
 		 */
@@ -777,10 +891,15 @@ public class SoqlParser {
 	 * and records the starting position of each top-level keyword.
 	 */
 	private class Scanner {
+		/** @description Map of recognized SOQL keyword to its starting character index in the query */
 		private final Map<String, Integer> positions;
+		/** @description The raw query string being scanned */
 		private final String rawQuery;
+		/** @description Uppercase version of the query string, used for case-insensitive keyword matching */
 		private final String upperQuery;
+		/** @description Tracks whether the scanner is currently inside a string literal */
 		private Boolean inString;
+		/** @description Tracks the current parenthesis nesting depth */
 		private Integer parenDepth;
 
 		/**

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -31,17 +31,86 @@ public class SoqlParser {
 	private static final String WITH_KEYWORD { get { return 'WITH'; } }
 	// prettier-ignore
 	private static final Integer MAX_INT { get { return 2147483647; } }
-	// prettier-ignore
-	private static final List<String> ALL_KEYWORDS { get { return new List<String>{ SELECT_KEYWORD, FROM_KEYWORD, WHERE_KEYWORD, GROUP_BY_KEYWORD, HAVING_KEYWORD, ORDER_BY_KEYWORD, LIMIT_KEYWORD, OFFSET_KEYWORD, USING_SCOPE_KEYWORD, WITH_KEYWORD, FOR_KEYWORD, ALL_ROWS_KEYWORD }; } }
-	// prettier-ignore
-	private static final Map<String, Soql.Function> FUNCTION_MAP { get { return new Map<String, Soql.Function>{ 'AVG' => Soql.Function.AVG, 'CALENDAR_MONTH' => Soql.Function.CALENDAR_MONTH, 'CALENDAR_QUARTER' => Soql.Function.CALENDAR_QUARTER, 'CALENDAR_YEAR' => Soql.Function.CALENDAR_YEAR, 'COUNT' => Soql.Function.COUNT, 'COUNT_DISTINCT' => Soql.Function.COUNT_DISTINCT, 'DAY_IN_MONTH' => Soql.Function.DAY_IN_MONTH, 'DAY_IN_WEEK' => Soql.Function.DAY_IN_WEEK, 'DAY_IN_YEAR' => Soql.Function.DAY_IN_YEAR, 'DAY_ONLY' => Soql.Function.DAY_ONLY, 'FISCAL_MONTH' => Soql.Function.FISCAL_MONTH, 'FISCAL_QUARTER' => Soql.Function.FISCAL_QUARTER, 'FISCAL_YEAR' => Soql.Function.FISCAL_YEAR, 'FORMAT' => Soql.Function.FORMAT, 'HOUR_IN_DAY' => Soql.Function.HOUR_IN_DAY, 'MAX' => Soql.Function.MAX, 'MIN' => Soql.Function.MIN, 'SUM' => Soql.Function.SUM, 'WEEK_IN_MONTH' => Soql.Function.WEEK_IN_MONTH, 'WEEK_IN_YEAR' => Soql.Function.WEEK_IN_YEAR }; } }
+	private static final List<String> ALL_KEYWORDS {
+		get {
+			return new List<String>{
+				SELECT_KEYWORD,
+				FROM_KEYWORD,
+				WHERE_KEYWORD,
+				GROUP_BY_KEYWORD,
+				HAVING_KEYWORD,
+				ORDER_BY_KEYWORD,
+				LIMIT_KEYWORD,
+				OFFSET_KEYWORD,
+				USING_SCOPE_KEYWORD,
+				WITH_KEYWORD,
+				FOR_KEYWORD,
+				ALL_ROWS_KEYWORD
+			};
+		}
+	}
+	private static final Map<String, Soql.Function> FUNCTION_MAP {
+		get {
+			return new Map<String, Soql.Function>{
+				'AVG' => Soql.Function.AVG,
+				'CALENDAR_MONTH' => Soql.Function.CALENDAR_MONTH,
+				'CALENDAR_QUARTER' => Soql.Function.CALENDAR_QUARTER,
+				'CALENDAR_YEAR' => Soql.Function.CALENDAR_YEAR,
+				'COUNT' => Soql.Function.COUNT,
+				'COUNT_DISTINCT' => Soql.Function.COUNT_DISTINCT,
+				'DAY_IN_MONTH' => Soql.Function.DAY_IN_MONTH,
+				'DAY_IN_WEEK' => Soql.Function.DAY_IN_WEEK,
+				'DAY_IN_YEAR' => Soql.Function.DAY_IN_YEAR,
+				'DAY_ONLY' => Soql.Function.DAY_ONLY,
+				'FISCAL_MONTH' => Soql.Function.FISCAL_MONTH,
+				'FISCAL_QUARTER' => Soql.Function.FISCAL_QUARTER,
+				'FISCAL_YEAR' => Soql.Function.FISCAL_YEAR,
+				'FORMAT' => Soql.Function.FORMAT,
+				'HOUR_IN_DAY' => Soql.Function.HOUR_IN_DAY,
+				'MAX' => Soql.Function.MAX,
+				'MIN' => Soql.Function.MIN,
+				'SUM' => Soql.Function.SUM,
+				'WEEK_IN_MONTH' => Soql.Function.WEEK_IN_MONTH,
+				'WEEK_IN_YEAR' => Soql.Function.WEEK_IN_YEAR
+			};
+		}
+	}
 	// Operators ordered by precedence: multi-word and longer tokens first to prevent partial matches
-	// prettier-ignore
-	private static final Map<String, Soql.Operator> OPERATOR_MAP { get { return new Map<String, Soql.Operator>{ '!=' => Soql.NOT_EQUALS, '<' => Soql.LESS_THAN, '<=' => Soql.LESS_OR_EQUAL, '=' => Soql.EQUALS, '>' => Soql.GREATER_THAN, '>=' => Soql.GREATER_OR_EQUAL, 'IN' => Soql.IN_COLLECTION, 'LIKE' => Soql.LIKE_RAW, 'NOT IN' => Soql.NOT_IN_COLLECTION, 'NOT LIKE' => Soql.NOT_LIKE_RAW }; } }
-	// prettier-ignore
-	private static final List<String> OPERATOR_PRECEDENCE { get { return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' }; } }
-	// prettier-ignore
-	private static final Map<String, Soql.Scope> SCOPE_MAP { get { return new Map<String, Soql.Scope>{ 'DELEGATED' => Soql.Scope.DELEGATED, 'EVERYTHING' => Soql.Scope.EVERYTHING, 'MINE' => Soql.Scope.MINE, 'MINE_AND_MY_GROUPS' => Soql.Scope.MINE_AND_MY_GROUPS, 'MY_TEAM_TERRITORY' => Soql.Scope.MY_TEAM_TERRITORY, 'MY_TERRITORY' => Soql.Scope.MY_TERRITORY, 'TEAM' => Soql.Scope.TEAM }; } }
+	private static final Map<String, Soql.Operator> OPERATOR_MAP {
+		get {
+			return new Map<String, Soql.Operator>{
+				'!=' => Soql.NOT_EQUALS,
+				'<' => Soql.LESS_THAN,
+				'<=' => Soql.LESS_OR_EQUAL,
+				'=' => Soql.EQUALS,
+				'>' => Soql.GREATER_THAN,
+				'>=' => Soql.GREATER_OR_EQUAL,
+				'IN' => Soql.IN_COLLECTION,
+				'LIKE' => Soql.LIKE_RAW,
+				'NOT IN' => Soql.NOT_IN_COLLECTION,
+				'NOT LIKE' => Soql.NOT_LIKE_RAW
+			};
+		}
+	}
+	private static final List<String> OPERATOR_PRECEDENCE {
+		get {
+			return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
+		}
+	}
+	private static final Map<String, Soql.Scope> SCOPE_MAP {
+		get {
+			return new Map<String, Soql.Scope>{
+				'DELEGATED' => Soql.Scope.DELEGATED,
+				'EVERYTHING' => Soql.Scope.EVERYTHING,
+				'MINE' => Soql.Scope.MINE,
+				'MINE_AND_MY_GROUPS' => Soql.Scope.MINE_AND_MY_GROUPS,
+				'MY_TEAM_TERRITORY' => Soql.Scope.MY_TEAM_TERRITORY,
+				'MY_TERRITORY' => Soql.Scope.MY_TERRITORY,
+				'TEAM' => Soql.Scope.TEAM
+			};
+		}
+	}
+
 	/**
 	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder.
 	 * @param builder The {@link Soql.Builder} to populate with parsed clauses
@@ -51,8 +120,6 @@ public class SoqlParser {
 		ParseContext ctx = new ParseContext(queryString, new Scanner(queryString).scan());
 		this.applyParsers(builder, ctx);
 	}
-
-	// ── PRIVATE ───────────────────────────────────────────────────────────
 
 	/**
 	 * @description Dispatches each SOQL clause to its corresponding parse method.

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -60,53 +60,8 @@ public class SoqlParser {
 	};
 
 	public void parse(Soql.Builder builder, String queryString) {
-		Map<String, Integer> keywordPositions = this.findKeywordPositions(queryString);
-
-		String selectStr = this.extractClause(queryString, keywordPositions, SELECT_KEYWORD, FROM_KEYWORD);
-		String fromStr = this.extractClause(queryString, keywordPositions, FROM_KEYWORD, this.getNextKeyword(keywordPositions, FROM_KEYWORD));
-		String whereStr = this.extractClause(queryString, keywordPositions, WHERE_KEYWORD, this.getNextKeyword(keywordPositions, WHERE_KEYWORD));
-		String groupByStr = this.extractClause(queryString, keywordPositions, GROUP_BY_KEYWORD, this.getNextKeyword(keywordPositions, GROUP_BY_KEYWORD));
-		String havingStr = this.extractClause(queryString, keywordPositions, HAVING_KEYWORD, this.getNextKeyword(keywordPositions, HAVING_KEYWORD));
-		String orderByStr = this.extractClause(queryString, keywordPositions, ORDER_BY_KEYWORD, this.getNextKeyword(keywordPositions, ORDER_BY_KEYWORD));
-		String limitStr = this.extractClause(queryString, keywordPositions, LIMIT_KEYWORD, this.getNextKeyword(keywordPositions, LIMIT_KEYWORD));
-		String offsetStr = this.extractClause(queryString, keywordPositions, OFFSET_KEYWORD, this.getNextKeyword(keywordPositions, OFFSET_KEYWORD));
-		String usingScopeStr = this.extractClause(queryString, keywordPositions, USING_SCOPE_KEYWORD, this.getNextKeyword(keywordPositions, USING_SCOPE_KEYWORD));
-		String withStr = this.extractClause(queryString, keywordPositions, WITH_KEYWORD, this.getNextKeyword(keywordPositions, WITH_KEYWORD));
-		String forStr = this.extractClause(queryString, keywordPositions, FOR_KEYWORD, this.getNextKeyword(keywordPositions, FOR_KEYWORD));
-		String allRowsStr = this.extractClause(queryString, keywordPositions, ALL_ROWS_KEYWORD, this.getNextKeyword(keywordPositions, ALL_ROWS_KEYWORD));
-
-		this.parseSelect(builder, selectStr);
-		this.parseFrom(builder, fromStr);
-		if (String.isNotBlank(whereStr)) {
-			this.parseWhere(builder, whereStr);
-		}
-		if (String.isNotBlank(groupByStr)) {
-			this.parseGroupBy(builder, groupByStr);
-		}
-		if (String.isNotBlank(havingStr)) {
-			this.parseHaving(builder, havingStr);
-		}
-		if (String.isNotBlank(orderByStr)) {
-			this.parseOrderBy(builder, orderByStr);
-		}
-		if (String.isNotBlank(limitStr)) {
-			this.parseLimit(builder, limitStr);
-		}
-		if (String.isNotBlank(offsetStr)) {
-			this.parseOffset(builder, offsetStr);
-		}
-		if (String.isNotBlank(usingScopeStr)) {
-			this.parseUsingScope(builder, usingScopeStr);
-		}
-		if (String.isNotBlank(withStr)) {
-			this.parseWith(builder, withStr);
-		}
-		if (String.isNotBlank(forStr)) {
-			this.parseFor(builder, forStr);
-		}
-		if (keywordPositions.containsKey(ALL_ROWS_KEYWORD)) {
-			this.parseAllRows(builder);
-		}
+		Map<String, Integer> positions = this.findKeywordPositions(queryString);
+		this.applyParsers(builder, queryString, positions);
 	}
 
 	public Map<String, Integer> findKeywordPositions(String queryString) {
@@ -116,33 +71,23 @@ public class SoqlParser {
 			FROM_KEYWORD, WHERE_KEYWORD, WITH_KEYWORD, HAVING_KEYWORD,
 			LIMIT_KEYWORD, OFFSET_KEYWORD, FOR_KEYWORD, ALL_ROWS_KEYWORD
 		};
-
 		String upper = queryString.toUpperCase();
 		Integer parenDepth = 0;
-		Boolean inStringLiteral = false;
-
+		Boolean inString = false;
 		for (Integer i = 0; i < upper.length(); i++) {
 			String c = queryString.substring(i, i + 1);
-
 			if (c == '\'' && (i == 0 || queryString.substring(i - 1, i) != '\\')) {
-				inStringLiteral = !inStringLiteral;
-			}
-
-			if (!inStringLiteral) {
-				if (c == '(') {
-					parenDepth++;
-				} else if (c == ')') {
-					parenDepth--;
-				}
-			}
-
-			if (parenDepth == 0 && !inStringLiteral) {
+				inString = !inString;
+			} else if (c == '(' && !inString) {
+				parenDepth++;
+			} else if (c == ')' && !inString) {
+				parenDepth--;
+			} else if (parenDepth == 0 && !inString) {
 				for (String keyword : keywords) {
 					Integer endIndex = i + keyword.length();
 					if (endIndex <= upper.length() && upper.substring(i, endIndex) == keyword) {
 						Boolean beforeOk = (i == 0 || upper.substring(i - 1, i) == ' ');
 						Boolean afterOk = (endIndex >= upper.length() || upper.substring(endIndex, endIndex + 1) == ' ');
-
 						if (beforeOk && afterOk && !positions.containsKey(keyword)) {
 							positions.put(keyword, i);
 						}
@@ -150,7 +95,6 @@ public class SoqlParser {
 				}
 			}
 		}
-
 		positions.put(SELECT_KEYWORD, 0);
 		return positions;
 	}
@@ -161,15 +105,12 @@ public class SoqlParser {
 			ORDER_BY_KEYWORD, LIMIT_KEYWORD, OFFSET_KEYWORD, USING_SCOPE_KEYWORD, WITH_KEYWORD,
 			FOR_KEYWORD, ALL_ROWS_KEYWORD
 		};
-
 		Integer currentPos = positions.get(currentKeyword);
 		if (currentPos == null) {
 			return null;
 		}
-
 		String nextKeyword = null;
 		Integer nextPos = MAX_INT;
-
 		for (String keyword : allKeywords) {
 			Integer pos = positions.get(keyword);
 			if (pos != null && pos > currentPos && pos < nextPos) {
@@ -177,7 +118,6 @@ public class SoqlParser {
 				nextKeyword = keyword;
 			}
 		}
-
 		return nextKeyword;
 	}
 
@@ -186,90 +126,21 @@ public class SoqlParser {
 		if (startPos == null) {
 			return '';
 		}
-
-		startPos = startPos + keyword.length();
-
-		Integer endPos;
-		if (nextKeyword == null) {
-			endPos = queryString.length();
-		} else {
-			Integer nextPos = positions.get(nextKeyword);
-			endPos = nextPos != null ? nextPos : queryString.length();
-		}
-
-		String clause = queryString.substring(startPos, endPos).trim();
-		return clause;
+		Integer endPos = this.calculateEndPos(queryString, positions, nextKeyword);
+		return queryString.substring(startPos + keyword.length(), endPos).trim();
 	}
 
-	private void parseSelect(Soql.Builder builder, String selectStr) {
-		builder.deselectAll();
-		List<String> selectItems = this.splitTopLevelKeyword(selectStr, ',');
-
-		for (String item : selectItems) {
-			String trimmed = item.trim();
-			if (trimmed.startsWith('(')) {
-				this.parseSubquery(builder, trimmed);
-			} else if (this.isAggregation(trimmed)) {
-				this.parseAggregation(builder, trimmed);
-			} else {
-				builder.addSelect(trimmed);
+	public Soql.Condition parseCondition(String str) {
+		List<String> operators = new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
+		for (String op : operators) {
+			Integer opPos = this.findOperatorPosition(str, op);
+			if (opPos >= 0) {
+				String fieldName = str.substring(0, opPos).trim();
+				String value = str.substring(opPos + op.length()).trim();
+				return new Soql.Condition(fieldName, OPERATOR_MAP.get(op), this.parseValue(value));
 			}
 		}
-	}
-
-	private Boolean isAggregation(String token) {
-		String upper = token.toUpperCase();
-		Integer parenPos = upper.indexOf('(');
-		if (parenPos <= 0) {
-			return false;
-		}
-
-		String functionName = upper.substring(0, parenPos).trim();
-		return FUNCTION_MAP.containsKey(functionName);
-	}
-
-	public void parseSubquery(Soql.Builder builder, String subqueryStr) {
-		String innerContent = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
-		Integer fromPos = innerContent.toUpperCase().indexOf(' FROM ');
-
-		if (fromPos < 0) {
-			return;
-		}
-
-		String selectPart = innerContent.substring(0, fromPos).trim();
-		String fromPart = innerContent.substring(fromPos + 6).trim();
-		String[] fromTokens = fromPart.split(' ');
-		String fromEntity = fromTokens[0];
-
-		if (selectPart.toUpperCase().startsWith('SELECT ')) {
-			selectPart = selectPart.substring(7).trim();
-		}
-
-		Soql.InnerQuery innerQuery = new Soql.InnerQuery(fromEntity);
-		new SoqlParser().parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
-		builder.addSelect((Soql.Selectable) innerQuery);
-	}
-
-	private void parseAggregation(Soql.Builder builder, String token) {
-		String upper = token.toUpperCase();
-		Integer openParen = upper.indexOf('(');
-		Integer closeParen = this.findMatchingParen(token, openParen);
-
-		String functionName = upper.substring(0, openParen).trim();
-		String innerField = token.substring(openParen + 1, closeParen).trim();
-		Soql.Function fn = FUNCTION_MAP.get(functionName);
-
-		Soql.Aggregation agg = new Soql.Aggregation(fn, innerField);
-
-		if (closeParen < token.length() - 1) {
-			String afterParen = token.substring(closeParen + 1).trim();
-			String alias = afterParen.trim();
-			if (String.isNotBlank(alias)) {
-				agg.withAlias(alias);
-			}
-		}
-
-		builder.addSelect(agg);
+		return new Soql.Condition(str, Soql.EQUALS, null);
 	}
 
 	public Integer findMatchingParen(String str, Integer openIndex) {
@@ -288,8 +159,142 @@ public class SoqlParser {
 		return str.length();
 	}
 
+	public void parseSubquery(Soql.Builder builder, String subqueryStr) {
+		String inner = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
+		Integer fromPos = inner.toUpperCase().indexOf(' FROM ');
+		if (fromPos < 0) {
+			return;
+		}
+		String selectPart = inner.substring(0, fromPos).trim();
+		String fromPart = inner.substring(fromPos + 6).trim();
+		if (selectPart.toUpperCase().startsWith('SELECT ')) {
+			selectPart = selectPart.substring(7).trim();
+		}
+		Soql.InnerQuery innerQuery = new Soql.InnerQuery(fromPart.split(' ')[0]);
+		new SoqlParser().parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
+		builder.addSelect((Soql.Selectable) innerQuery);
+	}
+
+	public Object parseValue(String token) {
+		String trimmed = token.trim();
+		String upper = trimmed.toUpperCase();
+		if (upper == 'NULL') return null;
+		if (upper == 'TRUE') return true;
+		if (upper == 'FALSE') return false;
+		if (trimmed.startsWith(':')) return trimmed;
+		if (trimmed.startsWith('\'')) return this.parseStringLiteral(trimmed);
+		if (trimmed.startsWith('(')) return this.parseList(trimmed);
+		if (this.isDateTime(upper)) return this.parseDateTime(trimmed);
+		if (this.isDate(upper)) return this.parseDate(trimmed);
+		return this.parseNumeric(trimmed);
+	}
+
+	private void applyParsers(Soql.Builder builder, String queryString, Map<String, Integer> positions) {
+		this.parseSelect(builder, this.extractClause(queryString, positions, SELECT_KEYWORD, FROM_KEYWORD));
+		this.parseFrom(builder, this.extractClause(queryString, positions, FROM_KEYWORD, this.getNextKeyword(positions, FROM_KEYWORD)));
+		String where = this.extractClause(queryString, positions, WHERE_KEYWORD, this.getNextKeyword(positions, WHERE_KEYWORD));
+		if (String.isNotBlank(where)) {
+			this.parseWhere(builder, where);
+		}
+		String groupBy = this.extractClause(queryString, positions, GROUP_BY_KEYWORD, this.getNextKeyword(positions, GROUP_BY_KEYWORD));
+		if (String.isNotBlank(groupBy)) {
+			this.parseGroupBy(builder, groupBy);
+		}
+		String having = this.extractClause(queryString, positions, HAVING_KEYWORD, this.getNextKeyword(positions, HAVING_KEYWORD));
+		if (String.isNotBlank(having)) {
+			this.parseHaving(builder, having);
+		}
+		String orderBy = this.extractClause(queryString, positions, ORDER_BY_KEYWORD, this.getNextKeyword(positions, ORDER_BY_KEYWORD));
+		if (String.isNotBlank(orderBy)) {
+			this.parseOrderBy(builder, orderBy);
+		}
+		String lim = this.extractClause(queryString, positions, LIMIT_KEYWORD, this.getNextKeyword(positions, LIMIT_KEYWORD));
+		if (String.isNotBlank(lim)) {
+			this.parseLimit(builder, lim);
+		}
+		String off = this.extractClause(queryString, positions, OFFSET_KEYWORD, this.getNextKeyword(positions, OFFSET_KEYWORD));
+		if (String.isNotBlank(off)) {
+			this.parseOffset(builder, off);
+		}
+		String usingScope = this.extractClause(queryString, positions, USING_SCOPE_KEYWORD, this.getNextKeyword(positions, USING_SCOPE_KEYWORD));
+		if (String.isNotBlank(usingScope)) {
+			this.parseUsingScope(builder, usingScope);
+		}
+		String withClause = this.extractClause(queryString, positions, WITH_KEYWORD, this.getNextKeyword(positions, WITH_KEYWORD));
+		if (String.isNotBlank(withClause)) {
+			this.parseWith(builder, withClause);
+		}
+		String forClause = this.extractClause(queryString, positions, FOR_KEYWORD, this.getNextKeyword(positions, FOR_KEYWORD));
+		if (String.isNotBlank(forClause)) {
+			this.parseFor(builder, forClause);
+		}
+		if (positions.containsKey(ALL_ROWS_KEYWORD)) {
+			this.parseAllRows(builder);
+		}
+	}
+
+	private Integer calculateEndPos(String queryString, Map<String, Integer> positions, String nextKeyword) {
+		if (nextKeyword == null) {
+			return queryString.length();
+		}
+		Integer nextPos = positions.get(nextKeyword);
+		return nextPos != null ? nextPos : queryString.length();
+	}
+
+	private void parseSelect(Soql.Builder builder, String selectStr) {
+		builder.deselectAll();
+		for (String item : this.splitTopLevelKeyword(selectStr, ',')) {
+			String token = item.trim();
+			if (token.startsWith('(')) {
+				this.parseSubquery(builder, token);
+			} else if (this.isAggregation(token)) {
+				this.parseAggregation(builder, token);
+			} else {
+				builder.addSelect(token);
+			}
+		}
+	}
+
+	private Boolean isAggregation(String token) {
+		String upper = token.toUpperCase();
+		Integer parenPos = upper.indexOf('(');
+		if (parenPos <= 0) {
+			return false;
+		}
+		return FUNCTION_MAP.containsKey(upper.substring(0, parenPos).trim());
+	}
+
+	private void parseAggregation(Soql.Builder builder, String token) {
+		builder.addSelect(this.buildAggregation(token));
+	}
+
+	private Soql.Aggregation buildAggregation(String token) {
+		String upper = token.toUpperCase();
+		Integer openParen = upper.indexOf('(');
+		Integer closeParen = this.findMatchingParen(token, openParen);
+		Soql.Aggregation agg = new Soql.Aggregation(
+			FUNCTION_MAP.get(upper.substring(0, openParen).trim()),
+			token.substring(openParen + 1, closeParen).trim()
+		);
+		if (closeParen < token.length() - 1) {
+			String alias = token.substring(closeParen + 1).trim();
+			if (String.isNotBlank(alias)) {
+				agg.withAlias(alias);
+			}
+		}
+		return agg;
+	}
+
 	private void parseFrom(Soql.Builder builder, String fromStr) {
-		builder.setFrom(fromStr.trim());
+		builder.setFrom(fromStr);
+	}
+
+	private void parseWhere(Soql.Builder builder, String whereStr) {
+		builder.setWhereCriteria(this.parseCriteriaLogic(whereStr));
+	}
+
+	private void parseHaving(Soql.Builder builder, String havingStr) {
+		builder.setHavingCriteria(this.parseCriteriaLogic(havingStr));
 	}
 
 	private Soql.ConditionalLogic parseCriteriaLogic(String str) {
@@ -302,16 +307,11 @@ public class SoqlParser {
 		return (Soql.ConditionalLogic) criteria;
 	}
 
-	private void parseWhere(Soql.Builder builder, String whereStr) {
-		builder.setWhereCriteria(this.parseCriteriaLogic(whereStr));
-	}
-
 	private Soql.Criteria parseExpr(String str) {
 		List<String> orParts = this.splitTopLevelKeyword(str, ' OR ');
 		if (orParts.size() == 1) {
 			return this.parseAndExpr(orParts[0]);
 		}
-
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
 		logic.setLogicType(Soql.LogicType.ANY_CONDITIONS);
 		for (String part : orParts) {
@@ -325,7 +325,6 @@ public class SoqlParser {
 		if (andParts.size() == 1) {
 			return this.parseFactor(andParts[0]);
 		}
-
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
 		logic.setLogicType(Soql.LogicType.ALL_CONDITIONS);
 		for (String part : andParts) {
@@ -337,36 +336,17 @@ public class SoqlParser {
 	private Soql.Criteria parseFactor(String str) {
 		String trimmed = str.trim();
 		if (trimmed.startsWith('(') && this.findMatchingParen(trimmed, 0) == trimmed.length() - 1) {
-			String innerStr = trimmed.substring(1, trimmed.length() - 1).trim();
-			return this.parseExpr(innerStr);
+			return this.parseExpr(trimmed.substring(1, trimmed.length() - 1).trim());
 		}
 		return this.parseCondition(trimmed);
-	}
-
-	public Soql.Condition parseCondition(String str) {
-		List<String> operators = new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
-
-		for (String op : operators) {
-			Integer opPos = this.findOperatorPosition(str, op);
-			if (opPos >= 0) {
-				String fieldName = str.substring(0, opPos).trim();
-				String value = str.substring(opPos + op.length()).trim();
-				Soql.Operator operator = OPERATOR_MAP.get(op.toUpperCase());
-				return new Soql.Condition(fieldName, operator, this.parseValue(value));
-			}
-		}
-
-		return new Soql.Condition(str, Soql.EQUALS, null);
 	}
 
 	private Integer findOperatorPosition(String str, String operator) {
 		Integer parenDepth = 0;
 		Boolean inString = false;
 		String strUpper = str.toUpperCase();
-
 		for (Integer i = 0; i <= str.length() - operator.length(); i++) {
 			String c = str.substring(i, i + 1);
-
 			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
 				inString = !inString;
 			} else if (!inString) {
@@ -385,108 +365,84 @@ public class SoqlParser {
 				}
 			}
 		}
-
 		return -1;
 	}
 
-	public Object parseValue(String token) {
-		String trimmed = token.trim();
-		String t = trimmed.toUpperCase();
+	private Object parseStringLiteral(String trimmed) {
+		return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
+	}
 
-		if (t == 'NULL') {
-			return null;
-		}
-		if (t == 'TRUE') {
-			return true;
-		}
-		if (t == 'FALSE') {
-			return false;
-		}
-		if (trimmed.startsWith(':')) {
+	private Object parseList(String trimmed) {
+		String inner = trimmed.substring(1, trimmed.length() - 1);
+		if (inner.toUpperCase().contains('SELECT')) {
 			return trimmed;
 		}
-		if (trimmed.startsWith('\'')) {
-			String unquoted = trimmed.substring(1, trimmed.length() - 1);
-			return unquoted.replace('\\\'', '\'');
+		List<String> result = new List<String>();
+		for (String item : this.splitTopLevelKeyword(inner, ',')) {
+			String val = item.trim();
+			result.add((val.startsWith('\'') && val.endsWith('\'')) ? val.substring(1, val.length() - 1) : val);
 		}
-		if (trimmed.startsWith('(')) {
-			String parenthetical = trimmed.substring(1, trimmed.length() - 1);
-			if (parenthetical.toUpperCase().contains('SELECT')) {
-				return trimmed;
-			}
-			List<String> items = this.splitTopLevelKeyword(parenthetical, ',');
-			List<String> result = new List<String>();
-			for (String item : items) {
-				String cleaned = item.trim();
-				if (cleaned.startsWith('\'') && cleaned.endsWith('\'')) {
-					cleaned = cleaned.substring(1, cleaned.length() - 1);
-				}
-				result.add(cleaned);
-			}
-			return result;
-		}
+		return result;
+	}
 
-		if (this.isDateTime(t)) {
-			try {
-				return DateTime.valueOfGmt(trimmed);
-			} catch (Exception e) {
-				return trimmed;
-			}
+	private Object parseDateTime(String trimmed) {
+		try {
+			return DateTime.valueOfGmt(trimmed);
+		} catch (Exception e) {
+			return trimmed;
 		}
-		if (this.isDate(t)) {
-			try {
-				return Date.valueOf(trimmed);
-			} catch (Exception e) {
-				return trimmed;
-			}
-		}
+	}
 
+	private Object parseDate(String trimmed) {
+		try {
+			return Date.valueOf(trimmed);
+		} catch (Exception e) {
+			return trimmed;
+		}
+	}
+
+	private Object parseNumeric(String trimmed) {
 		try {
 			return Integer.valueOf(trimmed);
 		} catch (Exception e) {
 		}
-
 		try {
 			return Decimal.valueOf(trimmed);
 		} catch (Exception e) {
 		}
-
 		return trimmed;
 	}
 
 	private void parseOrderBy(Soql.Builder builder, String orderByStr) {
-		List<String> items = this.splitTopLevelKeyword(orderByStr, ',');
-		for (String item : items) {
+		for (String item : this.splitTopLevelKeyword(orderByStr, ',')) {
 			builder.addRawOrderBy(item.trim());
 		}
 	}
 
 	private void parseGroupBy(Soql.Builder builder, String groupByStr) {
-		List<String> items = this.splitTopLevelKeyword(groupByStr, ',');
-		for (String item : items) {
+		for (String item : this.splitTopLevelKeyword(groupByStr, ',')) {
 			builder.addGroupBy(item.trim());
 		}
 	}
 
 	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
-		String scopeName = usingScopeStr.trim().toUpperCase();
-		Soql.Scope scope = SCOPE_MAP.get(scopeName);
+		Soql.Scope scope = SCOPE_MAP.get(usingScopeStr.toUpperCase());
 		if (scope != null) {
 			builder.setScope(scope);
 		}
 	}
 
 	private void parseWith(Soql.Builder builder, String withStr) {
-		builder.setWithClause(withStr.trim());
+		builder.setWithClause(withStr);
 	}
 
 	private void parseFor(Soql.Builder builder, String forStr) {
-		String trimmed = forStr.trim().toUpperCase();
-		if (trimmed.startsWith('UPDATE')) {
+		String upper = forStr.toUpperCase();
+		if (upper.startsWith('UPDATE')) {
 			builder.setUsage(Soql.Usage.FOR_UPDATE);
-		} else if (trimmed.startsWith('VIEW')) {
+		} else if (upper.startsWith('VIEW')) {
 			builder.setUsage(Soql.Usage.FOR_VIEW);
-		} else if (trimmed.startsWith('REFERENCE')) {
+		} else if (upper.startsWith('REFERENCE')) {
 			builder.setUsage(Soql.Usage.FOR_REFERENCE);
 		}
 	}
@@ -495,18 +451,12 @@ public class SoqlParser {
 		builder.setUsage(Soql.Usage.ALL_ROWS);
 	}
 
-	private void parseHaving(Soql.Builder builder, String havingStr) {
-		builder.setHavingCriteria(this.parseCriteriaLogic(havingStr));
-	}
-
 	private void parseLimit(Soql.Builder builder, String limitStr) {
-		Integer rowLimit = Integer.valueOf(limitStr.trim());
-		builder.setRowLimit(rowLimit);
+		builder.setRowLimit(Integer.valueOf(limitStr));
 	}
 
 	private void parseOffset(Soql.Builder builder, String offsetStr) {
-		Integer rowOffset = Integer.valueOf(offsetStr.trim());
-		builder.setRowOffset(rowOffset);
+		builder.setRowOffset(Integer.valueOf(offsetStr));
 	}
 
 	private List<String> splitTopLevelKeyword(String str, String keyword) {
@@ -515,10 +465,8 @@ public class SoqlParser {
 		Boolean inString = false;
 		Integer lastPos = 0;
 		String strUpper = str.toUpperCase();
-
 		for (Integer i = 0; i <= str.length() - keyword.length(); i++) {
 			String c = str.substring(i, i + 1);
-
 			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
 				inString = !inString;
 			} else if (!inString) {
@@ -533,29 +481,23 @@ public class SoqlParser {
 				}
 			}
 		}
-
 		if (lastPos < str.length()) {
 			parts.add(str.substring(lastPos));
 		} else if (lastPos == str.length() && parts.isEmpty()) {
 			parts.add(str);
 		}
-
 		return parts;
 	}
 
 	private Boolean isDateTime(String str) {
-		if (str == null || str.length() < 10) {
+		if (str == null || str.length() < 10 || !str.contains('T')) {
 			return false;
 		}
-		String prefix = str.substring(0, 10);
-		return this.isValidDatePrefix(prefix) && str.contains('T');
+		return this.isValidDatePrefix(str.substring(0, 10));
 	}
 
 	private Boolean isDate(String str) {
-		if (str == null || str.length() != 10) {
-			return false;
-		}
-		return this.isValidDatePrefix(str);
+		return str != null && str.length() == 10 && this.isValidDatePrefix(str);
 	}
 
 	private Boolean isValidDatePrefix(String datePrefix) {
@@ -565,14 +507,10 @@ public class SoqlParser {
 		if (datePrefix.substring(4, 5) != '-' || datePrefix.substring(7, 8) != '-') {
 			return false;
 		}
-		String yearPart = datePrefix.substring(0, 4);
-		String monthPart = datePrefix.substring(5, 7);
-		String dayPart = datePrefix.substring(8, 10);
-
 		try {
-			Integer year = Integer.valueOf(yearPart);
-			Integer month = Integer.valueOf(monthPart);
-			Integer day = Integer.valueOf(dayPart);
+			Integer year = Integer.valueOf(datePrefix.substring(0, 4));
+			Integer month = Integer.valueOf(datePrefix.substring(5, 7));
+			Integer day = Integer.valueOf(datePrefix.substring(8, 10));
 			return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
 		} catch (Exception e) {
 			return false;

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -3,8 +3,12 @@
  * Handles all standard SOQL clauses including SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY,
  * LIMIT, OFFSET, USING SCOPE, WITH, FOR, and ALL ROWS.
  */
-@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.PropertyNamingConventions')
+@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.ExcessiveClassLength,PMD.PropertyNamingConventions')
 public class SoqlParser {
+	/** @description Shared OperatorLexer instance for resolving SOQL operator tokens */
+	private static final SoqlParser.OperatorLexer OPERATORS = new SoqlParser.OperatorLexer();
+	/** @description Shared ValueParser instance for converting raw SOQL value tokens to Apex types */
+	private static final SoqlParser.ValueParser VALUE_PARSER = new SoqlParser.ValueParser();
 	/** @description SOQL keyword string for the ALL ROWS clause */
 	// prettier-ignore
 	private static final String ALL_ROWS_KEYWORD { get { return 'ALL ROWS'; } }
@@ -66,10 +70,6 @@ public class SoqlParser {
 		}
 		private set;
 	}
-	/** @description Shared OperatorLexer instance for resolving SOQL operator tokens */
-	private static final SoqlParser.OperatorLexer OPERATORS = new SoqlParser.OperatorLexer();
-	/** @description Shared ValueParser instance for converting raw SOQL value tokens to Apex types */
-	private static final SoqlParser.ValueParser VALUE_PARSER = new SoqlParser.ValueParser();
 
 	/**
 	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -11,6 +11,7 @@ public class SoqlParser {
 	private static final String WITH_KEYWORD = 'WITH';
 	private static final String FOR_KEYWORD = 'FOR';
 	private static final String ALL_ROWS_KEYWORD = 'ALL ROWS';
+	private static final Integer MAX_INT = 2147483647;
 
 	private static final Map<String, Soql.Function> FUNCTION_MAP = new Map<String, Soql.Function>{
 		'AVG' => Soql.Function.AVG,
@@ -137,8 +138,8 @@ public class SoqlParser {
 
 			if (parenDepth == 0 && !inStringLiteral) {
 				for (String keyword : keywords) {
-					if (upper.substring(i).startsWithIgnoreCase(keyword)) {
-						Integer endIndex = i + keyword.length();
+					Integer endIndex = i + keyword.length();
+					if (endIndex <= upper.length() && upper.substring(i, endIndex) == keyword) {
 						Boolean beforeOk = (i == 0 || upper.substring(i - 1, i) == ' ');
 						Boolean afterOk = (endIndex >= upper.length() || upper.substring(endIndex, endIndex + 1) == ' ');
 
@@ -167,7 +168,7 @@ public class SoqlParser {
 		}
 
 		String nextKeyword = null;
-		Integer nextPos = 999999;
+		Integer nextPos = MAX_INT;
 
 		for (String keyword : allKeywords) {
 			Integer pos = positions.get(keyword);
@@ -202,7 +203,7 @@ public class SoqlParser {
 
 	private void parseSelect(Soql.Builder builder, String selectStr) {
 		builder.deselectAll();
-		List<String> selectItems = this.splitTopLevel(selectStr, ',');
+		List<String> selectItems = this.splitTopLevelKeyword(selectStr, ',');
 
 		for (String item : selectItems) {
 			String trimmed = item.trim();
@@ -291,15 +292,18 @@ public class SoqlParser {
 		builder.setFrom(fromStr.trim());
 	}
 
-	private void parseWhere(Soql.Builder builder, String whereStr) {
-		Soql.Criteria criteria = this.parseExpr(whereStr);
+	private Soql.ConditionalLogic parseCriteriaLogic(String str) {
+		Soql.Criteria criteria = this.parseExpr(str);
 		if (criteria instanceof Soql.Condition) {
 			Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
 			logic.addCondition((Soql.Condition) criteria);
-			builder.setWhereCriteria(logic);
-		} else {
-			builder.setWhereCriteria((Soql.ConditionalLogic) criteria);
+			return logic;
 		}
+		return (Soql.ConditionalLogic) criteria;
+	}
+
+	private void parseWhere(Soql.Builder builder, String whereStr) {
+		builder.setWhereCriteria(this.parseCriteriaLogic(whereStr));
 	}
 
 	private Soql.Criteria parseExpr(String str) {
@@ -358,6 +362,7 @@ public class SoqlParser {
 	private Integer findOperatorPosition(String str, String operator) {
 		Integer parenDepth = 0;
 		Boolean inString = false;
+		String strUpper = str.toUpperCase();
 
 		for (Integer i = 0; i <= str.length() - operator.length(); i++) {
 			String c = str.substring(i, i + 1);
@@ -369,10 +374,11 @@ public class SoqlParser {
 					parenDepth++;
 				} else if (c == ')') {
 					parenDepth--;
-				} else if (parenDepth == 0 && str.substring(i).toUpperCase().startsWith(operator)) {
+				} else if (parenDepth == 0 && strUpper.substring(i, i + operator.length()) == operator) {
 					Integer afterPos = i + operator.length();
 					Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
-					Boolean afterOk = (afterPos >= str.length() || str.substring(afterPos, afterPos + 1) == ' ' || str.substring(afterPos, afterPos + 1) == '(');
+					String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
+					Boolean afterOk = (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
 					if (beforeOk && afterOk) {
 						return i;
 					}
@@ -384,7 +390,8 @@ public class SoqlParser {
 	}
 
 	public Object parseValue(String token) {
-		String t = token.trim().toUpperCase();
+		String trimmed = token.trim();
+		String t = trimmed.toUpperCase();
 
 		if (t == 'NULL') {
 			return null;
@@ -395,19 +402,19 @@ public class SoqlParser {
 		if (t == 'FALSE') {
 			return false;
 		}
-		if (token.trim().startsWith(':')) {
-			return token.trim();
+		if (trimmed.startsWith(':')) {
+			return trimmed;
 		}
-		if (token.trim().startsWith('\'')) {
-			String unquoted = token.trim().substring(1, token.trim().length() - 1);
+		if (trimmed.startsWith('\'')) {
+			String unquoted = trimmed.substring(1, trimmed.length() - 1);
 			return unquoted.replace('\\\'', '\'');
 		}
-		if (token.trim().startsWith('(')) {
-			String parenthetical = token.trim().substring(1, token.trim().length() - 1);
+		if (trimmed.startsWith('(')) {
+			String parenthetical = trimmed.substring(1, trimmed.length() - 1);
 			if (parenthetical.toUpperCase().contains('SELECT')) {
-				return token.trim();
+				return trimmed;
 			}
-			List<String> items = this.splitTopLevel(parenthetical, ',');
+			List<String> items = this.splitTopLevelKeyword(parenthetical, ',');
 			List<String> result = new List<String>();
 			for (String item : items) {
 				String cleaned = item.trim();
@@ -421,41 +428,41 @@ public class SoqlParser {
 
 		if (this.isDateTime(t)) {
 			try {
-				return DateTime.valueOfGmt(token.trim());
+				return DateTime.valueOfGmt(trimmed);
 			} catch (Exception e) {
-				return token.trim();
+				return trimmed;
 			}
 		}
 		if (this.isDate(t)) {
 			try {
-				return Date.valueOf(token.trim());
+				return Date.valueOf(trimmed);
 			} catch (Exception e) {
-				return token.trim();
+				return trimmed;
 			}
 		}
 
 		try {
-			return Integer.valueOf(token.trim());
+			return Integer.valueOf(trimmed);
 		} catch (Exception e) {
 		}
 
 		try {
-			return Decimal.valueOf(token.trim());
+			return Decimal.valueOf(trimmed);
 		} catch (Exception e) {
 		}
 
-		return token.trim();
+		return trimmed;
 	}
 
 	private void parseOrderBy(Soql.Builder builder, String orderByStr) {
-		List<String> items = this.splitTopLevel(orderByStr, ',');
+		List<String> items = this.splitTopLevelKeyword(orderByStr, ',');
 		for (String item : items) {
 			builder.addRawOrderBy(item.trim());
 		}
 	}
 
 	private void parseGroupBy(Soql.Builder builder, String groupByStr) {
-		List<String> items = this.splitTopLevel(groupByStr, ',');
+		List<String> items = this.splitTopLevelKeyword(groupByStr, ',');
 		for (String item : items) {
 			builder.addGroupBy(item.trim());
 		}
@@ -489,14 +496,7 @@ public class SoqlParser {
 	}
 
 	private void parseHaving(Soql.Builder builder, String havingStr) {
-		Soql.Criteria criteria = this.parseExpr(havingStr);
-		if (criteria instanceof Soql.Condition) {
-			Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
-			logic.addCondition((Soql.Condition) criteria);
-			builder.setHavingCriteria(logic);
-		} else {
-			builder.setHavingCriteria((Soql.ConditionalLogic) criteria);
-		}
+		builder.setHavingCriteria(this.parseCriteriaLogic(havingStr));
 	}
 
 	private void parseLimit(Soql.Builder builder, String limitStr) {
@@ -509,42 +509,12 @@ public class SoqlParser {
 		builder.setRowOffset(rowOffset);
 	}
 
-	private List<String> splitTopLevel(String str, String delimiter) {
-		List<String> parts = new List<String>();
-		Integer parenDepth = 0;
-		Boolean inString = false;
-		Integer lastPos = 0;
-
-		for (Integer i = 0; i < str.length(); i++) {
-			String c = str.substring(i, i + 1);
-
-			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
-				inString = !inString;
-			} else if (!inString) {
-				if (c == '(') {
-					parenDepth++;
-				} else if (c == ')') {
-					parenDepth--;
-				} else if (parenDepth == 0 && str.substring(i).startsWith(delimiter)) {
-					parts.add(str.substring(lastPos, i));
-					lastPos = i + delimiter.length();
-					i = lastPos - 1;
-				}
-			}
-		}
-
-		if (lastPos < str.length()) {
-			parts.add(str.substring(lastPos));
-		}
-
-		return parts;
-	}
-
 	private List<String> splitTopLevelKeyword(String str, String keyword) {
 		List<String> parts = new List<String>();
 		Integer parenDepth = 0;
 		Boolean inString = false;
 		Integer lastPos = 0;
+		String strUpper = str.toUpperCase();
 
 		for (Integer i = 0; i <= str.length() - keyword.length(); i++) {
 			String c = str.substring(i, i + 1);
@@ -556,7 +526,7 @@ public class SoqlParser {
 					parenDepth++;
 				} else if (c == ')') {
 					parenDepth--;
-				} else if (parenDepth == 0 && str.substring(i).toUpperCase().startsWith(keyword)) {
+				} else if (parenDepth == 0 && strUpper.substring(i, i + keyword.length()) == keyword) {
 					parts.add(str.substring(lastPos, i));
 					lastPos = i + keyword.length();
 					i = lastPos - 1;

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -84,9 +84,17 @@ public class SoqlParser {
 	public Map<String, Integer> findKeywordPositions(String queryString) {
 		Map<String, Integer> positions = new Map<String, Integer>();
 		List<String> keywords = new List<String>{
-			USING_SCOPE_KEYWORD, GROUP_BY_KEYWORD, ORDER_BY_KEYWORD,
-			FROM_KEYWORD, WHERE_KEYWORD, WITH_KEYWORD, HAVING_KEYWORD,
-			LIMIT_KEYWORD, OFFSET_KEYWORD, FOR_KEYWORD, ALL_ROWS_KEYWORD
+			USING_SCOPE_KEYWORD,
+			GROUP_BY_KEYWORD,
+			ORDER_BY_KEYWORD,
+			FROM_KEYWORD,
+			WHERE_KEYWORD,
+			WITH_KEYWORD,
+			HAVING_KEYWORD,
+			LIMIT_KEYWORD,
+			OFFSET_KEYWORD,
+			FOR_KEYWORD,
+			ALL_ROWS_KEYWORD
 		};
 		String upper = queryString.toUpperCase();
 		Integer parenDepth = 0;
@@ -118,9 +126,18 @@ public class SoqlParser {
 	 */
 	public String getNextKeyword(Map<String, Integer> positions, String currentKeyword) {
 		List<String> allKeywords = new List<String>{
-			SELECT_KEYWORD, FROM_KEYWORD, WHERE_KEYWORD, GROUP_BY_KEYWORD, HAVING_KEYWORD,
-			ORDER_BY_KEYWORD, LIMIT_KEYWORD, OFFSET_KEYWORD, USING_SCOPE_KEYWORD, WITH_KEYWORD,
-			FOR_KEYWORD, ALL_ROWS_KEYWORD
+			SELECT_KEYWORD,
+			FROM_KEYWORD,
+			WHERE_KEYWORD,
+			GROUP_BY_KEYWORD,
+			HAVING_KEYWORD,
+			ORDER_BY_KEYWORD,
+			LIMIT_KEYWORD,
+			OFFSET_KEYWORD,
+			USING_SCOPE_KEYWORD,
+			WITH_KEYWORD,
+			FOR_KEYWORD,
+			ALL_ROWS_KEYWORD
 		};
 		Integer currentPos = positions.get(currentKeyword);
 		if (currentPos == null) {
@@ -148,7 +165,12 @@ public class SoqlParser {
 	 * @return The trimmed clause text, or an empty string if the keyword is not present
 	 */
 	@SuppressWarnings('PMD.ExcessiveParameterList')
-	public String extractClause(String queryString, Map<String, Integer> positions, String keyword, String nextKeyword) {
+	public String extractClause(
+		String queryString,
+		Map<String, Integer> positions,
+		String keyword,
+		String nextKeyword
+	) {
 		Integer startPos = positions.get(keyword);
 		if (startPos == null) {
 			return '';
@@ -164,7 +186,18 @@ public class SoqlParser {
 	 * @return A {@link Soql.Condition} representing the parsed condition
 	 */
 	public Soql.Condition parseCondition(String str) {
-		List<String> operators = new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
+		List<String> operators = new List<String>{
+			'NOT IN',
+			'NOT LIKE',
+			'!=',
+			'>=',
+			'<=',
+			'>',
+			'<',
+			'=',
+			'IN',
+			'LIKE'
+		};
 		for (String op : operators) {
 			Integer opPos = this.findOperatorPosition(str, op);
 			if (opPos >= 0) {
@@ -230,53 +263,117 @@ public class SoqlParser {
 	public Object parseValue(String token) {
 		String trimmed = token.trim();
 		String upper = trimmed.toUpperCase();
-		if (upper == 'NULL') { return null; }
-		if (upper == 'TRUE') { return true; }
-		if (upper == 'FALSE') { return false; }
-		if (trimmed.startsWith(':')) { return trimmed; }
-		if (trimmed.startsWith('\'')) { return this.parseStringLiteral(trimmed); }
-		if (trimmed.startsWith('(')) { return this.parseList(trimmed); }
-		if (this.isDateTime(upper)) { return this.parseDateTime(trimmed); }
-		if (this.isDate(upper)) { return this.parseDate(trimmed); }
+		if (upper == 'NULL') {
+			return null;
+		}
+		if (upper == 'TRUE') {
+			return true;
+		}
+		if (upper == 'FALSE') {
+			return false;
+		}
+		if (trimmed.startsWith(':')) {
+			return trimmed;
+		}
+		if (trimmed.startsWith('\'')) {
+			return this.parseStringLiteral(trimmed);
+		}
+		if (trimmed.startsWith('(')) {
+			return this.parseList(trimmed);
+		}
+		if (this.isDateTime(upper)) {
+			return this.parseDateTime(trimmed);
+		}
+		if (this.isDate(upper)) {
+			return this.parseDate(trimmed);
+		}
 		return this.parseNumeric(trimmed);
 	}
 
 	private void applyParsers(Soql.Builder builder, String queryString, Map<String, Integer> positions) {
 		this.parseSelect(builder, this.extractClause(queryString, positions, SELECT_KEYWORD, FROM_KEYWORD));
-		this.parseFrom(builder, this.extractClause(queryString, positions, FROM_KEYWORD, this.getNextKeyword(positions, FROM_KEYWORD)));
-		String whereClause = this.extractClause(queryString, positions, WHERE_KEYWORD, this.getNextKeyword(positions, WHERE_KEYWORD));
+		this.parseFrom(
+			builder,
+			this.extractClause(queryString, positions, FROM_KEYWORD, this.getNextKeyword(positions, FROM_KEYWORD))
+		);
+		String whereClause = this.extractClause(
+			queryString,
+			positions,
+			WHERE_KEYWORD,
+			this.getNextKeyword(positions, WHERE_KEYWORD)
+		);
 		if (String.isNotBlank(whereClause)) {
 			this.parseWhere(builder, whereClause);
 		}
-		String groupBy = this.extractClause(queryString, positions, GROUP_BY_KEYWORD, this.getNextKeyword(positions, GROUP_BY_KEYWORD));
+		String groupBy = this.extractClause(
+			queryString,
+			positions,
+			GROUP_BY_KEYWORD,
+			this.getNextKeyword(positions, GROUP_BY_KEYWORD)
+		);
 		if (String.isNotBlank(groupBy)) {
 			this.parseGroupBy(builder, groupBy);
 		}
-		String havingClause = this.extractClause(queryString, positions, HAVING_KEYWORD, this.getNextKeyword(positions, HAVING_KEYWORD));
+		String havingClause = this.extractClause(
+			queryString,
+			positions,
+			HAVING_KEYWORD,
+			this.getNextKeyword(positions, HAVING_KEYWORD)
+		);
 		if (String.isNotBlank(havingClause)) {
 			this.parseHaving(builder, havingClause);
 		}
-		String orderBy = this.extractClause(queryString, positions, ORDER_BY_KEYWORD, this.getNextKeyword(positions, ORDER_BY_KEYWORD));
+		String orderBy = this.extractClause(
+			queryString,
+			positions,
+			ORDER_BY_KEYWORD,
+			this.getNextKeyword(positions, ORDER_BY_KEYWORD)
+		);
 		if (String.isNotBlank(orderBy)) {
 			this.parseOrderBy(builder, orderBy);
 		}
-		String lim = this.extractClause(queryString, positions, LIMIT_KEYWORD, this.getNextKeyword(positions, LIMIT_KEYWORD));
+		String lim = this.extractClause(
+			queryString,
+			positions,
+			LIMIT_KEYWORD,
+			this.getNextKeyword(positions, LIMIT_KEYWORD)
+		);
 		if (String.isNotBlank(lim)) {
 			this.parseLimit(builder, lim);
 		}
-		String off = this.extractClause(queryString, positions, OFFSET_KEYWORD, this.getNextKeyword(positions, OFFSET_KEYWORD));
+		String off = this.extractClause(
+			queryString,
+			positions,
+			OFFSET_KEYWORD,
+			this.getNextKeyword(positions, OFFSET_KEYWORD)
+		);
 		if (String.isNotBlank(off)) {
 			this.parseOffset(builder, off);
 		}
-		String usingScope = this.extractClause(queryString, positions, USING_SCOPE_KEYWORD, this.getNextKeyword(positions, USING_SCOPE_KEYWORD));
+		String usingScope = this.extractClause(
+			queryString,
+			positions,
+			USING_SCOPE_KEYWORD,
+			this.getNextKeyword(positions, USING_SCOPE_KEYWORD)
+		);
 		if (String.isNotBlank(usingScope)) {
 			this.parseUsingScope(builder, usingScope);
 		}
-		String withClause = this.extractClause(queryString, positions, WITH_KEYWORD, this.getNextKeyword(positions, WITH_KEYWORD));
+		String withClause = this.extractClause(
+			queryString,
+			positions,
+			WITH_KEYWORD,
+			this.getNextKeyword(positions, WITH_KEYWORD)
+		);
 		if (String.isNotBlank(withClause)) {
 			this.parseWith(builder, withClause);
 		}
-		String forClause = this.extractClause(queryString, positions, FOR_KEYWORD, this.getNextKeyword(positions, FOR_KEYWORD));
+		String forClause = this.extractClause(
+			queryString,
+			positions,
+			FOR_KEYWORD,
+			this.getNextKeyword(positions, FOR_KEYWORD)
+		);
 		if (String.isNotBlank(forClause)) {
 			this.parseFor(builder, forClause);
 		}
@@ -419,7 +516,11 @@ public class SoqlParser {
 					parenDepth++;
 				} else if (c == ')') {
 					parenDepth--;
-				} else if (parenDepth == 0 && strUpper.substring(i, i + operator.length()) == operator && this.isAtWordBoundary(str, i, operator)) {
+				} else if (
+					parenDepth == 0 &&
+					strUpper.substring(i, i + operator.length()) == operator &&
+					this.isAtWordBoundary(str, i, operator)
+				) {
 					return i;
 				}
 			}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -31,9 +31,10 @@ public class SoqlParser {
 	private static final String WITH_KEYWORD { get { return 'WITH'; } }
 	// prettier-ignore
 	private static final Integer MAX_INT { get { return 2147483647; } }
+	// prettier-ignore
 	private static final List<String> ALL_KEYWORDS {
 		get {
-			return new List<String>{
+			ALL_KEYWORDS = ALL_KEYWORDS ?? new List<String>{
 				SELECT_KEYWORD,
 				FROM_KEYWORD,
 				WHERE_KEYWORD,
@@ -47,15 +48,17 @@ public class SoqlParser {
 				FOR_KEYWORD,
 				ALL_ROWS_KEYWORD
 			};
+			return ALL_KEYWORDS;
 		}
+		private set;
 	}
-	// prettier-ignore
-	private static final OperatorLexer OPERATORS { get { return new OperatorLexer(); }}
-	// prettier-ignore
-	private static final ValueParser VALUE_PARSER { get { return new ValueParser(); }}
+	private static final SoqlParser.OperatorLexer OPERATORS = new SoqlParser.OperatorLexer();
+	private static final SoqlParser.ValueParser VALUE_PARSER = new SoqlParser.ValueParser();
+
 	/**
+	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder
 	 * @param builder The {@link Soql.Builder} to populate with parsed clauses
-	 * @param queryString The SOQL query string to parse
+	 * @param str The SOQL query string to parse
 	 */
 	public void parse(Soql.Builder builder, String str) {
 		try {
@@ -118,14 +121,15 @@ public class SoqlParser {
 	 */
 	private String extractClause(ParseContext ctx, String keyword) {
 		Integer startPos = ctx.positions?.get(keyword);
-		if (startPos == null) {
+		if (startPos != null) {
+			String nextKeyword = this.getNextKeyword(ctx.positions, keyword);
+			Integer endPos = nextKeyword == null
+				? ctx.queryString.length()
+				: (ctx.positions.get(nextKeyword) ?? ctx.queryString.length());
+			return ctx.queryString.substring(startPos + keyword.length(), endPos).trim();
+		} else {
 			return '';
 		}
-		String nextKeyword = this.getNextKeyword(ctx.positions, keyword);
-		Integer endPos = nextKeyword == null
-			? ctx.queryString.length()
-			: (ctx.positions.get(nextKeyword) ?? ctx.queryString.length());
-		return ctx.queryString.substring(startPos + keyword.length(), endPos).trim();
 	}
 
 	/**
@@ -139,19 +143,24 @@ public class SoqlParser {
 	private Integer findMatchingParen(String str, Integer openIndex) {
 		Integer depth = 0;
 		for (Integer i = openIndex; i < str.length(); i++) {
-			String c = str.substring(i, i + 1);
-			if (c == '(') {
+			String character = str.substring(i, i + 1);
+			if (character == '(') {
 				depth++;
-			} else if (c == ')') {
+			} else if (character == ')') {
 				depth--;
 				if (depth == 0) {
 					return i;
 				}
 			}
 		}
-		return str.length();
+		return str?.length();
 	}
 
+	/**
+	 * @description Resolves a function name string to its {@link Soql.Function} enum value
+	 * @param name The uppercase function name (e.g. COUNT, SUM)
+	 * @return The matching {@link Soql.Function}
+	 */
 	private Soql.Function getFunctionByName(String name) {
 		try {
 			return Soql.Function.valueOf(name);
@@ -184,6 +193,11 @@ public class SoqlParser {
 		return nextKeyword;
 	}
 
+	/**
+	 * @description Resolves a scope name string to its {@link Soql.Scope} enum value
+	 * @param name The uppercase scope name (e.g. MINE, TEAM)
+	 * @return The matching {@link Soql.Scope}
+	 */
 	private Soql.Scope getScopeByName(String name) {
 		try {
 			return Soql.Scope.valueOf(name);
@@ -206,9 +220,7 @@ public class SoqlParser {
 		}
 		try {
 			String functionName = upper?.substring(0, parenPos).trim();
-			this.getFunctionByName(functionName);
-			// No error; is a Soql.Function value:
-			return true;
+			return this.getFunctionByName(functionName) != null;
 		} catch (System.NoSuchElementException error) {
 			return false;
 		}
@@ -262,8 +274,8 @@ public class SoqlParser {
 		for (String op : OPERATORS?.precedence()) {
 			Integer opPos = OPERATORS?.findPosition(str, op);
 			if (opPos >= 0) {
-				String fieldName = str.substring(0, opPos).trim();
-				String rawValue = str.substring(opPos + op.length()).trim();
+				String fieldName = str?.substring(0, opPos).trim();
+				String rawValue = str?.substring(opPos + op.length()).trim();
 				Soql.Operator operator = OPERATORS?.resolve(op);
 				Object value = this.parseValue(rawValue);
 				return new Soql.Condition(fieldName, operator, value);
@@ -280,8 +292,9 @@ public class SoqlParser {
 	private Soql.ConditionalLogic parseCriteriaLogic(String str) {
 		Soql.Criteria criteria = this.parseExpr(str);
 		if (criteria instanceof Soql.Condition) {
+			Soql.Condition condition = (Soql.Condition) criteria;
 			Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
-			logic.addCondition((Soql.Condition) criteria);
+			logic?.addCondition(condition);
 			return logic;
 		}
 		return (Soql.ConditionalLogic) criteria;
@@ -295,13 +308,14 @@ public class SoqlParser {
 	private Soql.Criteria parseExpr(String str) {
 		List<String> orParts = this.splitTopLevelKeyword(str, ' OR ');
 		if (orParts.size() == 1) {
-			return this.parseAndExpr(orParts?.get(0));
+			String orPart = orParts?.get(0);
+			return this.parseAndExpr(orPart);
 		}
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
-		logic.setLogicType(Soql.LogicType.ANY_CONDITIONS);
+		logic?.setLogicType(Soql.LogicType.ANY_CONDITIONS);
 		for (String part : orParts) {
 			Soql.Criteria andExpr = this.parseAndExpr(part);
-			logic.addCondition(andExpr);
+			logic?.addCondition(andExpr);
 		}
 		return logic;
 	}
@@ -314,8 +328,9 @@ public class SoqlParser {
 	 */
 	private Soql.Criteria parseFactor(String str) {
 		String trimmed = str?.trim();
+		Integer lastIndex = (trimmed?.length ?? 0) - 1;
 		Integer closeParen = this.findMatchingParen(trimmed, 0);
-		Boolean isWrapped = trimmed?.startsWith('(') && closeParen == trimmed?.length() - 1;
+		Boolean isWrapped = trimmed?.startsWith('(') == true && closeParen == lastIndex;
 		if (isWrapped) {
 			String body = trimmed?.substring(1, trimmed?.length() - 1)?.trim();
 			return this.parseExpr(body);
@@ -329,16 +344,13 @@ public class SoqlParser {
 	 * @param forStr The FOR clause value (e.g. UPDATE, VIEW, REFERENCE)
 	 */
 	private void parseFor(Soql.Builder builder, String forStr) {
-		if (String.isBlank(forStr)) {
-			return;
-		}
-		String upper = forStr.toUpperCase();
-		if (upper.startsWith('UPDATE')) {
-			builder.setUsage(Soql.Usage.FOR_UPDATE);
-		} else if (upper.startsWith('VIEW')) {
-			builder.setUsage(Soql.Usage.FOR_VIEW);
-		} else if (upper.startsWith('REFERENCE')) {
-			builder.setUsage(Soql.Usage.FOR_REFERENCE);
+		String upper = forStr?.toUpperCase();
+		if (upper?.startsWith('UPDATE') == true) {
+			builder?.setUsage(Soql.Usage.FOR_UPDATE);
+		} else if (upper?.startsWith('VIEW') == true) {
+			builder?.setUsage(Soql.Usage.FOR_VIEW);
+		} else if (upper?.startsWith('REFERENCE') == true) {
+			builder?.setUsage(Soql.Usage.FOR_REFERENCE);
 		}
 	}
 
@@ -348,7 +360,7 @@ public class SoqlParser {
 	 * @param fromStr The entity name string
 	 */
 	private void parseFrom(Soql.Builder builder, String fromStr) {
-		builder.setFrom(fromStr);
+		builder?.setFrom(fromStr);
 	}
 
 	/**
@@ -357,11 +369,11 @@ public class SoqlParser {
 	 * @param groupByStr The GROUP BY clause content
 	 */
 	private void parseGroupBy(Soql.Builder builder, String groupByStr) {
-		if (String.isBlank(groupByStr)) {
-			return;
-		}
-		for (String item : this.splitTopLevelKeyword(groupByStr, ',')) {
-			builder.addGroupBy(item.trim());
+		if (String.isNotBlank(groupByStr)) {
+			for (String item : this.splitTopLevelKeyword(groupByStr, ',')) {
+				String trimmed = item.trim();
+				builder?.addGroupBy(trimmed);
+			}
 		}
 	}
 
@@ -371,10 +383,10 @@ public class SoqlParser {
 	 * @param havingStr The HAVING clause content
 	 */
 	private void parseHaving(Soql.Builder builder, String havingStr) {
-		if (String.isBlank(havingStr)) {
-			return;
+		if (String.isNotBlank(havingStr)) {
+			Soql.ConditionalLogic logic = this.parseCriteriaLogic(havingStr);
+			builder?.setHavingCriteria(logic);
 		}
-		builder.setHavingCriteria(this.parseCriteriaLogic(havingStr));
 	}
 
 	/**
@@ -442,17 +454,17 @@ public class SoqlParser {
 	 */
 	private void parseSubquery(Soql.Builder builder, String subqueryStr) {
 		String body = subqueryStr?.substring(1, subqueryStr?.length() - 1).trim();
-		String bodyUpper = body.toUpperCase();
-		Integer fromPos = bodyUpper.indexOf(' FROM ');
+		String bodyUpper = body?.toUpperCase();
+		Integer fromPos = bodyUpper?.indexOf(' FROM ');
 		if (fromPos < 0) {
 			return;
 		}
-		String selectPart = body.substring(0, fromPos).trim();
-		String fromPart = body.substring(fromPos + 6).trim();
-		if (selectPart.toUpperCase().startsWith('SELECT ')) {
-			selectPart = selectPart.substring(7).trim();
+		String selectPart = body?.substring(0, fromPos)?.trim();
+		String fromPart = body?.substring(fromPos + 6)?.trim();
+		if (selectPart?.toUpperCase()?.startsWith('SELECT ') == true) {
+			selectPart = selectPart?.substring(7)?.trim();
 		}
-		String objectName = fromPart.split(' ')?.get(0);
+		String objectName = fromPart?.split(' ')?.get(0);
 		Soql.InnerQuery innerQuery = new Soql.InnerQuery(objectName);
 		SoqlParser subParser = new SoqlParser();
 		subParser.parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
@@ -480,7 +492,7 @@ public class SoqlParser {
 	 */
 	@TestVisible
 	private Object parseValue(String token) {
-		return VALUE_PARSER.parse(token);
+		return VALUE_PARSER?.parse(token);
 	}
 
 	/**
@@ -489,7 +501,7 @@ public class SoqlParser {
 	 * @param whereStr The WHERE clause content
 	 */
 	private void parseWhere(Soql.Builder builder, String whereStr) {
-		if (String.isBlank(whereStr) == false) {
+		if (String.isNotBlank(whereStr)) {
 			Soql.ConditionalLogic logic = this.parseCriteriaLogic(whereStr);
 			builder?.setWhereCriteria(logic);
 		}
@@ -513,18 +525,32 @@ public class SoqlParser {
 	 */
 	private List<String> splitTopLevelKeyword(String str, String delimiter) {
 		List<String> parts = new List<String>();
+		Integer lastPos = this.findParts(str, delimiter, parts);
+		this.addTrailingPart(str, lastPos, parts);
+		return parts;
+	}
+
+	/**
+	 * @description Scans {@code str} character-by-character, appending each segment before a
+	 * top-level {@code delimiter} to {@code parts}.
+	 * @param str The string to scan
+	 * @param delimiter The delimiter to split on
+	 * @param parts The list to append segments to
+	 * @return The position immediately after the last delimiter found, or 0 if none
+	 */
+	private Integer findParts(String str, String delimiter, List<String> parts) {
 		String strUpper = str?.toUpperCase() ?? '';
 		Integer parenDepth = 0;
 		Boolean inString = false;
 		Integer lastPos = 0;
 		for (Integer i = 0; i <= str.length() - delimiter.length(); i++) {
-			String c = str.substring(i, i + 1);
-			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+			String character = str.substring(i, i + 1);
+			if (character == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
 				inString = (inString == false);
 			} else if (inString == false) {
-				if (c == '(') {
+				if (character == '(') {
 					parenDepth++;
-				} else if (c == ')') {
+				} else if (character == ')') {
 					parenDepth--;
 				} else if (parenDepth == 0 && strUpper.substring(i, i + delimiter.length()) == delimiter) {
 					parts.add(str.substring(lastPos, i));
@@ -533,12 +559,22 @@ public class SoqlParser {
 				}
 			}
 		}
+		return lastPos;
+	}
+
+	/**
+	 * @description Appends any remaining segment of {@code str} after the last delimiter to
+	 * {@code parts}. If no delimiter was found, appends the entire string.
+	 * @param str The original string
+	 * @param lastPos The position immediately after the last delimiter found
+	 * @param parts The list to append the trailing segment to
+	 */
+	private void addTrailingPart(String str, Integer lastPos, List<String> parts) {
 		if (lastPos < str.length()) {
 			parts.add(str.substring(lastPos));
 		} else if (parts.isEmpty()) {
 			parts.add(str);
 		}
-		return parts;
 	}
 
 	// **** INNER **** //
@@ -575,17 +611,17 @@ public class SoqlParser {
 		}
 
 		private Boolean isDateTime(String str) {
-			return str?.length() >= 10 && str.contains('T') && this.isValidDatePrefix(str.substring(0, 10));
+			return str?.length() >= 10 && str?.contains('T') == true && this.isValidDatePrefix(str?.substring(0, 10));
 		}
 
 		private Boolean isValidDatePrefix(String datePrefix) {
-			if (datePrefix?.length() != 10 || datePrefix.substring(4, 5) != '-' || datePrefix.substring(7, 8) != '-') {
+			if (datePrefix?.length() != 10 || datePrefix?.substring(4, 5) != '-' || datePrefix?.substring(7, 8) != '-') {
 				return false;
 			}
 			try {
-				Integer year = Integer.valueOf(datePrefix.substring(0, 4));
-				Integer month = Integer.valueOf(datePrefix.substring(5, 7));
-				Integer day = Integer.valueOf(datePrefix.substring(8, 10));
+				Integer year = Integer.valueOf(datePrefix?.substring(0, 4));
+				Integer month = Integer.valueOf(datePrefix?.substring(5, 7));
+				Integer day = Integer.valueOf(datePrefix?.substring(8, 10));
 				return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
 			} catch (Exception error) {
 				return false;
@@ -628,10 +664,10 @@ public class SoqlParser {
 			Boolean inString = false;
 			Integer lastPos = 0;
 			for (Integer i = 0; i < str.length(); i++) {
-				String c = str.substring(i, i + 1);
-				if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+				String character = str.substring(i, i + 1);
+				if (character == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
 					inString = (inString == false);
-				} else if (!inString && c == ',') {
+				} else if (!inString && character == ',') {
 					parts.add(str.substring(lastPos, i));
 					lastPos = i + 1;
 				}
@@ -688,13 +724,13 @@ public class SoqlParser {
 			Integer parenDepth = 0;
 			Boolean inString = false;
 			for (Integer i = 0; i <= str.length() - operator.length(); i++) {
-				String c = str.substring(i, i + 1);
-				if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+				String character = str.substring(i, i + 1);
+				if (character == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
 					inString = (inString == false);
 				} else if (inString == false) {
-					if (c == '(') {
+					if (character == '(') {
 						parenDepth++;
-					} else if (c == ')') {
+					} else if (character == ')') {
 						parenDepth--;
 					} else if (
 						parenDepth == 0 &&
@@ -779,12 +815,12 @@ public class SoqlParser {
 		 * @param i The character index to process
 		 */
 		private void processChar(Integer i) {
-			String c = this.rawQuery.substring(i, i + 1);
-			if (c == '\'' && this.isNotEscaped(i)) {
+			String character = this.rawQuery.substring(i, i + 1);
+			if (character == '\'' && this.isNotEscaped(i)) {
 				this.inString = (this.inString == false);
-			} else if (c == '(' && this.inString == false) {
+			} else if (character == '(' && this.inString == false) {
 				this.parenDepth++;
-			} else if (c == ')' && this.inString == false) {
+			} else if (character == ')' && this.inString == false) {
 				this.parenDepth--;
 			} else if (this.parenDepth == 0 && this.inString == false) {
 				this.tryRecordAllKeywords(i);

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -141,7 +141,7 @@ public class SoqlParser {
 		if (startPos != null) {
 			String nextKeyword = this.getNextKeyword(ctx.positions, keyword);
 			Integer endPos = this.getClauseEndPos(ctx, nextKeyword);
-			return ctx?.queryString.substring(startPos + keyword?.length(), endPos)?.trim();
+			return ctx?.queryString?.substring(startPos + keyword?.length(), endPos)?.trim();
 		} else {
 			return '';
 		}
@@ -249,7 +249,7 @@ public class SoqlParser {
 			return false;
 		}
 		try {
-			String functionName = upper?.substring(0, parenPos).trim();
+			String functionName = upper?.substring(0, parenPos)?.trim();
 			return this.getFunctionByName(functionName) != null;
 		} catch (System.NoSuchElementException error) {
 			return false;
@@ -304,8 +304,8 @@ public class SoqlParser {
 		for (String op : OPERATORS?.precedence()) {
 			Integer opPos = OPERATORS?.findPosition(str, op);
 			if (opPos >= 0) {
-				String fieldName = str?.substring(0, opPos).trim();
-				String rawValue = str?.substring(opPos + op.length()).trim();
+				String fieldName = str?.substring(0, opPos)?.trim();
+				String rawValue = str?.substring(opPos + op.length())?.trim();
 				if (op == 'LIKE' || op == 'NOT LIKE') {
 					return this.parseLikeCondition(fieldName, op, rawValue);
 				}
@@ -500,7 +500,7 @@ public class SoqlParser {
 		List<String> tokens = this.splitTopLevelKeyword(selectStr, ',');
 		for (String item : tokens) {
 			String token = item.trim();
-			if (token?.startsWith('(')) {
+			if (token?.startsWith('(') == true) {
 				this.parseSubquery(builder, token);
 			} else if (this.isAggregation(token)) {
 				this.parseAggregation(builder, token);
@@ -517,7 +517,7 @@ public class SoqlParser {
 	 * @param subqueryStr The parenthesized subquery string, e.g. {@code (SELECT Id FROM Contacts)}
 	 */
 	private void parseSubquery(Soql.Builder builder, String subqueryStr) {
-		String body = subqueryStr?.substring(1, subqueryStr?.length() - 1).trim();
+		String body = subqueryStr?.substring(1, subqueryStr?.length() - 1)?.trim();
 		String bodyUpper = body?.toUpperCase();
 		Integer fromPos = bodyUpper?.indexOf(' FROM ');
 		if (fromPos < 0) {

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -5,19 +5,34 @@
  */
 @SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity')
 public class SoqlParser {
-	private static final String SELECT_KEYWORD = 'SELECT';
+	private static final String ALL_ROWS_KEYWORD = 'ALL ROWS';
+	private static final String FOR_KEYWORD = 'FOR';
 	private static final String FROM_KEYWORD = 'FROM';
-	private static final String WHERE_KEYWORD = 'WHERE';
 	private static final String GROUP_BY_KEYWORD = 'GROUP BY';
 	private static final String HAVING_KEYWORD = 'HAVING';
-	private static final String ORDER_BY_KEYWORD = 'ORDER BY';
 	private static final String LIMIT_KEYWORD = 'LIMIT';
 	private static final String OFFSET_KEYWORD = 'OFFSET';
+	private static final String ORDER_BY_KEYWORD = 'ORDER BY';
+	private static final String SELECT_KEYWORD = 'SELECT';
 	private static final String USING_SCOPE_KEYWORD = 'USING SCOPE';
+	private static final String WHERE_KEYWORD = 'WHERE';
 	private static final String WITH_KEYWORD = 'WITH';
-	private static final String FOR_KEYWORD = 'FOR';
-	private static final String ALL_ROWS_KEYWORD = 'ALL ROWS';
 	private static final Integer MAX_INT = 2147483647;
+
+	private static final List<String> ALL_KEYWORDS = new List<String>{
+		SELECT_KEYWORD,
+		FROM_KEYWORD,
+		WHERE_KEYWORD,
+		GROUP_BY_KEYWORD,
+		HAVING_KEYWORD,
+		ORDER_BY_KEYWORD,
+		LIMIT_KEYWORD,
+		OFFSET_KEYWORD,
+		USING_SCOPE_KEYWORD,
+		WITH_KEYWORD,
+		FOR_KEYWORD,
+		ALL_ROWS_KEYWORD
+	};
 
 	private static final Map<String, Soql.Function> FUNCTION_MAP = new Map<String, Soql.Function>{
 		'AVG' => Soql.Function.AVG,
@@ -35,11 +50,38 @@ public class SoqlParser {
 		'FISCAL_YEAR' => Soql.Function.FISCAL_YEAR,
 		'FORMAT' => Soql.Function.FORMAT,
 		'HOUR_IN_DAY' => Soql.Function.HOUR_IN_DAY,
-		'MIN' => Soql.Function.MIN,
 		'MAX' => Soql.Function.MAX,
+		'MIN' => Soql.Function.MIN,
 		'SUM' => Soql.Function.SUM,
 		'WEEK_IN_MONTH' => Soql.Function.WEEK_IN_MONTH,
 		'WEEK_IN_YEAR' => Soql.Function.WEEK_IN_YEAR
+	};
+
+	private static final Map<String, Soql.Operator> OPERATOR_MAP = new Map<String, Soql.Operator>{
+		'!=' => Soql.NOT_EQUALS,
+		'<' => Soql.LESS_THAN,
+		'<=' => Soql.LESS_OR_EQUAL,
+		'=' => Soql.EQUALS,
+		'>' => Soql.GREATER_THAN,
+		'>=' => Soql.GREATER_OR_EQUAL,
+		'IN' => Soql.IN_COLLECTION,
+		'LIKE' => Soql.LIKE_RAW,
+		'NOT IN' => Soql.NOT_IN_COLLECTION,
+		'NOT LIKE' => Soql.NOT_LIKE_RAW
+	};
+
+	// Operators ordered by precedence: multi-word and longer tokens first to prevent partial matches
+	private static final List<String> OPERATOR_PRECEDENCE = new List<String>{
+		'NOT IN',
+		'NOT LIKE',
+		'!=',
+		'>=',
+		'<=',
+		'>',
+		'<',
+		'=',
+		'IN',
+		'LIKE'
 	};
 
 	private static final Map<String, Soql.Scope> SCOPE_MAP = new Map<String, Soql.Scope>{
@@ -47,23 +89,12 @@ public class SoqlParser {
 		'EVERYTHING' => Soql.Scope.EVERYTHING,
 		'MINE' => Soql.Scope.MINE,
 		'MINE_AND_MY_GROUPS' => Soql.Scope.MINE_AND_MY_GROUPS,
-		'MY_TERRITORY' => Soql.Scope.MY_TERRITORY,
 		'MY_TEAM_TERRITORY' => Soql.Scope.MY_TEAM_TERRITORY,
+		'MY_TERRITORY' => Soql.Scope.MY_TERRITORY,
 		'TEAM' => Soql.Scope.TEAM
 	};
 
-	private static final Map<String, Soql.Operator> OPERATOR_MAP = new Map<String, Soql.Operator>{
-		'=' => Soql.EQUALS,
-		'!=' => Soql.NOT_EQUALS,
-		'>' => Soql.GREATER_THAN,
-		'>=' => Soql.GREATER_OR_EQUAL,
-		'<' => Soql.LESS_THAN,
-		'<=' => Soql.LESS_OR_EQUAL,
-		'IN' => Soql.IN_COLLECTION,
-		'NOT IN' => Soql.NOT_IN_COLLECTION,
-		'LIKE' => Soql.LIKE_RAW,
-		'NOT LIKE' => Soql.NOT_LIKE_RAW
-	};
+	// ── PUBLIC ────────────────────────────────────────────────────────────
 
 	/**
 	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder.
@@ -71,142 +102,109 @@ public class SoqlParser {
 	 * @param queryString The SOQL query string to parse
 	 */
 	public void parse(Soql.Builder builder, String queryString) {
-		Map<String, Integer> positions = this.findKeywordPositions(queryString);
-		this.applyParsers(builder, queryString, positions);
+		ParseContext ctx = new ParseContext(queryString, new Scanner(queryString).scan());
+		this.applyParsers(builder, ctx);
 	}
 
+	// ── PRIVATE ───────────────────────────────────────────────────────────
+
 	/**
-	 * @description Scans a query string and returns the character position of each SOQL keyword found
-	 * at the top level (not inside parentheses or string literals).
-	 * @param queryString The SOQL query string to scan
-	 * @return A map of keyword to its starting character position
+	 * @description Dispatches each SOQL clause to its corresponding parse method.
+	 * @param builder The {@link Soql.Builder} to populate
+	 * @param ctx The {@link ParseContext} containing the query string and keyword positions
 	 */
-	public Map<String, Integer> findKeywordPositions(String queryString) {
-		Map<String, Integer> positions = new Map<String, Integer>();
-		List<String> keywords = new List<String>{
-			USING_SCOPE_KEYWORD,
-			GROUP_BY_KEYWORD,
-			ORDER_BY_KEYWORD,
-			FROM_KEYWORD,
-			WHERE_KEYWORD,
-			WITH_KEYWORD,
-			HAVING_KEYWORD,
-			LIMIT_KEYWORD,
-			OFFSET_KEYWORD,
-			FOR_KEYWORD,
-			ALL_ROWS_KEYWORD
-		};
-		String upper = queryString.toUpperCase();
-		Integer parenDepth = 0;
-		Boolean inString = false;
-		for (Integer i = 0; i < upper.length(); i++) {
-			String c = queryString.substring(i, i + 1);
-			if (c == '\'' && (i == 0 || queryString.substring(i - 1, i) != '\\')) {
-				inString = !inString;
-			} else if (c == '(' && !inString) {
-				parenDepth++;
-			} else if (c == ')' && !inString) {
-				parenDepth--;
-			} else if (parenDepth == 0 && !inString) {
-				for (String keyword : keywords) {
-					this.tryRecordKeyword(positions, upper, keyword, i);
-				}
-			}
+	private void applyParsers(Soql.Builder builder, ParseContext ctx) {
+		this.parseSelect(builder, this.extractClause(ctx, SELECT_KEYWORD));
+		this.parseFrom(builder, this.extractClause(ctx, FROM_KEYWORD));
+		String whereClause = this.extractClause(ctx, WHERE_KEYWORD);
+		if (String.isNotBlank(whereClause)) {
+			this.parseWhere(builder, whereClause);
 		}
-		positions.put(SELECT_KEYWORD, 0);
-		return positions;
+		String groupBy = this.extractClause(ctx, GROUP_BY_KEYWORD);
+		if (String.isNotBlank(groupBy)) {
+			this.parseGroupBy(builder, groupBy);
+		}
+		String havingClause = this.extractClause(ctx, HAVING_KEYWORD);
+		if (String.isNotBlank(havingClause)) {
+			this.parseHaving(builder, havingClause);
+		}
+		String orderBy = this.extractClause(ctx, ORDER_BY_KEYWORD);
+		if (String.isNotBlank(orderBy)) {
+			this.parseOrderBy(builder, orderBy);
+		}
+		String lim = this.extractClause(ctx, LIMIT_KEYWORD);
+		if (String.isNotBlank(lim)) {
+			this.parseLimit(builder, lim);
+		}
+		String off = this.extractClause(ctx, OFFSET_KEYWORD);
+		if (String.isNotBlank(off)) {
+			this.parseOffset(builder, off);
+		}
+		String usingScope = this.extractClause(ctx, USING_SCOPE_KEYWORD);
+		if (String.isNotBlank(usingScope)) {
+			this.parseUsingScope(builder, usingScope);
+		}
+		String withClause = this.extractClause(ctx, WITH_KEYWORD);
+		if (String.isNotBlank(withClause)) {
+			this.parseWith(builder, withClause);
+		}
+		String forClause = this.extractClause(ctx, FOR_KEYWORD);
+		if (String.isNotBlank(forClause)) {
+			this.parseFor(builder, forClause);
+		}
+		if (ctx.positions?.containsKey(ALL_ROWS_KEYWORD) == true) {
+			this.parseAllRows(builder);
+		}
 	}
 
 	/**
-	 * @description Returns the keyword that immediately follows the given keyword in the query,
-	 * based on character positions.
-	 * @param positions The keyword position map from {@link #findKeywordPositions}
-	 * @param currentKeyword The keyword to find the successor of
-	 * @return The next keyword name, or null if there is none
+	 * @description Builds an {@link Soql.Aggregation} from a function call token such as
+	 * {@code COUNT(Id) cnt}.
+	 * @param token The raw aggregation token
+	 * @return The constructed {@link Soql.Aggregation}
 	 */
-	public String getNextKeyword(Map<String, Integer> positions, String currentKeyword) {
-		List<String> allKeywords = new List<String>{
-			SELECT_KEYWORD,
-			FROM_KEYWORD,
-			WHERE_KEYWORD,
-			GROUP_BY_KEYWORD,
-			HAVING_KEYWORD,
-			ORDER_BY_KEYWORD,
-			LIMIT_KEYWORD,
-			OFFSET_KEYWORD,
-			USING_SCOPE_KEYWORD,
-			WITH_KEYWORD,
-			FOR_KEYWORD,
-			ALL_ROWS_KEYWORD
-		};
-		Integer currentPos = positions.get(currentKeyword);
-		if (currentPos == null) {
-			return null;
+	private Soql.Aggregation buildAggregation(String token) {
+		String upper = token.toUpperCase();
+		Integer openParen = upper.indexOf('(');
+		Integer closeParen = this.findMatchingParen(token, openParen);
+		Soql.Aggregation agg = new Soql.Aggregation(
+			FUNCTION_MAP.get(upper.substring(0, openParen).trim()),
+			token.substring(openParen + 1, closeParen).trim()
+		);
+		String alias = token.substring(closeParen + 1).trim();
+		if (String.isNotBlank(alias)) {
+			agg.withAlias(alias);
 		}
-		String nextKeyword = null;
-		Integer nextPos = MAX_INT;
-		for (String keyword : allKeywords) {
-			Integer pos = positions.get(keyword);
-			if (pos != null && pos > currentPos && pos < nextPos) {
-				nextPos = pos;
-				nextKeyword = keyword;
-			}
-		}
-		return nextKeyword;
+		return agg;
 	}
 
 	/**
-	 * @description Extracts the text of a clause by slicing between the start of one keyword and
-	 * the start of the next, trimming the keyword itself and surrounding whitespace.
-	 * @param queryString The full SOQL query string
-	 * @param positions The keyword position map from {@link #findKeywordPositions}
+	 * @description Extracts the text of a clause by slicing between the start of {@code keyword}
+	 * and the start of the next keyword, trimming the keyword name and surrounding whitespace.
+	 * @param ctx The {@link ParseContext} holding the query and positions
 	 * @param keyword The keyword whose clause content to extract
-	 * @param nextKeyword The keyword that terminates the clause, or null if none follows
-	 * @return The trimmed clause text, or an empty string if the keyword is not present
+	 * @return The trimmed clause text, or an empty string if the keyword is absent
 	 */
-	@SuppressWarnings('PMD.ExcessiveParameterList')
-	public String extractClause(
-		String queryString,
-		Map<String, Integer> positions,
-		String keyword,
-		String nextKeyword
-	) {
-		Integer startPos = positions.get(keyword);
+	private String extractClause(ParseContext ctx, String keyword) {
+		Integer startPos = ctx.positions?.get(keyword);
 		if (startPos == null) {
 			return '';
 		}
-		Integer endPos = this.calculateEndPos(queryString, positions, nextKeyword);
-		return queryString.substring(startPos + keyword.length(), endPos).trim();
+		String nextKeyword = this.getNextKeyword(ctx.positions, keyword);
+		Integer endPos = nextKeyword == null
+			? ctx.queryString.length()
+			: (ctx.positions.get(nextKeyword) ?? ctx.queryString.length());
+		return ctx.queryString.substring(startPos + keyword.length(), endPos).trim();
 	}
 
 	/**
-	 * @description Parses a single WHERE/HAVING condition expression of the form
-	 * {@code field operator value}.
-	 * @param str The condition string to parse
-	 * @return A {@link Soql.Condition} representing the parsed condition
+	 * @description Scans {@code queryString} and returns the starting position of each SOQL
+	 * keyword found at the top level (not inside parentheses or string literals).
+	 * @param queryString The SOQL query string to scan
+	 * @return A map of keyword to its starting character position
 	 */
-	public Soql.Condition parseCondition(String str) {
-		List<String> operators = new List<String>{
-			'NOT IN',
-			'NOT LIKE',
-			'!=',
-			'>=',
-			'<=',
-			'>',
-			'<',
-			'=',
-			'IN',
-			'LIKE'
-		};
-		for (String op : operators) {
-			Integer opPos = this.findOperatorPosition(str, op);
-			if (opPos >= 0) {
-				String fieldName = str.substring(0, opPos).trim();
-				String value = str.substring(opPos + op.length()).trim();
-				return new Soql.Condition(fieldName, OPERATOR_MAP.get(op), this.parseValue(value));
-			}
-		}
-		return new Soql.Condition(str, Soql.EQUALS, null);
+	private Map<String, Integer> findKeywordPositions(String queryString) {
+		return new Scanner(queryString).scan();
 	}
 
 	/**
@@ -214,9 +212,10 @@ public class SoqlParser {
 	 * at {@code openIndex}, accounting for nested parentheses.
 	 * @param str The string to search
 	 * @param openIndex The index of the opening parenthesis
-	 * @return The index of the matching closing parenthesis, or the string length if not found
+	 * @return The index of the matching closing parenthesis, or the string length if none found
 	 */
-	public Integer findMatchingParen(String str, Integer openIndex) {
+	@TestVisible
+	private Integer findMatchingParen(String str, Integer openIndex) {
 		Integer depth = 0;
 		for (Integer i = openIndex; i < str.length(); i++) {
 			String c = str.substring(i, i + 1);
@@ -233,12 +232,402 @@ public class SoqlParser {
 	}
 
 	/**
+	 * @description Finds the starting index of {@code operator} in {@code str} at the top level
+	 * (not inside parentheses or string literals), respecting word boundaries for alphabetic
+	 * operators.
+	 * @param str The condition string to scan
+	 * @param operator The operator token to locate
+	 * @return The index of the operator, or -1 if not found
+	 */
+	private Integer findOperatorPosition(String str, String operator) {
+		String strUpper = str.toUpperCase();
+		Integer parenDepth = 0;
+		Boolean inString = false;
+		for (Integer i = 0; i <= str.length() - operator.length(); i++) {
+			String c = str.substring(i, i + 1);
+			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+				inString = (inString == false);
+			} else if (inString == false) {
+				if (c == '(') {
+					parenDepth++;
+				} else if (c == ')') {
+					parenDepth--;
+				} else if (parenDepth == 0 && strUpper.substring(i, i + operator.length()) == operator && this.isAtWordBoundary(str, i, operator)) {
+					return i;
+				}
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * @description Returns the keyword that immediately follows {@code currentKeyword} in the
+	 * query, based on character positions.
+	 * @param positions The keyword position map
+	 * @param currentKeyword The keyword to find the successor of
+	 * @return The next keyword name, or null if none follows
+	 */
+	private String getNextKeyword(Map<String, Integer> positions, String currentKeyword) {
+		Integer currentPos = positions?.get(currentKeyword);
+		if (currentPos == null) {
+			return null;
+		}
+		String nextKeyword = null;
+		Integer nextPos = MAX_INT;
+		for (String keyword : ALL_KEYWORDS) {
+			Integer pos = positions.get(keyword);
+			if (pos != null && pos > currentPos && pos < nextPos) {
+				nextPos = pos;
+				nextKeyword = keyword;
+			}
+		}
+		return nextKeyword;
+	}
+
+	/**
+	 * @description Returns true if {@code token} is an aggregation function call (e.g.
+	 * {@code COUNT(Id)}).
+	 * @param token The SELECT item token to inspect
+	 * @return True if the token begins with a known aggregate function name followed by {@code (}
+	 */
+	private Boolean isAggregation(String token) {
+		String upper = token.toUpperCase();
+		Integer parenPos = upper.indexOf('(');
+		return parenPos > 0 && FUNCTION_MAP.containsKey(upper.substring(0, parenPos).trim());
+	}
+
+	/**
+	 * @description Returns true if the operator at position {@code i} in {@code str} is surrounded
+	 * by word boundaries (spaces, parentheses, or string start/end).
+	 * @param str The condition string
+	 * @param i The starting index of the operator
+	 * @param operator The operator text
+	 * @return True if both the before and after characters qualify as word boundaries
+	 */
+	private Boolean isAtWordBoundary(String str, Integer i, String operator) {
+		Integer afterPos = i + operator.length();
+		Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
+		String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
+		return beforeOk && (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
+	}
+
+	/**
+	 * @description Returns true if {@code str} looks like an ISO 8601 date (10 characters,
+	 * YYYY-MM-DD format).
+	 * @param str The uppercase string to test
+	 * @return True if it matches a date pattern
+	 */
+	private Boolean isDate(String str) {
+		return str?.length() == 10 && this.isValidDatePrefix(str);
+	}
+
+	/**
+	 * @description Returns true if {@code str} looks like an ISO 8601 datetime (at least 10
+	 * characters, contains 'T', and starts with a valid date prefix).
+	 * @param str The uppercase string to test
+	 * @return True if it matches a datetime pattern
+	 */
+	private Boolean isDateTime(String str) {
+		return str?.length() >= 10 && str.contains('T') && this.isValidDatePrefix(str.substring(0, 10));
+	}
+
+	/**
+	 * @description Returns true if {@code datePrefix} is a plausible YYYY-MM-DD date prefix
+	 * within the range 1900–2100.
+	 * @param datePrefix A 10-character string to validate
+	 * @return True if it parses as a valid calendar date
+	 */
+	private Boolean isValidDatePrefix(String datePrefix) {
+		if (datePrefix?.length() != 10 || datePrefix.substring(4, 5) != '-' || datePrefix.substring(7, 8) != '-') {
+			return false;
+		}
+		try {
+			Integer year = Integer.valueOf(datePrefix.substring(0, 4));
+			Integer month = Integer.valueOf(datePrefix.substring(5, 7));
+			Integer day = Integer.valueOf(datePrefix.substring(8, 10));
+			return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+
+	/**
+	 * @description Sets the ALL ROWS clause on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 */
+	private void parseAllRows(Soql.Builder builder) {
+		builder.setUsage(Soql.Usage.ALL_ROWS);
+	}
+
+	/**
+	 * @description Adds an aggregation SELECT item to the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param token The raw aggregation token
+	 */
+	private void parseAggregation(Soql.Builder builder, String token) {
+		builder.addSelect(this.buildAggregation(token));
+	}
+
+	/**
+	 * @description Splits {@code str} on top-level AND tokens and returns a parsed
+	 * {@link Soql.Criteria} tree.
+	 * @param str The AND expression to parse
+	 * @return A single {@link Soql.Condition} or a {@link Soql.ConditionalLogic} with ALL_CONDITIONS
+	 */
+	private Soql.Criteria parseAndExpr(String str) {
+		List<String> andParts = this.splitTopLevelKeyword(str, ' AND ');
+		if (andParts.size() == 1) {
+			return this.parseFactor(andParts[0]);
+		}
+		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
+		logic.setLogicType(Soql.LogicType.ALL_CONDITIONS);
+		for (String part : andParts) {
+			logic.addCondition(this.parseFactor(part));
+		}
+		return logic;
+	}
+
+	/**
+	 * @description Parses a single WHERE/HAVING condition expression of the form
+	 * {@code field operator value}.
+	 * @param str The condition string to parse
+	 * @return A {@link Soql.Condition} representing the parsed condition
+	 */
+	@TestVisible
+	private Soql.Condition parseCondition(String str) {
+		for (String op : OPERATOR_PRECEDENCE) {
+			Integer opPos = this.findOperatorPosition(str, op);
+			if (opPos >= 0) {
+				String fieldName = str.substring(0, opPos).trim();
+				String value = str.substring(opPos + op.length()).trim();
+				return new Soql.Condition(fieldName, OPERATOR_MAP.get(op), this.parseValue(value));
+			}
+		}
+		return new Soql.Condition(str, Soql.EQUALS, null);
+	}
+
+	/**
+	 * @description Parses a raw WHERE/HAVING expression into a {@link Soql.ConditionalLogic} tree.
+	 * @param str The expression string to wrap
+	 * @return A {@link Soql.ConditionalLogic} containing the parsed criteria
+	 */
+	private Soql.ConditionalLogic parseCriteriaLogic(String str) {
+		Soql.Criteria criteria = this.parseExpr(str);
+		if (criteria instanceof Soql.Condition) {
+			Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
+			logic.addCondition((Soql.Condition) criteria);
+			return logic;
+		}
+		return (Soql.ConditionalLogic) criteria;
+	}
+
+	/**
+	 * @description Parses a raw date string into a {@link Date}, falling back to the raw string
+	 * on failure.
+	 * @param trimmed The date string to parse
+	 * @return A {@link Date} or the original string
+	 */
+	private Object parseDate(String trimmed) {
+		try {
+			return Date.valueOf(trimmed);
+		} catch (Exception e) {
+			return trimmed;
+		}
+	}
+
+	/**
+	 * @description Parses a raw datetime string into a {@link DateTime}, falling back to the raw
+	 * string on failure.
+	 * @param trimmed The datetime string to parse
+	 * @return A {@link DateTime} or the original string
+	 */
+	private Object parseDateTime(String trimmed) {
+		try {
+			return DateTime.valueOfGmt(trimmed);
+		} catch (Exception e) {
+			return trimmed;
+		}
+	}
+
+	/**
+	 * @description Recursively parses a WHERE/HAVING expression, handling OR at the top level.
+	 * @param str The expression string to parse
+	 * @return A {@link Soql.Criteria} tree
+	 */
+	private Soql.Criteria parseExpr(String str) {
+		List<String> orParts = this.splitTopLevelKeyword(str, ' OR ');
+		if (orParts.size() == 1) {
+			return this.parseAndExpr(orParts[0]);
+		}
+		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
+		logic.setLogicType(Soql.LogicType.ANY_CONDITIONS);
+		for (String part : orParts) {
+			logic.addCondition(this.parseAndExpr(part));
+		}
+		return logic;
+	}
+
+	/**
+	 * @description Parses a single term: either a parenthesized sub-expression or a leaf
+	 * condition.
+	 * @param str The term string to parse
+	 * @return A {@link Soql.Criteria}
+	 */
+	private Soql.Criteria parseFactor(String str) {
+		String trimmed = str.trim();
+		if (trimmed.startsWith('(') && this.findMatchingParen(trimmed, 0) == trimmed.length() - 1) {
+			return this.parseExpr(trimmed.substring(1, trimmed.length() - 1).trim());
+		}
+		return this.parseCondition(trimmed);
+	}
+
+	/**
+	 * @description Sets the FOR clause on the builder based on the clause value.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param forStr The FOR clause value (e.g. UPDATE, VIEW, REFERENCE)
+	 */
+	private void parseFor(Soql.Builder builder, String forStr) {
+		String upper = forStr.toUpperCase();
+		if (upper.startsWith('UPDATE')) {
+			builder.setUsage(Soql.Usage.FOR_UPDATE);
+		} else if (upper.startsWith('VIEW')) {
+			builder.setUsage(Soql.Usage.FOR_VIEW);
+		} else if (upper.startsWith('REFERENCE')) {
+			builder.setUsage(Soql.Usage.FOR_REFERENCE);
+		}
+	}
+
+	/**
+	 * @description Sets the FROM clause on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param fromStr The entity name string
+	 */
+	private void parseFrom(Soql.Builder builder, String fromStr) {
+		builder.setFrom(fromStr);
+	}
+
+	/**
+	 * @description Parses the GROUP BY clause and adds each field to the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param groupByStr The GROUP BY clause content
+	 */
+	private void parseGroupBy(Soql.Builder builder, String groupByStr) {
+		for (String item : this.splitTopLevelKeyword(groupByStr, ',')) {
+			builder.addGroupBy(item.trim());
+		}
+	}
+
+	/**
+	 * @description Parses the HAVING clause into a criteria tree and sets it on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param havingStr The HAVING clause content
+	 */
+	private void parseHaving(Soql.Builder builder, String havingStr) {
+		builder.setHavingCriteria(this.parseCriteriaLogic(havingStr));
+	}
+
+	/**
+	 * @description Sets the LIMIT clause on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param limitStr The LIMIT value string
+	 */
+	private void parseLimit(Soql.Builder builder, String limitStr) {
+		builder.setRowLimit(Integer.valueOf(limitStr));
+	}
+
+	/**
+	 * @description Parses a parenthesized list value token into a {@link List<String>}.
+	 * Returns the raw string unchanged if the list body contains a subquery.
+	 * @param trimmed The parenthesized token to parse
+	 * @return A {@link List<String>} of values, or the original string for subqueries
+	 */
+	private Object parseList(String trimmed) {
+		String body = trimmed.substring(1, trimmed.length() - 1);
+		if (body.toUpperCase().contains('SELECT')) {
+			return trimmed;
+		}
+		List<String> result = new List<String>();
+		for (String item : this.splitTopLevelKeyword(body, ',')) {
+			String val = item.trim();
+			result.add((val.startsWith('\'') && val.endsWith('\'')) ? val.substring(1, val.length() - 1) : val);
+		}
+		return result;
+	}
+
+	/**
+	 * @description Parses a raw numeric string into an {@link Integer} or {@link Decimal},
+	 * falling back to the original string if parsing fails.
+	 * @param trimmed The numeric string to parse
+	 * @return An {@link Integer}, {@link Decimal}, or the original string
+	 */
+	private Object parseNumeric(String trimmed) {
+		try {
+			return Integer.valueOf(trimmed);
+		} catch (Exception intErr) {
+			try {
+				return Decimal.valueOf(trimmed);
+			} catch (Exception decErr) {
+				return trimmed;
+			}
+		}
+	}
+
+	/**
+	 * @description Sets the OFFSET clause on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param offsetStr The OFFSET value string
+	 */
+	private void parseOffset(Soql.Builder builder, String offsetStr) {
+		builder.setRowOffset(Integer.valueOf(offsetStr));
+	}
+
+	/**
+	 * @description Parses the ORDER BY clause and adds each item verbatim to the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param orderByStr The ORDER BY clause content
+	 */
+	private void parseOrderBy(Soql.Builder builder, String orderByStr) {
+		for (String item : this.splitTopLevelKeyword(orderByStr, ',')) {
+			builder.addRawOrderBy(item.trim());
+		}
+	}
+
+	/**
+	 * @description Parses the SELECT clause and registers each item (field, aggregation, or
+	 * subquery) on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param selectStr The SELECT clause content (after the SELECT keyword)
+	 */
+	private void parseSelect(Soql.Builder builder, String selectStr) {
+		builder.deselectAll();
+		for (String item : this.splitTopLevelKeyword(selectStr, ',')) {
+			String token = item.trim();
+			if (token.startsWith('(')) {
+				this.parseSubquery(builder, token);
+			} else if (this.isAggregation(token)) {
+				this.parseAggregation(builder, token);
+			} else {
+				builder.addSelect(token);
+			}
+		}
+	}
+
+	/**
+	 * @description Unquotes a single-quoted string literal, unescaping internal quotes.
+	 * @param trimmed The quoted token, including surrounding single quotes
+	 * @return The unquoted string value
+	 */
+	private Object parseStringLiteral(String trimmed) {
+		return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
+	}
+
+	/**
 	 * @description Parses a parenthesized subquery token and registers it as a SELECT item on the
-	 * builder.
+	 * builder. If the subquery body has no FROM clause, it is silently ignored.
 	 * @param builder The {@link Soql.Builder} to add the subquery to
 	 * @param subqueryStr The parenthesized subquery string, e.g. {@code (SELECT Id FROM Contacts)}
 	 */
-	public void parseSubquery(Soql.Builder builder, String subqueryStr) {
+	private void parseSubquery(Soql.Builder builder, String subqueryStr) {
 		String body = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
 		Integer fromPos = body.toUpperCase().indexOf(' FROM ');
 		if (fromPos < 0) {
@@ -255,14 +644,27 @@ public class SoqlParser {
 	}
 
 	/**
+	 * @description Sets the USING SCOPE clause on the builder when the scope name is recognized.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param usingScopeStr The scope name string
+	 */
+	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
+		Soql.Scope scope = SCOPE_MAP.get(usingScopeStr?.toUpperCase());
+		if (scope != null) {
+			builder.setScope(scope);
+		}
+	}
+
+	/**
 	 * @description Parses a raw SOQL value token into an appropriate Apex type (Boolean, Date,
 	 * DateTime, Integer, Decimal, List, or String).
 	 * @param token The raw value token from the query
 	 * @return The parsed value, or the original token string if no conversion applies
 	 */
-	public Object parseValue(String token) {
-		String trimmed = token.trim();
-		String upper = trimmed.toUpperCase();
+	@TestVisible
+	private Object parseValue(String token) {
+		String trimmed = token?.trim();
+		String upper = trimmed?.toUpperCase();
 		if (upper == 'NULL') {
 			return null;
 		}
@@ -272,13 +674,13 @@ public class SoqlParser {
 		if (upper == 'FALSE') {
 			return false;
 		}
-		if (trimmed.startsWith(':')) {
+		if (trimmed?.startsWith(':') == true) {
 			return trimmed;
 		}
-		if (trimmed.startsWith('\'')) {
+		if (trimmed?.startsWith('\'') == true) {
 			return this.parseStringLiteral(trimmed);
 		}
-		if (trimmed.startsWith('(')) {
+		if (trimmed?.startsWith('(') == true) {
 			return this.parseList(trimmed);
 		}
 		if (this.isDateTime(upper)) {
@@ -290,397 +692,173 @@ public class SoqlParser {
 		return this.parseNumeric(trimmed);
 	}
 
-	private void applyParsers(Soql.Builder builder, String queryString, Map<String, Integer> positions) {
-		this.parseSelect(builder, this.extractClause(queryString, positions, SELECT_KEYWORD, FROM_KEYWORD));
-		this.parseFrom(
-			builder,
-			this.extractClause(queryString, positions, FROM_KEYWORD, this.getNextKeyword(positions, FROM_KEYWORD))
-		);
-		String whereClause = this.extractClause(
-			queryString,
-			positions,
-			WHERE_KEYWORD,
-			this.getNextKeyword(positions, WHERE_KEYWORD)
-		);
-		if (String.isNotBlank(whereClause)) {
-			this.parseWhere(builder, whereClause);
-		}
-		String groupBy = this.extractClause(
-			queryString,
-			positions,
-			GROUP_BY_KEYWORD,
-			this.getNextKeyword(positions, GROUP_BY_KEYWORD)
-		);
-		if (String.isNotBlank(groupBy)) {
-			this.parseGroupBy(builder, groupBy);
-		}
-		String havingClause = this.extractClause(
-			queryString,
-			positions,
-			HAVING_KEYWORD,
-			this.getNextKeyword(positions, HAVING_KEYWORD)
-		);
-		if (String.isNotBlank(havingClause)) {
-			this.parseHaving(builder, havingClause);
-		}
-		String orderBy = this.extractClause(
-			queryString,
-			positions,
-			ORDER_BY_KEYWORD,
-			this.getNextKeyword(positions, ORDER_BY_KEYWORD)
-		);
-		if (String.isNotBlank(orderBy)) {
-			this.parseOrderBy(builder, orderBy);
-		}
-		String lim = this.extractClause(
-			queryString,
-			positions,
-			LIMIT_KEYWORD,
-			this.getNextKeyword(positions, LIMIT_KEYWORD)
-		);
-		if (String.isNotBlank(lim)) {
-			this.parseLimit(builder, lim);
-		}
-		String off = this.extractClause(
-			queryString,
-			positions,
-			OFFSET_KEYWORD,
-			this.getNextKeyword(positions, OFFSET_KEYWORD)
-		);
-		if (String.isNotBlank(off)) {
-			this.parseOffset(builder, off);
-		}
-		String usingScope = this.extractClause(
-			queryString,
-			positions,
-			USING_SCOPE_KEYWORD,
-			this.getNextKeyword(positions, USING_SCOPE_KEYWORD)
-		);
-		if (String.isNotBlank(usingScope)) {
-			this.parseUsingScope(builder, usingScope);
-		}
-		String withClause = this.extractClause(
-			queryString,
-			positions,
-			WITH_KEYWORD,
-			this.getNextKeyword(positions, WITH_KEYWORD)
-		);
-		if (String.isNotBlank(withClause)) {
-			this.parseWith(builder, withClause);
-		}
-		String forClause = this.extractClause(
-			queryString,
-			positions,
-			FOR_KEYWORD,
-			this.getNextKeyword(positions, FOR_KEYWORD)
-		);
-		if (String.isNotBlank(forClause)) {
-			this.parseFor(builder, forClause);
-		}
-		if (positions.containsKey(ALL_ROWS_KEYWORD)) {
-			this.parseAllRows(builder);
-		}
-	}
-
-	private Integer calculateEndPos(String queryString, Map<String, Integer> positions, String nextKeyword) {
-		if (nextKeyword == null) {
-			return queryString.length();
-		}
-		Integer nextPos = positions.get(nextKeyword);
-		return nextPos != null ? nextPos : queryString.length();
-	}
-
-	@SuppressWarnings('PMD.ExcessiveParameterList')
-	private void tryRecordKeyword(Map<String, Integer> positions, String upper, String keyword, Integer i) {
-		Integer endIndex = i + keyword.length();
-		if (endIndex > upper.length() || upper.substring(i, endIndex) != keyword) {
-			return;
-		}
-		Boolean beforeOk = (i == 0 || upper.substring(i - 1, i) == ' ');
-		Boolean afterOk = (endIndex >= upper.length() || upper.substring(endIndex, endIndex + 1) == ' ');
-		if (beforeOk && afterOk && !positions.containsKey(keyword)) {
-			positions.put(keyword, i);
-		}
-	}
-
-	private void parseSelect(Soql.Builder builder, String selectStr) {
-		builder.deselectAll();
-		for (String item : this.splitTopLevelKeyword(selectStr, ',')) {
-			String token = item.trim();
-			if (token.startsWith('(')) {
-				this.parseSubquery(builder, token);
-			} else if (this.isAggregation(token)) {
-				this.parseAggregation(builder, token);
-			} else {
-				builder.addSelect(token);
-			}
-		}
-	}
-
-	private Boolean isAggregation(String token) {
-		String upper = token.toUpperCase();
-		Integer parenPos = upper.indexOf('(');
-		if (parenPos <= 0) {
-			return false;
-		}
-		return FUNCTION_MAP.containsKey(upper.substring(0, parenPos).trim());
-	}
-
-	private void parseAggregation(Soql.Builder builder, String token) {
-		builder.addSelect(this.buildAggregation(token));
-	}
-
-	private Soql.Aggregation buildAggregation(String token) {
-		String upper = token.toUpperCase();
-		Integer openParen = upper.indexOf('(');
-		Integer closeParen = this.findMatchingParen(token, openParen);
-		Soql.Aggregation agg = new Soql.Aggregation(
-			FUNCTION_MAP.get(upper.substring(0, openParen).trim()),
-			token.substring(openParen + 1, closeParen).trim()
-		);
-		if (closeParen < token.length() - 1) {
-			String alias = token.substring(closeParen + 1).trim();
-			if (String.isNotBlank(alias)) {
-				agg.withAlias(alias);
-			}
-		}
-		return agg;
-	}
-
-	private void parseFrom(Soql.Builder builder, String fromStr) {
-		builder.setFrom(fromStr);
-	}
-
+	/**
+	 * @description Parses the WHERE clause into a criteria tree and sets it on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param whereStr The WHERE clause content
+	 */
 	private void parseWhere(Soql.Builder builder, String whereStr) {
 		builder.setWhereCriteria(this.parseCriteriaLogic(whereStr));
 	}
 
-	private void parseHaving(Soql.Builder builder, String havingStr) {
-		builder.setHavingCriteria(this.parseCriteriaLogic(havingStr));
-	}
-
-	private Soql.ConditionalLogic parseCriteriaLogic(String str) {
-		Soql.Criteria criteria = this.parseExpr(str);
-		if (criteria instanceof Soql.Condition) {
-			Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
-			logic.addCondition((Soql.Condition) criteria);
-			return logic;
-		}
-		return (Soql.ConditionalLogic) criteria;
-	}
-
-	private Soql.Criteria parseExpr(String str) {
-		List<String> orParts = this.splitTopLevelKeyword(str, ' OR ');
-		if (orParts.size() == 1) {
-			return this.parseAndExpr(orParts[0]);
-		}
-		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
-		logic.setLogicType(Soql.LogicType.ANY_CONDITIONS);
-		for (String part : orParts) {
-			logic.addCondition(this.parseAndExpr(part));
-		}
-		return logic;
-	}
-
-	private Soql.Criteria parseAndExpr(String str) {
-		List<String> andParts = this.splitTopLevelKeyword(str, ' AND ');
-		if (andParts.size() == 1) {
-			return this.parseFactor(andParts[0]);
-		}
-		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
-		logic.setLogicType(Soql.LogicType.ALL_CONDITIONS);
-		for (String part : andParts) {
-			logic.addCondition(this.parseFactor(part));
-		}
-		return logic;
-	}
-
-	private Soql.Criteria parseFactor(String str) {
-		String trimmed = str.trim();
-		if (trimmed.startsWith('(') && this.findMatchingParen(trimmed, 0) == trimmed.length() - 1) {
-			return this.parseExpr(trimmed.substring(1, trimmed.length() - 1).trim());
-		}
-		return this.parseCondition(trimmed);
-	}
-
-	private Integer findOperatorPosition(String str, String operator) {
-		Integer parenDepth = 0;
-		Boolean inString = false;
-		String strUpper = str.toUpperCase();
-		for (Integer i = 0; i <= str.length() - operator.length(); i++) {
-			String c = str.substring(i, i + 1);
-			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
-				inString = !inString;
-			} else if (!inString) {
-				if (c == '(') {
-					parenDepth++;
-				} else if (c == ')') {
-					parenDepth--;
-				} else if (
-					parenDepth == 0 &&
-					strUpper.substring(i, i + operator.length()) == operator &&
-					this.isAtWordBoundary(str, i, operator)
-				) {
-					return i;
-				}
-			}
-		}
-		return -1;
-	}
-
-	private Boolean isAtWordBoundary(String str, Integer i, String operator) {
-		Integer afterPos = i + operator.length();
-		Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
-		String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
-		return beforeOk && (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
-	}
-
-	private Object parseStringLiteral(String trimmed) {
-		return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
-	}
-
-	private Object parseList(String trimmed) {
-		String body = trimmed.substring(1, trimmed.length() - 1);
-		if (body.toUpperCase().contains('SELECT')) {
-			return trimmed;
-		}
-		List<String> result = new List<String>();
-		for (String item : this.splitTopLevelKeyword(body, ',')) {
-			String val = item.trim();
-			result.add((val.startsWith('\'') && val.endsWith('\'')) ? val.substring(1, val.length() - 1) : val);
-		}
-		return result;
-	}
-
-	private Object parseDateTime(String trimmed) {
-		try {
-			return DateTime.valueOfGmt(trimmed);
-		} catch (Exception e) {
-			return trimmed;
-		}
-	}
-
-	private Object parseDate(String trimmed) {
-		try {
-			return Date.valueOf(trimmed);
-		} catch (Exception e) {
-			return trimmed;
-		}
-	}
-
-	private Object parseNumeric(String trimmed) {
-		try {
-			return Integer.valueOf(trimmed);
-		} catch (Exception intErr) {
-			try {
-				return Decimal.valueOf(trimmed);
-			} catch (Exception decErr) {
-				return trimmed;
-			}
-		}
-	}
-
-	private void parseOrderBy(Soql.Builder builder, String orderByStr) {
-		for (String item : this.splitTopLevelKeyword(orderByStr, ',')) {
-			builder.addRawOrderBy(item.trim());
-		}
-	}
-
-	private void parseGroupBy(Soql.Builder builder, String groupByStr) {
-		for (String item : this.splitTopLevelKeyword(groupByStr, ',')) {
-			builder.addGroupBy(item.trim());
-		}
-	}
-
-	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
-		Soql.Scope scope = SCOPE_MAP.get(usingScopeStr.toUpperCase());
-		if (scope != null) {
-			builder.setScope(scope);
-		}
-	}
-
+	/**
+	 * @description Sets the WITH clause on the builder.
+	 * @param builder The {@link Soql.Builder} to modify
+	 * @param withStr The WITH clause value
+	 */
 	private void parseWith(Soql.Builder builder, String withStr) {
 		builder.setWithClause(withStr);
 	}
 
-	private void parseFor(Soql.Builder builder, String forStr) {
-		String upper = forStr.toUpperCase();
-		if (upper.startsWith('UPDATE')) {
-			builder.setUsage(Soql.Usage.FOR_UPDATE);
-		} else if (upper.startsWith('VIEW')) {
-			builder.setUsage(Soql.Usage.FOR_VIEW);
-		} else if (upper.startsWith('REFERENCE')) {
-			builder.setUsage(Soql.Usage.FOR_REFERENCE);
-		}
-	}
-
-	private void parseAllRows(Soql.Builder builder) {
-		builder.setUsage(Soql.Usage.ALL_ROWS);
-	}
-
-	private void parseLimit(Soql.Builder builder, String limitStr) {
-		builder.setRowLimit(Integer.valueOf(limitStr));
-	}
-
-	private void parseOffset(Soql.Builder builder, String offsetStr) {
-		builder.setRowOffset(Integer.valueOf(offsetStr));
-	}
-
-	private List<String> splitTopLevelKeyword(String str, String keyword) {
+	/**
+	 * @description Splits {@code str} on top-level occurrences of {@code delimiter} (not inside
+	 * parentheses or string literals).
+	 * @param str The string to split
+	 * @param delimiter The delimiter to split on
+	 * @return A list of substrings between top-level delimiter occurrences
+	 */
+	private List<String> splitTopLevelKeyword(String str, String delimiter) {
 		List<String> parts = new List<String>();
+		String strUpper = str?.toUpperCase() ?? '';
 		Integer parenDepth = 0;
 		Boolean inString = false;
 		Integer lastPos = 0;
-		String strUpper = str.toUpperCase();
-		for (Integer i = 0; i <= str.length() - keyword.length(); i++) {
+		for (Integer i = 0; i <= str.length() - delimiter.length(); i++) {
 			String c = str.substring(i, i + 1);
 			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
-				inString = !inString;
-			} else if (!inString) {
+				inString = (inString == false);
+			} else if (inString == false) {
 				if (c == '(') {
 					parenDepth++;
 				} else if (c == ')') {
 					parenDepth--;
-				} else if (parenDepth == 0 && strUpper.substring(i, i + keyword.length()) == keyword) {
+				} else if (parenDepth == 0 && strUpper.substring(i, i + delimiter.length()) == delimiter) {
 					parts.add(str.substring(lastPos, i));
-					lastPos = i + keyword.length();
+					lastPos = i + delimiter.length();
 					i = lastPos - 1;
 				}
 			}
 		}
 		if (lastPos < str.length()) {
 			parts.add(str.substring(lastPos));
-		} else if (lastPos == str.length() && parts.isEmpty()) {
+		} else if (parts.isEmpty()) {
 			parts.add(str);
 		}
 		return parts;
 	}
 
-	private Boolean isDateTime(String str) {
-		if (str == null || str.length() < 10 || !str.contains('T')) {
-			return false;
+	// ── INNER CLASSES ─────────────────────────────────────────────────────
+
+	/**
+	 * @description Holds a parsed query's raw string and keyword position map, used to pass
+	 * context through the parse pipeline without excessive parameter lists.
+	 */
+	private class ParseContext {
+		/** @description The raw query string being parsed. */
+		final String queryString;
+		/** @description Map of keyword name to its starting character position in the query. */
+		final Map<String, Integer> positions;
+
+		/**
+		 * @description Constructs a ParseContext with the given query and positions.
+		 * @param queryString The raw SOQL query string
+		 * @param positions The keyword position map produced by {@link Scanner#scan}
+		 */
+		ParseContext(String queryString, Map<String, Integer> positions) {
+			this.queryString = queryString;
+			this.positions = positions;
 		}
-		return this.isValidDatePrefix(str.substring(0, 10));
 	}
 
-	private Boolean isDate(String str) {
-		return str != null && str.length() == 10 && this.isValidDatePrefix(str);
-	}
+	/**
+	 * @description Stateful scanner that walks a SOQL query string character-by-character
+	 * and records the starting position of each top-level keyword.
+	 */
+	private class Scanner {
+		private final String rawQuery;
+		private final String upperQuery;
+		private Integer parenDepth = 0;
+		private Boolean inString = false;
+		private final Map<String, Integer> positions = new Map<String, Integer>();
 
-	private Boolean isValidDatePrefix(String datePrefix) {
-		if (datePrefix == null || datePrefix.length() != 10) {
-			return false;
+		/**
+		 * @description Constructs a Scanner for the given query string.
+		 * @param queryString The SOQL query string to scan
+		 */
+		private Scanner(String queryString) {
+			this.rawQuery = queryString;
+			this.upperQuery = queryString?.toUpperCase() ?? '';
 		}
-		if (datePrefix.substring(4, 5) != '-' || datePrefix.substring(7, 8) != '-') {
-			return false;
+
+		/**
+		 * @description Walks the query and returns a map of keyword to character position.
+		 * SELECT is always recorded at position 0; all other keywords are detected at top level only.
+		 * @return The keyword position map
+		 */
+		private Map<String, Integer> scan() {
+			for (Integer i = 0; i < this.upperQuery.length(); i++) {
+				this.processChar(i);
+			}
+			this.positions.put(SELECT_KEYWORD, 0);
+			return this.positions;
 		}
-		try {
-			Integer year = Integer.valueOf(datePrefix.substring(0, 4));
-			Integer month = Integer.valueOf(datePrefix.substring(5, 7));
-			Integer day = Integer.valueOf(datePrefix.substring(8, 10));
-			return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
-		} catch (Exception e) {
-			return false;
+
+		/**
+		 * @description Processes a single character: toggles string mode on unescaped quotes,
+		 * tracks paren depth, and attempts to record keyword positions at top level.
+		 * @param i The character index to process
+		 */
+		private void processChar(Integer i) {
+			String c = this.rawQuery.substring(i, i + 1);
+			if (c == '\'' && this.isNotEscaped(i)) {
+				this.inString = (this.inString == false);
+			} else if (c == '(' && this.inString == false) {
+				this.parenDepth++;
+			} else if (c == ')' && this.inString == false) {
+				this.parenDepth--;
+			} else if (this.parenDepth == 0 && this.inString == false) {
+				this.tryRecordAllKeywords(i);
+			}
+		}
+
+		/**
+		 * @description Returns true if the character at {@code i} is not preceded by a backslash.
+		 * @param i The character index to test
+		 * @return True if the character is unescaped
+		 */
+		private Boolean isNotEscaped(Integer i) {
+			return i == 0 || this.rawQuery.substring(i - 1, i) != '\\';
+		}
+
+		/**
+		 * @description Attempts to match and record every non-SELECT keyword at position {@code i}.
+		 * @param i The character index to test
+		 */
+		private void tryRecordAllKeywords(Integer i) {
+			for (String keyword : ALL_KEYWORDS) {
+				if (keyword == SELECT_KEYWORD) {
+					continue;
+				}
+				this.tryRecordKeyword(keyword, i);
+			}
+		}
+
+		/**
+		 * @description Records {@code keyword} at position {@code i} if the query text matches it
+		 * there with valid surrounding word boundaries, and it has not already been recorded.
+		 * @param keyword The keyword to attempt to match
+		 * @param i The character index to test
+		 */
+		private void tryRecordKeyword(String keyword, Integer i) {
+			Integer endIndex = i + keyword.length();
+			if (endIndex > this.upperQuery.length() || this.upperQuery.substring(i, endIndex) != keyword) {
+				return;
+			}
+			Boolean beforeOk = (i == 0 || this.upperQuery.substring(i - 1, i) == ' ');
+			Boolean afterOk = (endIndex >= this.upperQuery.length() || this.upperQuery.substring(endIndex, endIndex + 1) == ' ');
+			if (beforeOk && afterOk && this.positions?.containsKey(keyword) == false) {
+				this.positions.put(keyword, i);
+			}
 		}
 	}
 }

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -3,99 +3,45 @@
  * Handles all standard SOQL clauses including SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY,
  * LIMIT, OFFSET, USING SCOPE, WITH, FOR, and ALL ROWS.
  */
-@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity')
+@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.PropertyNamingConventions')
 public class SoqlParser {
-	private static final String ALL_ROWS_KEYWORD = 'ALL ROWS';
-	private static final String FOR_KEYWORD = 'FOR';
-	private static final String FROM_KEYWORD = 'FROM';
-	private static final String GROUP_BY_KEYWORD = 'GROUP BY';
-	private static final String HAVING_KEYWORD = 'HAVING';
-	private static final String LIMIT_KEYWORD = 'LIMIT';
-	private static final String OFFSET_KEYWORD = 'OFFSET';
-	private static final String ORDER_BY_KEYWORD = 'ORDER BY';
-	private static final String SELECT_KEYWORD = 'SELECT';
-	private static final String USING_SCOPE_KEYWORD = 'USING SCOPE';
-	private static final String WHERE_KEYWORD = 'WHERE';
-	private static final String WITH_KEYWORD = 'WITH';
-	private static final Integer MAX_INT = 2147483647;
-
-	private static final List<String> ALL_KEYWORDS = new List<String>{
-		SELECT_KEYWORD,
-		FROM_KEYWORD,
-		WHERE_KEYWORD,
-		GROUP_BY_KEYWORD,
-		HAVING_KEYWORD,
-		ORDER_BY_KEYWORD,
-		LIMIT_KEYWORD,
-		OFFSET_KEYWORD,
-		USING_SCOPE_KEYWORD,
-		WITH_KEYWORD,
-		FOR_KEYWORD,
-		ALL_ROWS_KEYWORD
-	};
-
-	private static final Map<String, Soql.Function> FUNCTION_MAP = new Map<String, Soql.Function>{
-		'AVG' => Soql.Function.AVG,
-		'CALENDAR_MONTH' => Soql.Function.CALENDAR_MONTH,
-		'CALENDAR_QUARTER' => Soql.Function.CALENDAR_QUARTER,
-		'CALENDAR_YEAR' => Soql.Function.CALENDAR_YEAR,
-		'COUNT' => Soql.Function.COUNT,
-		'COUNT_DISTINCT' => Soql.Function.COUNT_DISTINCT,
-		'DAY_IN_MONTH' => Soql.Function.DAY_IN_MONTH,
-		'DAY_IN_WEEK' => Soql.Function.DAY_IN_WEEK,
-		'DAY_IN_YEAR' => Soql.Function.DAY_IN_YEAR,
-		'DAY_ONLY' => Soql.Function.DAY_ONLY,
-		'FISCAL_MONTH' => Soql.Function.FISCAL_MONTH,
-		'FISCAL_QUARTER' => Soql.Function.FISCAL_QUARTER,
-		'FISCAL_YEAR' => Soql.Function.FISCAL_YEAR,
-		'FORMAT' => Soql.Function.FORMAT,
-		'HOUR_IN_DAY' => Soql.Function.HOUR_IN_DAY,
-		'MAX' => Soql.Function.MAX,
-		'MIN' => Soql.Function.MIN,
-		'SUM' => Soql.Function.SUM,
-		'WEEK_IN_MONTH' => Soql.Function.WEEK_IN_MONTH,
-		'WEEK_IN_YEAR' => Soql.Function.WEEK_IN_YEAR
-	};
-
-	private static final Map<String, Soql.Operator> OPERATOR_MAP = new Map<String, Soql.Operator>{
-		'!=' => Soql.NOT_EQUALS,
-		'<' => Soql.LESS_THAN,
-		'<=' => Soql.LESS_OR_EQUAL,
-		'=' => Soql.EQUALS,
-		'>' => Soql.GREATER_THAN,
-		'>=' => Soql.GREATER_OR_EQUAL,
-		'IN' => Soql.IN_COLLECTION,
-		'LIKE' => Soql.LIKE_RAW,
-		'NOT IN' => Soql.NOT_IN_COLLECTION,
-		'NOT LIKE' => Soql.NOT_LIKE_RAW
-	};
-
+	// prettier-ignore
+	private static final String ALL_ROWS_KEYWORD { get { return 'ALL ROWS'; } }
+	// prettier-ignore
+	private static final String FOR_KEYWORD { get { return 'FOR'; } }
+	// prettier-ignore
+	private static final String FROM_KEYWORD { get { return 'FROM'; } }
+	// prettier-ignore
+	private static final String GROUP_BY_KEYWORD { get { return 'GROUP BY'; } }
+	// prettier-ignore
+	private static final String HAVING_KEYWORD { get { return 'HAVING'; } }
+	// prettier-ignore
+	private static final String LIMIT_KEYWORD { get { return 'LIMIT'; } }
+	// prettier-ignore
+	private static final String OFFSET_KEYWORD { get { return 'OFFSET'; } }
+	// prettier-ignore
+	private static final String ORDER_BY_KEYWORD { get { return 'ORDER BY'; } }
+	// prettier-ignore
+	private static final String SELECT_KEYWORD { get { return 'SELECT'; } }
+	// prettier-ignore
+	private static final String USING_SCOPE_KEYWORD { get { return 'USING SCOPE'; } }
+	// prettier-ignore
+	private static final String WHERE_KEYWORD { get { return 'WHERE'; } }
+	// prettier-ignore
+	private static final String WITH_KEYWORD { get { return 'WITH'; } }
+	// prettier-ignore
+	private static final Integer MAX_INT { get { return 2147483647; } }
+	// prettier-ignore
+	private static final List<String> ALL_KEYWORDS { get { return new List<String>{ SELECT_KEYWORD, FROM_KEYWORD, WHERE_KEYWORD, GROUP_BY_KEYWORD, HAVING_KEYWORD, ORDER_BY_KEYWORD, LIMIT_KEYWORD, OFFSET_KEYWORD, USING_SCOPE_KEYWORD, WITH_KEYWORD, FOR_KEYWORD, ALL_ROWS_KEYWORD }; } }
+	// prettier-ignore
+	private static final Map<String, Soql.Function> FUNCTION_MAP { get { return new Map<String, Soql.Function>{ 'AVG' => Soql.Function.AVG, 'CALENDAR_MONTH' => Soql.Function.CALENDAR_MONTH, 'CALENDAR_QUARTER' => Soql.Function.CALENDAR_QUARTER, 'CALENDAR_YEAR' => Soql.Function.CALENDAR_YEAR, 'COUNT' => Soql.Function.COUNT, 'COUNT_DISTINCT' => Soql.Function.COUNT_DISTINCT, 'DAY_IN_MONTH' => Soql.Function.DAY_IN_MONTH, 'DAY_IN_WEEK' => Soql.Function.DAY_IN_WEEK, 'DAY_IN_YEAR' => Soql.Function.DAY_IN_YEAR, 'DAY_ONLY' => Soql.Function.DAY_ONLY, 'FISCAL_MONTH' => Soql.Function.FISCAL_MONTH, 'FISCAL_QUARTER' => Soql.Function.FISCAL_QUARTER, 'FISCAL_YEAR' => Soql.Function.FISCAL_YEAR, 'FORMAT' => Soql.Function.FORMAT, 'HOUR_IN_DAY' => Soql.Function.HOUR_IN_DAY, 'MAX' => Soql.Function.MAX, 'MIN' => Soql.Function.MIN, 'SUM' => Soql.Function.SUM, 'WEEK_IN_MONTH' => Soql.Function.WEEK_IN_MONTH, 'WEEK_IN_YEAR' => Soql.Function.WEEK_IN_YEAR }; } }
 	// Operators ordered by precedence: multi-word and longer tokens first to prevent partial matches
-	private static final List<String> OPERATOR_PRECEDENCE = new List<String>{
-		'NOT IN',
-		'NOT LIKE',
-		'!=',
-		'>=',
-		'<=',
-		'>',
-		'<',
-		'=',
-		'IN',
-		'LIKE'
-	};
-
-	private static final Map<String, Soql.Scope> SCOPE_MAP = new Map<String, Soql.Scope>{
-		'DELEGATED' => Soql.Scope.DELEGATED,
-		'EVERYTHING' => Soql.Scope.EVERYTHING,
-		'MINE' => Soql.Scope.MINE,
-		'MINE_AND_MY_GROUPS' => Soql.Scope.MINE_AND_MY_GROUPS,
-		'MY_TEAM_TERRITORY' => Soql.Scope.MY_TEAM_TERRITORY,
-		'MY_TERRITORY' => Soql.Scope.MY_TERRITORY,
-		'TEAM' => Soql.Scope.TEAM
-	};
-
-	// ── PUBLIC ────────────────────────────────────────────────────────────
-
+	// prettier-ignore
+	private static final Map<String, Soql.Operator> OPERATOR_MAP { get { return new Map<String, Soql.Operator>{ '!=' => Soql.NOT_EQUALS, '<' => Soql.LESS_THAN, '<=' => Soql.LESS_OR_EQUAL, '=' => Soql.EQUALS, '>' => Soql.GREATER_THAN, '>=' => Soql.GREATER_OR_EQUAL, 'IN' => Soql.IN_COLLECTION, 'LIKE' => Soql.LIKE_RAW, 'NOT IN' => Soql.NOT_IN_COLLECTION, 'NOT LIKE' => Soql.NOT_LIKE_RAW }; } }
+	// prettier-ignore
+	private static final List<String> OPERATOR_PRECEDENCE { get { return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' }; } }
+	// prettier-ignore
+	private static final Map<String, Soql.Scope> SCOPE_MAP { get { return new Map<String, Soql.Scope>{ 'DELEGATED' => Soql.Scope.DELEGATED, 'EVERYTHING' => Soql.Scope.EVERYTHING, 'MINE' => Soql.Scope.MINE, 'MINE_AND_MY_GROUPS' => Soql.Scope.MINE_AND_MY_GROUPS, 'MY_TEAM_TERRITORY' => Soql.Scope.MY_TEAM_TERRITORY, 'MY_TERRITORY' => Soql.Scope.MY_TERRITORY, 'TEAM' => Soql.Scope.TEAM }; } }
 	/**
 	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder.
 	 * @param builder The {@link Soql.Builder} to populate with parsed clauses

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -57,10 +57,15 @@ public class SoqlParser {
 	 * @param builder The {@link Soql.Builder} to populate with parsed clauses
 	 * @param queryString The SOQL query string to parse
 	 */
-	public void parse(Soql.Builder builder, String queryString) {
-		Map<String, Integer> positions = new Scanner(queryString).scan();
-		ParseContext ctx = new ParseContext(queryString, positions);
-		this.applyParsers(builder, ctx);
+	public void parse(Soql.Builder builder, String str) {
+		try {
+			Map<String, Integer> positions = new Scanner(str)?.scan();
+			ParseContext ctx = new ParseContext(str, positions);
+			this.applyParsers(builder, ctx);
+		} catch (Exception error) {
+			String msg = 'Invalid query: ' + str + '\n' + error + '\n' + error?.getStackTraceString();
+			throw new System.QueryException(msg);
+		}
 	}
 
 	/**
@@ -96,7 +101,7 @@ public class SoqlParser {
 		Integer openParen = upper.indexOf('(');
 		Integer closeParen = this.findMatchingParen(token, openParen);
 		String functionName = upper.substring(0, openParen)?.trim();
-		Soql.Function func = Soql.Function.valueOf(functionName);
+		Soql.Function func = this.getFunctionByName(functionName);
 		String field = token?.substring(openParen + 1, closeParen)?.trim();
 		Soql.Aggregation agg = new Soql.Aggregation(func, field);
 		String alias = token?.substring(closeParen + 1)?.trim();
@@ -147,6 +152,14 @@ public class SoqlParser {
 		return str.length();
 	}
 
+	private Soql.Function getFunctionByName(String name) {
+		try {
+			return Soql.Function.valueOf(name);
+		} catch (Exception error) {
+			throw new System.NoSuchElementException('Invalid SOQL Function: ' + name);
+		}
+	}
+
 	/**
 	 * @description Returns the keyword that immediately follows {@code currentKeyword} in the
 	 * query, based on character positions.
@@ -162,13 +175,21 @@ public class SoqlParser {
 		String nextKeyword = null;
 		Integer nextPos = MAX_INT;
 		for (String keyword : ALL_KEYWORDS) {
-			Integer pos = positions.get(keyword);
+			Integer pos = positions?.get(keyword);
 			if (pos != null && pos > currentPos && pos < nextPos) {
 				nextPos = pos;
 				nextKeyword = keyword;
 			}
 		}
 		return nextKeyword;
+	}
+
+	private Soql.Scope getScopeByName(String name) {
+		try {
+			return Soql.Scope.valueOf(name);
+		} catch (Exception error) {
+			throw new System.NoSuchElementException('Invalid SOQL Scope: ' + name);
+		}
 	}
 
 	/**
@@ -185,9 +206,10 @@ public class SoqlParser {
 		}
 		try {
 			String functionName = upper?.substring(0, parenPos).trim();
-			Soql.Function.valueOf(functionName);
+			this.getFunctionByName(functionName);
+			// No error; is a Soql.Function value:
 			return true;
-		} catch (System.NoSuchElementException errorrror) {
+		} catch (System.NoSuchElementException error) {
 			return false;
 		}
 	}
@@ -221,8 +243,7 @@ public class SoqlParser {
 			String andPart = andParts?.get(0);
 			return this.parseFactor(andPart);
 		}
-		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
-		logic.setLogicType(Soql.LogicType.ALL_CONDITIONS);
+		Soql.ConditionalLogic logic = new Soql.ConditionalLogic()?.setLogicType(Soql.LogicType.ALL_CONDITIONS);
 		for (String part : andParts) {
 			Soql.Criteria factor = this.parseFactor(part);
 			logic.addCondition(factor);
@@ -238,12 +259,12 @@ public class SoqlParser {
 	 */
 	@TestVisible
 	private Soql.Condition parseCondition(String str) {
-		for (String op : OPERATORS.precedence()) {
-			Integer opPos = OPERATORS.findPosition(str, op);
+		for (String op : OPERATORS?.precedence()) {
+			Integer opPos = OPERATORS?.findPosition(str, op);
 			if (opPos >= 0) {
 				String fieldName = str.substring(0, opPos).trim();
 				String rawValue = str.substring(opPos + op.length()).trim();
-				Soql.Operator operator = OPERATORS.resolve(op);
+				Soql.Operator operator = OPERATORS?.resolve(op);
 				Object value = this.parseValue(rawValue);
 				return new Soql.Condition(fieldName, operator, value);
 			}
@@ -292,11 +313,11 @@ public class SoqlParser {
 	 * @return A {@link Soql.Criteria}
 	 */
 	private Soql.Criteria parseFactor(String str) {
-		String trimmed = str.trim();
+		String trimmed = str?.trim();
 		Integer closeParen = this.findMatchingParen(trimmed, 0);
-		Boolean isWrapped = trimmed.startsWith('(') && closeParen == trimmed.length() - 1;
+		Boolean isWrapped = trimmed?.startsWith('(') && closeParen == trimmed?.length() - 1;
 		if (isWrapped) {
-			String body = trimmed.substring(1, trimmed.length() - 1).trim();
+			String body = trimmed?.substring(1, trimmed?.length() - 1)?.trim();
 			return this.parseExpr(body);
 		}
 		return this.parseCondition(trimmed);
@@ -362,10 +383,10 @@ public class SoqlParser {
 	 * @param limitStr The LIMIT value string
 	 */
 	private void parseLimit(Soql.Builder builder, String limitStr) {
-		if (String.isBlank(limitStr)) {
-			return;
+		if (String.isNotBlank(limitStr)) {
+			Integer rowLimit = Integer.valueOf(limitStr);
+			builder?.setRowLimit(rowLimit);
 		}
-		builder.setRowLimit(Integer.valueOf(limitStr));
 	}
 
 	/**
@@ -374,10 +395,10 @@ public class SoqlParser {
 	 * @param offsetStr The OFFSET value string
 	 */
 	private void parseOffset(Soql.Builder builder, String offsetStr) {
-		if (String.isBlank(offsetStr)) {
-			return;
+		if (String.isNotBlank(offsetStr)) {
+			Integer offset = Integer.valueOf(offsetStr);
+			builder?.setRowOffset(offset);
 		}
-		builder.setRowOffset(Integer.valueOf(offsetStr));
 	}
 
 	/**
@@ -386,11 +407,9 @@ public class SoqlParser {
 	 * @param orderByStr The ORDER BY clause content
 	 */
 	private void parseOrderBy(Soql.Builder builder, String orderByStr) {
-		if (String.isBlank(orderByStr)) {
-			return;
-		}
 		for (String item : this.splitTopLevelKeyword(orderByStr, ',')) {
-			builder.addRawOrderBy(item.trim());
+			String trimmed = item?.trim();
+			builder?.addRawOrderBy(trimmed);
 		}
 	}
 
@@ -401,16 +420,16 @@ public class SoqlParser {
 	 * @param selectStr The SELECT clause content (after the SELECT keyword)
 	 */
 	private void parseSelect(Soql.Builder builder, String selectStr) {
-		builder.deselectAll();
+		builder?.deselectAll();
 		List<String> tokens = this.splitTopLevelKeyword(selectStr, ',');
 		for (String item : tokens) {
 			String token = item.trim();
-			if (token.startsWith('(')) {
+			if (token?.startsWith('(')) {
 				this.parseSubquery(builder, token);
 			} else if (this.isAggregation(token)) {
 				this.parseAggregation(builder, token);
 			} else {
-				builder.addSelect(token);
+				builder?.addSelect(token);
 			}
 		}
 	}
@@ -422,7 +441,7 @@ public class SoqlParser {
 	 * @param subqueryStr The parenthesized subquery string, e.g. {@code (SELECT Id FROM Contacts)}
 	 */
 	private void parseSubquery(Soql.Builder builder, String subqueryStr) {
-		String body = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
+		String body = subqueryStr?.substring(1, subqueryStr?.length() - 1).trim();
 		String bodyUpper = body.toUpperCase();
 		Integer fromPos = bodyUpper.indexOf(' FROM ');
 		if (fromPos < 0) {
@@ -447,9 +466,10 @@ public class SoqlParser {
 	 * @param usingScopeStr The scope name string
 	 */
 	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
-		String value = usingScopeStr?.toUpperCase();
-		Soql.Scope scope = Soql.Scope.valueOf(value);
-		builder?.setScope(scope);
+		if (String.isNotBlank(usingScopeStr)) {
+			Soql.Scope scope = this.getScopeByName(usingScopeStr);
+			builder?.setScope(scope);
+		}
 	}
 
 	/**

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -252,7 +252,11 @@ public class SoqlParser {
 					parenDepth++;
 				} else if (c == ')') {
 					parenDepth--;
-				} else if (parenDepth == 0 && strUpper.substring(i, i + operator.length()) == operator && this.isAtWordBoundary(str, i, operator)) {
+				} else if (
+					parenDepth == 0 &&
+					strUpper.substring(i, i + operator.length()) == operator &&
+					this.isAtWordBoundary(str, i, operator)
+				) {
 					return i;
 				}
 			}
@@ -855,7 +859,8 @@ public class SoqlParser {
 				return;
 			}
 			Boolean beforeOk = (i == 0 || this.upperQuery.substring(i - 1, i) == ' ');
-			Boolean afterOk = (endIndex >= this.upperQuery.length() || this.upperQuery.substring(endIndex, endIndex + 1) == ' ');
+			Boolean afterOk = (endIndex >= this.upperQuery.length() ||
+			this.upperQuery.substring(endIndex, endIndex + 1) == ' ');
 			if (beforeOk && afterOk && this.positions?.containsKey(keyword) == false) {
 				this.positions.put(keyword, i);
 			}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -1,0 +1,609 @@
+public class SoqlParser {
+	private static final String SELECT_KEYWORD = 'SELECT';
+	private static final String FROM_KEYWORD = 'FROM';
+	private static final String WHERE_KEYWORD = 'WHERE';
+	private static final String GROUP_BY_KEYWORD = 'GROUP BY';
+	private static final String HAVING_KEYWORD = 'HAVING';
+	private static final String ORDER_BY_KEYWORD = 'ORDER BY';
+	private static final String LIMIT_KEYWORD = 'LIMIT';
+	private static final String OFFSET_KEYWORD = 'OFFSET';
+	private static final String USING_SCOPE_KEYWORD = 'USING SCOPE';
+	private static final String WITH_KEYWORD = 'WITH';
+	private static final String FOR_KEYWORD = 'FOR';
+	private static final String ALL_ROWS_KEYWORD = 'ALL ROWS';
+
+	private static final Map<String, Soql.Function> FUNCTION_MAP = new Map<String, Soql.Function>{
+		'AVG' => Soql.Function.AVG,
+		'CALENDAR_MONTH' => Soql.Function.CALENDAR_MONTH,
+		'CALENDAR_QUARTER' => Soql.Function.CALENDAR_QUARTER,
+		'CALENDAR_YEAR' => Soql.Function.CALENDAR_YEAR,
+		'COUNT' => Soql.Function.COUNT,
+		'COUNT_DISTINCT' => Soql.Function.COUNT_DISTINCT,
+		'DAY_IN_MONTH' => Soql.Function.DAY_IN_MONTH,
+		'DAY_IN_WEEK' => Soql.Function.DAY_IN_WEEK,
+		'DAY_IN_YEAR' => Soql.Function.DAY_IN_YEAR,
+		'DAY_ONLY' => Soql.Function.DAY_ONLY,
+		'FISCAL_MONTH' => Soql.Function.FISCAL_MONTH,
+		'FISCAL_QUARTER' => Soql.Function.FISCAL_QUARTER,
+		'FISCAL_YEAR' => Soql.Function.FISCAL_YEAR,
+		'FORMAT' => Soql.Function.FORMAT,
+		'HOUR_IN_DAY' => Soql.Function.HOUR_IN_DAY,
+		'MIN' => Soql.Function.MIN,
+		'MAX' => Soql.Function.MAX,
+		'SUM' => Soql.Function.SUM,
+		'WEEK_IN_MONTH' => Soql.Function.WEEK_IN_MONTH,
+		'WEEK_IN_YEAR' => Soql.Function.WEEK_IN_YEAR
+	};
+
+	private static final Map<String, Soql.Scope> SCOPE_MAP = new Map<String, Soql.Scope>{
+		'DELEGATED' => Soql.Scope.DELEGATED,
+		'EVERYTHING' => Soql.Scope.EVERYTHING,
+		'MINE' => Soql.Scope.MINE,
+		'MINE_AND_MY_GROUPS' => Soql.Scope.MINE_AND_MY_GROUPS,
+		'MY_TERRITORY' => Soql.Scope.MY_TERRITORY,
+		'MY_TEAM_TERRITORY' => Soql.Scope.MY_TEAM_TERRITORY,
+		'TEAM' => Soql.Scope.TEAM
+	};
+
+	private static final Map<String, Soql.Operator> OPERATOR_MAP = new Map<String, Soql.Operator>{
+		'=' => Soql.EQUALS,
+		'!=' => Soql.NOT_EQUALS,
+		'>' => Soql.GREATER_THAN,
+		'>=' => Soql.GREATER_OR_EQUAL,
+		'<' => Soql.LESS_THAN,
+		'<=' => Soql.LESS_OR_EQUAL,
+		'IN' => Soql.IN_COLLECTION,
+		'NOT IN' => Soql.NOT_IN_COLLECTION,
+		'LIKE' => Soql.CONTAINS,
+		'NOT LIKE' => Soql.NOT_CONTAINS
+	};
+
+	public void parse(Soql.Builder builder, String queryString) {
+		Map<String, Integer> keywordPositions = this.findKeywordPositions(queryString);
+
+		String selectStr = this.extractClause(queryString, keywordPositions, SELECT_KEYWORD, FROM_KEYWORD);
+		String fromStr = this.extractClause(queryString, keywordPositions, FROM_KEYWORD, this.getNextKeyword(keywordPositions, FROM_KEYWORD));
+		String whereStr = this.extractClause(queryString, keywordPositions, WHERE_KEYWORD, this.getNextKeyword(keywordPositions, WHERE_KEYWORD));
+		String groupByStr = this.extractClause(queryString, keywordPositions, GROUP_BY_KEYWORD, this.getNextKeyword(keywordPositions, GROUP_BY_KEYWORD));
+		String havingStr = this.extractClause(queryString, keywordPositions, HAVING_KEYWORD, this.getNextKeyword(keywordPositions, HAVING_KEYWORD));
+		String orderByStr = this.extractClause(queryString, keywordPositions, ORDER_BY_KEYWORD, this.getNextKeyword(keywordPositions, ORDER_BY_KEYWORD));
+		String limitStr = this.extractClause(queryString, keywordPositions, LIMIT_KEYWORD, this.getNextKeyword(keywordPositions, LIMIT_KEYWORD));
+		String offsetStr = this.extractClause(queryString, keywordPositions, OFFSET_KEYWORD, this.getNextKeyword(keywordPositions, OFFSET_KEYWORD));
+		String usingScopeStr = this.extractClause(queryString, keywordPositions, USING_SCOPE_KEYWORD, this.getNextKeyword(keywordPositions, USING_SCOPE_KEYWORD));
+		String withStr = this.extractClause(queryString, keywordPositions, WITH_KEYWORD, this.getNextKeyword(keywordPositions, WITH_KEYWORD));
+		String forStr = this.extractClause(queryString, keywordPositions, FOR_KEYWORD, this.getNextKeyword(keywordPositions, FOR_KEYWORD));
+		String allRowsStr = this.extractClause(queryString, keywordPositions, ALL_ROWS_KEYWORD, this.getNextKeyword(keywordPositions, ALL_ROWS_KEYWORD));
+
+		this.parseSelect(builder, selectStr);
+		this.parseFrom(builder, fromStr);
+		if (String.isNotBlank(whereStr)) {
+			this.parseWhere(builder, whereStr);
+		}
+		if (String.isNotBlank(groupByStr)) {
+			this.parseGroupBy(builder, groupByStr);
+		}
+		if (String.isNotBlank(havingStr)) {
+			this.parseHaving(builder, havingStr);
+		}
+		if (String.isNotBlank(orderByStr)) {
+			this.parseOrderBy(builder, orderByStr);
+		}
+		if (String.isNotBlank(limitStr)) {
+			this.parseLimit(builder, limitStr);
+		}
+		if (String.isNotBlank(offsetStr)) {
+			this.parseOffset(builder, offsetStr);
+		}
+		if (String.isNotBlank(usingScopeStr)) {
+			this.parseUsingScope(builder, usingScopeStr);
+		}
+		if (String.isNotBlank(withStr)) {
+			this.parseWith(builder, withStr);
+		}
+		if (String.isNotBlank(forStr)) {
+			this.parseFor(builder, forStr);
+		}
+		if (String.isNotBlank(allRowsStr)) {
+			this.parseAllRows(builder);
+		}
+	}
+
+	private Map<String, Integer> findKeywordPositions(String queryString) {
+		Map<String, Integer> positions = new Map<String, Integer>();
+		List<String> keywords = new List<String>{
+			USING_SCOPE_KEYWORD, GROUP_BY_KEYWORD, ORDER_BY_KEYWORD,
+			FROM_KEYWORD, WHERE_KEYWORD, WITH_KEYWORD, HAVING_KEYWORD,
+			LIMIT_KEYWORD, OFFSET_KEYWORD, FOR_KEYWORD, ALL_ROWS_KEYWORD
+		};
+
+		String upper = queryString.toUpperCase();
+		Integer parenDepth = 0;
+		Boolean inStringLiteral = false;
+
+		for (Integer i = 0; i < upper.length(); i++) {
+			String c = queryString.substring(i, i + 1);
+
+			if (c == '\'' && (i == 0 || queryString.substring(i - 1, i) != '\\')) {
+				inStringLiteral = !inStringLiteral;
+			}
+
+			if (!inStringLiteral) {
+				if (c == '(') {
+					parenDepth++;
+				} else if (c == ')') {
+					parenDepth--;
+				}
+			}
+
+			if (parenDepth == 0 && !inStringLiteral) {
+				for (String keyword : keywords) {
+					if (upper.substring(i).startsWithIgnoreCase(keyword)) {
+						Integer endIndex = i + keyword.length();
+						Boolean beforeOk = (i == 0 || upper.substring(i - 1, i) == ' ');
+						Boolean afterOk = (endIndex >= upper.length() || upper.substring(endIndex, endIndex + 1) == ' ');
+
+						if (beforeOk && afterOk && !positions.containsKey(keyword)) {
+							positions.put(keyword, i);
+						}
+					}
+				}
+			}
+		}
+
+		positions.put(SELECT_KEYWORD, 0);
+		return positions;
+	}
+
+	private String getNextKeyword(Map<String, Integer> positions, String currentKeyword) {
+		List<String> allKeywords = new List<String>{
+			SELECT_KEYWORD, FROM_KEYWORD, WHERE_KEYWORD, GROUP_BY_KEYWORD, HAVING_KEYWORD,
+			ORDER_BY_KEYWORD, LIMIT_KEYWORD, OFFSET_KEYWORD, USING_SCOPE_KEYWORD, WITH_KEYWORD,
+			FOR_KEYWORD, ALL_ROWS_KEYWORD
+		};
+
+		Integer currentPos = positions.get(currentKeyword);
+		if (currentPos == null) {
+			return null;
+		}
+
+		String nextKeyword = null;
+		Integer nextPos = 999999;
+
+		for (String keyword : allKeywords) {
+			Integer pos = positions.get(keyword);
+			if (pos != null && pos > currentPos && pos < nextPos) {
+				nextPos = pos;
+				nextKeyword = keyword;
+			}
+		}
+
+		return nextKeyword;
+	}
+
+	private String extractClause(String queryString, Map<String, Integer> positions, String keyword, String nextKeyword) {
+		Integer startPos = positions.get(keyword);
+		if (startPos == null) {
+			return '';
+		}
+
+		startPos = startPos + keyword.length();
+
+		Integer endPos;
+		if (nextKeyword == null) {
+			endPos = queryString.length();
+		} else {
+			Integer nextPos = positions.get(nextKeyword);
+			endPos = nextPos != null ? nextPos : queryString.length();
+		}
+
+		String clause = queryString.substring(startPos, endPos).trim();
+		return clause;
+	}
+
+	private void parseSelect(Soql.Builder builder, String selectStr) {
+		builder.deselectAll();
+		List<String> selectItems = this.splitTopLevel(selectStr, ',');
+
+		for (String item : selectItems) {
+			String trimmed = item.trim();
+			if (trimmed.startsWith('(')) {
+				this.parseSubquery(builder, trimmed);
+			} else if (this.isAggregation(trimmed)) {
+				this.parseAggregation(builder, trimmed);
+			} else {
+				builder.addSelect(trimmed);
+			}
+		}
+	}
+
+	private Boolean isAggregation(String token) {
+		String upper = token.toUpperCase();
+		Integer parenPos = upper.indexOf('(');
+		if (parenPos <= 0) {
+			return false;
+		}
+
+		String functionName = upper.substring(0, parenPos).trim();
+		return FUNCTION_MAP.containsKey(functionName);
+	}
+
+	private void parseSubquery(Soql.Builder builder, String subqueryStr) {
+		String innerContent = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
+		Integer fromPos = innerContent.toUpperCase().indexOf(' FROM ');
+
+		if (fromPos < 0) {
+			return;
+		}
+
+		String selectPart = innerContent.substring(0, fromPos).trim();
+		String fromPart = innerContent.substring(fromPos + 6).trim();
+		String[] fromTokens = fromPart.split(' ');
+		String fromEntity = fromTokens[0];
+
+		if (selectPart.toUpperCase().startsWith('SELECT ')) {
+			selectPart = selectPart.substring(7).trim();
+		}
+
+		Soql.InnerQuery innerQuery = new Soql.InnerQuery(fromEntity);
+		new SoqlParser().parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
+		builder.addSelect((Soql.Selectable) innerQuery);
+	}
+
+	private void parseAggregation(Soql.Builder builder, String token) {
+		String upper = token.toUpperCase();
+		Integer openParen = upper.indexOf('(');
+		Integer closeParen = this.findMatchingParen(token, openParen);
+
+		String functionName = upper.substring(0, openParen).trim();
+		String innerField = token.substring(openParen + 1, closeParen).trim();
+		Soql.Function fn = FUNCTION_MAP.get(functionName);
+
+		Soql.Aggregation agg = new Soql.Aggregation(fn, innerField);
+
+		if (closeParen < token.length() - 1) {
+			String afterParen = token.substring(closeParen + 1).trim();
+			String alias = afterParen.trim();
+			if (String.isNotBlank(alias)) {
+				agg.withAlias(alias);
+			}
+		}
+
+		builder.addSelect(agg);
+	}
+
+	private Integer findMatchingParen(String str, Integer openIndex) {
+		Integer depth = 0;
+		for (Integer i = openIndex; i < str.length(); i++) {
+			String c = str.substring(i, i + 1);
+			if (c == '(') {
+				depth++;
+			} else if (c == ')') {
+				depth--;
+				if (depth == 0) {
+					return i;
+				}
+			}
+		}
+		return str.length();
+	}
+
+	private void parseFrom(Soql.Builder builder, String fromStr) {
+		builder.setFrom(fromStr.trim());
+	}
+
+	private void parseWhere(Soql.Builder builder, String whereStr) {
+		Soql.Criteria criteria = this.parseExpr(whereStr);
+		if (criteria instanceof Soql.Condition) {
+			Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
+			logic.addCondition((Soql.Condition) criteria);
+			builder.setWhereCriteria(logic);
+		} else {
+			builder.setWhereCriteria((Soql.ConditionalLogic) criteria);
+		}
+	}
+
+	private Soql.Criteria parseExpr(String str) {
+		List<String> orParts = this.splitTopLevelKeyword(str, ' OR ');
+		if (orParts.size() == 1) {
+			return this.parseAndExpr(orParts[0]);
+		}
+
+		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
+		logic.setLogicType(Soql.LogicType.ANY_CONDITIONS);
+		for (String part : orParts) {
+			logic.addCondition(this.parseAndExpr(part));
+		}
+		return logic;
+	}
+
+	private Soql.Criteria parseAndExpr(String str) {
+		List<String> andParts = this.splitTopLevelKeyword(str, ' AND ');
+		if (andParts.size() == 1) {
+			return this.parseFactor(andParts[0]);
+		}
+
+		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
+		logic.setLogicType(Soql.LogicType.ALL_CONDITIONS);
+		for (String part : andParts) {
+			logic.addCondition(this.parseFactor(part));
+		}
+		return logic;
+	}
+
+	private Soql.Criteria parseFactor(String str) {
+		String trimmed = str.trim();
+		if (trimmed.startsWith('(') && this.findMatchingParen(trimmed, 0) == trimmed.length() - 1) {
+			String innerStr = trimmed.substring(1, trimmed.length() - 1).trim();
+			return this.parseExpr(innerStr);
+		}
+		return this.parseCondition(trimmed);
+	}
+
+	private Soql.Condition parseCondition(String str) {
+		List<String> operators = new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
+
+		for (String op : operators) {
+			Integer opPos = this.findOperatorPosition(str, op);
+			if (opPos >= 0) {
+				String fieldName = str.substring(0, opPos).trim();
+				String value = str.substring(opPos + op.length()).trim();
+				Soql.Operator operator = OPERATOR_MAP.get(op.toUpperCase());
+				if (operator == null) {
+					operator = Soql.EQUALS;
+				}
+				return new Soql.Condition(fieldName, operator, this.parseValue(value));
+			}
+		}
+
+		return new Soql.Condition(str, Soql.EQUALS, null);
+	}
+
+	private Integer findOperatorPosition(String str, String operator) {
+		Integer parenDepth = 0;
+		Boolean inString = false;
+
+		for (Integer i = 0; i <= str.length() - operator.length(); i++) {
+			String c = str.substring(i, i + 1);
+
+			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+				inString = !inString;
+			} else if (!inString) {
+				if (c == '(') {
+					parenDepth++;
+				} else if (c == ')') {
+					parenDepth--;
+				} else if (parenDepth == 0 && str.substring(i).toUpperCase().startsWith(operator)) {
+					return i;
+				}
+			}
+		}
+
+		return -1;
+	}
+
+	private Object parseValue(String token) {
+		String t = token.trim().toUpperCase();
+
+		if (t == 'NULL') {
+			return null;
+		}
+		if (t == 'TRUE') {
+			return true;
+		}
+		if (t == 'FALSE') {
+			return false;
+		}
+		if (token.trim().startsWith(':')) {
+			return token.trim();
+		}
+		if (token.trim().startsWith('\'')) {
+			String unquoted = token.trim().substring(1, token.trim().length() - 1);
+			return unquoted.replace('\\\'', '\'');
+		}
+		if (token.trim().startsWith('(')) {
+			String parenthetical = token.trim().substring(1, token.trim().length() - 1);
+			if (parenthetical.toUpperCase().contains('SELECT')) {
+				return token.trim();
+			}
+			List<String> items = this.splitTopLevel(parenthetical, ',');
+			List<String> result = new List<String>();
+			for (String item : items) {
+				String cleaned = item.trim();
+				if (cleaned.startsWith('\'') && cleaned.endsWith('\'')) {
+					cleaned = cleaned.substring(1, cleaned.length() - 1);
+				}
+				result.add(cleaned);
+			}
+			return result;
+		}
+
+		if (this.isDateTime(t)) {
+			try {
+				return DateTime.valueOfGmt(token.trim());
+			} catch (Exception e) {
+				return token.trim();
+			}
+		}
+		if (this.isDate(t)) {
+			try {
+				return Date.valueOf(token.trim());
+			} catch (Exception e) {
+				return token.trim();
+			}
+		}
+
+		try {
+			return Integer.valueOf(token.trim());
+		} catch (Exception e) {
+		}
+
+		try {
+			return Decimal.valueOf(token.trim());
+		} catch (Exception e) {
+		}
+
+		return token.trim();
+	}
+
+	private void parseOrderBy(Soql.Builder builder, String orderByStr) {
+		List<String> items = this.splitTopLevel(orderByStr, ',');
+		for (String item : items) {
+			builder.addRawOrderBy(item.trim());
+		}
+	}
+
+	private void parseGroupBy(Soql.Builder builder, String groupByStr) {
+		List<String> items = this.splitTopLevel(groupByStr, ',');
+		for (String item : items) {
+			builder.addGroupBy(item.trim());
+		}
+	}
+
+	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
+		String scopeName = usingScopeStr.trim().toUpperCase();
+		Soql.Scope scope = SCOPE_MAP.get(scopeName);
+		if (scope != null) {
+			builder.setScope(scope);
+		}
+	}
+
+	private void parseWith(Soql.Builder builder, String withStr) {
+		builder.setWithClause(withStr.trim());
+	}
+
+	private void parseFor(Soql.Builder builder, String forStr) {
+		String trimmed = forStr.trim().toUpperCase();
+		if (trimmed.startsWith('UPDATE')) {
+			builder.setUsage(Soql.Usage.FOR_UPDATE);
+		} else if (trimmed.startsWith('VIEW')) {
+			builder.setUsage(Soql.Usage.FOR_VIEW);
+		} else if (trimmed.startsWith('REFERENCE')) {
+			builder.setUsage(Soql.Usage.FOR_REFERENCE);
+		}
+	}
+
+	private void parseAllRows(Soql.Builder builder) {
+		builder.setUsage(Soql.Usage.ALL_ROWS);
+	}
+
+	private void parseHaving(Soql.Builder builder, String havingStr) {
+		Soql.Criteria criteria = this.parseExpr(havingStr);
+		if (criteria instanceof Soql.Condition) {
+			Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
+			logic.addCondition((Soql.Condition) criteria);
+			builder.setHavingCriteria(logic);
+		} else {
+			builder.setHavingCriteria((Soql.ConditionalLogic) criteria);
+		}
+	}
+
+	private void parseLimit(Soql.Builder builder, String limitStr) {
+		Integer rowLimit = Integer.valueOf(limitStr.trim());
+		builder.setRowLimit(rowLimit);
+	}
+
+	private void parseOffset(Soql.Builder builder, String offsetStr) {
+		Integer rowOffset = Integer.valueOf(offsetStr.trim());
+		builder.setRowOffset(rowOffset);
+	}
+
+	private List<String> splitTopLevel(String str, String delimiter) {
+		List<String> parts = new List<String>();
+		Integer parenDepth = 0;
+		Boolean inString = false;
+		Integer lastPos = 0;
+
+		for (Integer i = 0; i < str.length(); i++) {
+			String c = str.substring(i, i + 1);
+
+			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+				inString = !inString;
+			} else if (!inString) {
+				if (c == '(') {
+					parenDepth++;
+				} else if (c == ')') {
+					parenDepth--;
+				} else if (parenDepth == 0 && str.substring(i).startsWith(delimiter)) {
+					parts.add(str.substring(lastPos, i));
+					lastPos = i + delimiter.length();
+					i = lastPos - 1;
+				}
+			}
+		}
+
+		if (lastPos < str.length()) {
+			parts.add(str.substring(lastPos));
+		}
+
+		return parts;
+	}
+
+	private List<String> splitTopLevelKeyword(String str, String keyword) {
+		List<String> parts = new List<String>();
+		Integer parenDepth = 0;
+		Boolean inString = false;
+		Integer lastPos = 0;
+
+		for (Integer i = 0; i <= str.length() - keyword.length(); i++) {
+			String c = str.substring(i, i + 1);
+
+			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+				inString = !inString;
+			} else if (!inString) {
+				if (c == '(') {
+					parenDepth++;
+				} else if (c == ')') {
+					parenDepth--;
+				} else if (parenDepth == 0 && str.substring(i).toUpperCase().startsWith(keyword)) {
+					parts.add(str.substring(lastPos, i));
+					lastPos = i + keyword.length();
+					i = lastPos - 1;
+				}
+			}
+		}
+
+		if (lastPos < str.length()) {
+			parts.add(str.substring(lastPos));
+		} else if (lastPos == str.length() && parts.isEmpty()) {
+			parts.add(str);
+		}
+
+		return parts;
+	}
+
+	private Boolean isDateTime(String str) {
+		if (str == null || str.length() < 10) {
+			return false;
+		}
+		String prefix = str.substring(0, 10);
+		return this.isValidDatePrefix(prefix) && str.contains('T');
+	}
+
+	private Boolean isDate(String str) {
+		if (str == null || str.length() != 10) {
+			return false;
+		}
+		return this.isValidDatePrefix(str);
+	}
+
+	private Boolean isValidDatePrefix(String datePrefix) {
+		if (datePrefix == null || datePrefix.length() != 10) {
+			return false;
+		}
+		if (datePrefix.substring(4, 5) != '-' || datePrefix.substring(7, 8) != '-') {
+			return false;
+		}
+		String yearPart = datePrefix.substring(0, 4);
+		String monthPart = datePrefix.substring(5, 7);
+		String dayPart = datePrefix.substring(8, 10);
+
+		try {
+			Integer year = Integer.valueOf(yearPart);
+			Integer month = Integer.valueOf(monthPart);
+			Integer day = Integer.valueOf(dayPart);
+			return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
+		} catch (Exception e) {
+			return false;
+		}
+	}
+}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -306,12 +306,46 @@ public class SoqlParser {
 			if (opPos >= 0) {
 				String fieldName = str?.substring(0, opPos).trim();
 				String rawValue = str?.substring(opPos + op.length()).trim();
+				if (op == 'LIKE' || op == 'NOT LIKE') {
+					return this.parseLikeCondition(fieldName, op, rawValue);
+				}
 				Soql.Operator operator = OPERATORS?.resolve(op);
 				Object value = this.parseValue(rawValue);
 				return new Soql.Condition(fieldName, operator, value);
 			}
 		}
 		return new Soql.Condition(str, Soql.EQUALS, null);
+	}
+
+	/**
+	 * @description Parses a LIKE or NOT LIKE condition, routing to the appropriate semantic operator
+	 * based on the wildcard pattern in the value. Simple patterns map to existing operators
+	 * ({@link Soql.CONTAINS}, {@link Soql.STARTS_WITH}, {@link Soql.ENDS_WITH}); complex patterns
+	 * fall back to {@link SoqlParser.RawLikeOperator}.
+	 * @param fieldName The field name being compared
+	 * @param op The operator symbol ('LIKE' or 'NOT LIKE')
+	 * @param rawValue The raw value token from the query string
+	 * @return A {@link Soql.Condition} with the appropriate operator and stripped value
+	 */
+	private Soql.Condition parseLikeCondition(String fieldName, String op, String rawValue) {
+		Boolean negated = op == 'NOT LIKE';
+		Object parsed = this.parseValue(rawValue);
+		if (parsed instanceof String) {
+			String value = (String) parsed;
+			Boolean leadingWild = value?.startsWith('%') == true;
+			Boolean trailingWild = value?.endsWith('%') == true;
+			if (leadingWild && trailingWild) {
+				Soql.Operator operator = negated ? Soql.NOT_CONTAINS : Soql.CONTAINS;
+				return new Soql.Condition(fieldName, operator, value.substring(1, value.length() - 1));
+			} else if (trailingWild) {
+				Soql.Operator operator = negated ? Soql.NOT_STARTS_WITH : Soql.STARTS_WITH;
+				return new Soql.Condition(fieldName, operator, value.substring(0, value.length() - 1));
+			} else if (leadingWild) {
+				Soql.Operator operator = negated ? Soql.NOT_ENDS_WITH : Soql.ENDS_WITH;
+				return new Soql.Condition(fieldName, operator, value.substring(1));
+			}
+		}
+		return new Soql.Condition(fieldName, new SoqlParser.RawLikeOperator(op), parsed);
 	}
 
 	/**
@@ -653,9 +687,7 @@ public class SoqlParser {
 				'>' => Soql.GREATER_THAN,
 				'>=' => Soql.GREATER_OR_EQUAL,
 				'IN' => Soql.IN_COLLECTION,
-				'LIKE' => Soql.LIKE_RAW,
-				'NOT IN' => Soql.NOT_IN_COLLECTION,
-				'NOT LIKE' => Soql.NOT_LIKE_RAW
+				'NOT IN' => Soql.NOT_IN_COLLECTION
 			}.get(symbol);
 		}
 
@@ -998,6 +1030,17 @@ public class SoqlParser {
 		 */
 		private Object parseStringLiteral(String trimmed) {
 			return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
+		}
+	}
+
+	/**
+	 * @description Operator for raw LIKE/NOT LIKE expressions where the value already contains
+	 * wildcard characters (e.g., {@code '%foo%bar%'}). Unlike {@link Soql.ContainsOperator},
+	 * this operator does not add additional wildcard characters around the value.
+	 */
+	private class RawLikeOperator extends Soql.Operator {
+		private RawLikeOperator(String token) {
+			super(token);
 		}
 	}
 }

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -328,7 +328,7 @@ public class SoqlParser {
 	 */
 	private Soql.Criteria parseFactor(String str) {
 		String trimmed = str?.trim();
-		Integer lastIndex = (trimmed?.length ?? 0) - 1;
+		Integer lastIndex = (trimmed?.length() ?? 0) - 1;
 		Integer closeParen = this.findMatchingParen(trimmed, 0);
 		Boolean isWrapped = trimmed?.startsWith('(') == true && closeParen == lastIndex;
 		if (isWrapped) {
@@ -619,10 +619,9 @@ public class SoqlParser {
 				return false;
 			}
 			try {
-				Integer year = Integer.valueOf(datePrefix?.substring(0, 4));
 				Integer month = Integer.valueOf(datePrefix?.substring(5, 7));
 				Integer day = Integer.valueOf(datePrefix?.substring(8, 10));
-				return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
+				return month >= 1 && month <= 12 && day >= 1 && day <= 31;
 			} catch (Exception error) {
 				return false;
 			}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -77,7 +77,8 @@ public class SoqlParser {
 	 * @param queryString The SOQL query string to parse
 	 */
 	public void parse(Soql.Builder builder, String queryString) {
-		ParseContext ctx = new ParseContext(queryString, new Scanner(queryString).scan());
+		Map<String, Integer> positions = new Scanner(queryString).scan();
+		ParseContext ctx = new ParseContext(queryString, positions);
 		this.applyParsers(builder, ctx);
 	}
 
@@ -113,14 +114,11 @@ public class SoqlParser {
 		String upper = token.toUpperCase();
 		Integer openParen = upper.indexOf('(');
 		Integer closeParen = this.findMatchingParen(token, openParen);
-		Soql.Aggregation agg = new Soql.Aggregation(
-			Soql.Function.valueOf(upper.substring(0, openParen).trim()),
-			token.substring(openParen + 1, closeParen).trim()
-		);
-		String alias = token.substring(closeParen + 1).trim();
-		if (String.isNotBlank(alias)) {
-			agg.withAlias(alias);
-		}
+		Soql.Function func = Soql.Function.valueOf(upper.substring(0, openParen)?.trim());
+		String field = token?.substring(openParen + 1, closeParen)?.trim();
+		Soql.Aggregation agg = new Soql.Aggregation(func, field);
+		String alias = token?.substring(closeParen + 1)?.trim();
+		agg?.withAlias(alias);
 		return agg;
 	}
 
@@ -340,7 +338,8 @@ public class SoqlParser {
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
 		logic.setLogicType(Soql.LogicType.ALL_CONDITIONS);
 		for (String part : andParts) {
-			logic.addCondition(this.parseFactor(part));
+			Soql.Criteria factor = this.parseFactor(part);
+			logic.addCondition(factor);
 		}
 		return logic;
 	}
@@ -357,8 +356,10 @@ public class SoqlParser {
 			Integer opPos = this.findOperatorPosition(str, op);
 			if (opPos >= 0) {
 				String fieldName = str.substring(0, opPos).trim();
-				String value = str.substring(opPos + op.length()).trim();
-				return new Soql.Condition(fieldName, OPERATOR_MAP.get(op), this.parseValue(value));
+				String rawValue = str.substring(opPos + op.length()).trim();
+				Soql.Operator operator = OPERATOR_MAP.get(op);
+				Object value = this.parseValue(rawValue);
+				return new Soql.Condition(fieldName, operator, value);
 			}
 		}
 		return new Soql.Condition(str, Soql.EQUALS, null);
@@ -420,7 +421,8 @@ public class SoqlParser {
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
 		logic.setLogicType(Soql.LogicType.ANY_CONDITIONS);
 		for (String part : orParts) {
-			logic.addCondition(this.parseAndExpr(part));
+			Soql.Criteria andExpr = this.parseAndExpr(part);
+			logic.addCondition(andExpr);
 		}
 		return logic;
 	}
@@ -433,8 +435,11 @@ public class SoqlParser {
 	 */
 	private Soql.Criteria parseFactor(String str) {
 		String trimmed = str.trim();
-		if (trimmed.startsWith('(') && this.findMatchingParen(trimmed, 0) == trimmed.length() - 1) {
-			return this.parseExpr(trimmed.substring(1, trimmed.length() - 1).trim());
+		Integer closeParen = this.findMatchingParen(trimmed, 0);
+		Boolean isWrapped = trimmed.startsWith('(') && closeParen == trimmed.length() - 1;
+		if (isWrapped) {
+			String inner = trimmed.substring(1, trimmed.length() - 1).trim();
+			return this.parseExpr(inner);
 		}
 		return this.parseCondition(trimmed);
 	}
@@ -513,13 +518,16 @@ public class SoqlParser {
 	 */
 	private Object parseList(String trimmed) {
 		String body = trimmed.substring(1, trimmed.length() - 1);
-		if (body.toUpperCase().contains('SELECT')) {
+		String bodyUpper = body.toUpperCase();
+		if (bodyUpper.contains('SELECT')) {
 			return trimmed;
 		}
 		List<String> result = new List<String>();
-		for (String item : this.splitTopLevelKeyword(body, ',')) {
+		List<String> items = this.splitTopLevelKeyword(body, ',');
+		for (String item : items) {
 			String val = item.trim();
-			result.add((val.startsWith('\'') && val.endsWith('\'')) ? val.substring(1, val.length() - 1) : val);
+			String unquoted = val.substring(1, val.length() - 1);
+			result.add((val.startsWith('\'') && val.endsWith('\'')) ? unquoted : val);
 		}
 		return result;
 	}
@@ -576,7 +584,8 @@ public class SoqlParser {
 	 */
 	private void parseSelect(Soql.Builder builder, String selectStr) {
 		builder.deselectAll();
-		for (String item : this.splitTopLevelKeyword(selectStr, ',')) {
+		List<String> tokens = this.splitTopLevelKeyword(selectStr, ',');
+		for (String item : tokens) {
 			String token = item.trim();
 			if (token.startsWith('(')) {
 				this.parseSubquery(builder, token);
@@ -605,7 +614,8 @@ public class SoqlParser {
 	 */
 	private void parseSubquery(Soql.Builder builder, String subqueryStr) {
 		String body = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
-		Integer fromPos = body.toUpperCase().indexOf(' FROM ');
+		String bodyUpper = body.toUpperCase();
+		Integer fromPos = bodyUpper.indexOf(' FROM ');
 		if (fromPos < 0) {
 			return;
 		}
@@ -614,9 +624,12 @@ public class SoqlParser {
 		if (selectPart.toUpperCase().startsWith('SELECT ')) {
 			selectPart = selectPart.substring(7).trim();
 		}
-		Soql.InnerQuery innerQuery = new Soql.InnerQuery(fromPart.split(' ')[0]);
-		new SoqlParser().parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
-		builder.addSelect((Soql.Selectable) innerQuery);
+		String objectName = fromPart.split(' ')[0];
+		Soql.InnerQuery innerQuery = new Soql.InnerQuery(objectName);
+		SoqlParser subParser = new SoqlParser();
+		subParser.parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
+		Soql.Selectable selectable = (Soql.Selectable) innerQuery;
+		builder.addSelect(selectable);
 	}
 
 	/**
@@ -625,14 +638,9 @@ public class SoqlParser {
 	 * @param usingScopeStr The scope name string
 	 */
 	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
-		if (String.isBlank(usingScopeStr)) {
-			return;
-		}
-		try {
-			builder.setScope(Soql.Scope.valueOf(usingScopeStr?.toUpperCase()));
-		} catch (Exception e) {
-			// Unrecognized scope — ignore
-		}
+		String value = usingScopeStr?.toUpperCase();
+		Soql.Scope scope = Soql.Scope.valueOf(value);
+		builder?.setScope(scope);
 	}
 
 	/**
@@ -672,10 +680,10 @@ public class SoqlParser {
 	 * @param whereStr The WHERE clause content
 	 */
 	private void parseWhere(Soql.Builder builder, String whereStr) {
-		if (String.isBlank(whereStr)) {
-			return;
+		if (String.isBlank(whereStr) == false) {
+			Soql.ConditionalLogic logic = this.parseCriteriaLogic(whereStr);
+			builder?.setWhereCriteria(logic);
 		}
-		builder.setWhereCriteria(this.parseCriteriaLogic(whereStr));
 	}
 
 	/**
@@ -684,10 +692,7 @@ public class SoqlParser {
 	 * @param withStr The WITH clause value
 	 */
 	private void parseWith(Soql.Builder builder, String withStr) {
-		if (String.isBlank(withStr)) {
-			return;
-		}
-		builder.setWithClause(withStr);
+		builder?.setWithClause(withStr);
 	}
 
 	/**
@@ -727,24 +732,23 @@ public class SoqlParser {
 		return parts;
 	}
 
-	// ── INNER CLASSES ─────────────────────────────────────────────────────
-
+	// **** INNER **** //
 	/**
 	 * @description Holds a parsed query's raw string and keyword position map, used to pass
 	 * context through the parse pipeline without excessive parameter lists.
 	 */
 	private class ParseContext {
 		/** @description The raw query string being parsed. */
-		final String queryString;
+		private final String queryString;
 		/** @description Map of keyword name to its starting character position in the query. */
-		final Map<String, Integer> positions;
+		private final Map<String, Integer> positions;
 
 		/**
 		 * @description Constructs a ParseContext with the given query and positions.
 		 * @param queryString The raw SOQL query string
 		 * @param positions The keyword position map produced by {@link Scanner#scan}
 		 */
-		ParseContext(String queryString, Map<String, Integer> positions) {
+		private ParseContext(String queryString, Map<String, Integer> positions) {
 			this.queryString = queryString;
 			this.positions = positions;
 		}
@@ -755,17 +759,20 @@ public class SoqlParser {
 	 * and records the starting position of each top-level keyword.
 	 */
 	private class Scanner {
+		private final Map<String, Integer> positions;
 		private final String rawQuery;
 		private final String upperQuery;
-		private Integer parenDepth = 0;
-		private Boolean inString = false;
-		private final Map<String, Integer> positions = new Map<String, Integer>();
+		private Boolean inString;
+		private Integer parenDepth;
 
 		/**
 		 * @description Constructs a Scanner for the given query string.
 		 * @param queryString The SOQL query string to scan
 		 */
 		private Scanner(String queryString) {
+			this.inString = false;
+			this.parenDepth = 0;
+			this.positions = new Map<String, Integer>();
 			this.rawQuery = queryString;
 			this.upperQuery = queryString?.toUpperCase() ?? '';
 		}
@@ -779,7 +786,7 @@ public class SoqlParser {
 			for (Integer i = 0; i < this.upperQuery.length(); i++) {
 				this.processChar(i);
 			}
-			this.positions.put(SELECT_KEYWORD, 0);
+			this.positions?.put(SELECT_KEYWORD, 0);
 			return this.positions;
 		}
 
@@ -816,10 +823,9 @@ public class SoqlParser {
 		 */
 		private void tryRecordAllKeywords(Integer i) {
 			for (String keyword : ALL_KEYWORDS) {
-				if (keyword == SELECT_KEYWORD) {
-					continue;
+				if (keyword != SELECT_KEYWORD) {
+					this.tryRecordKeyword(keyword, i);
 				}
-				this.tryRecordKeyword(keyword, i);
 			}
 		}
 

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -348,9 +348,6 @@ public class SoqlParser {
 				String fieldName = str.substring(0, opPos).trim();
 				String value = str.substring(opPos + op.length()).trim();
 				Soql.Operator operator = OPERATOR_MAP.get(op.toUpperCase());
-				if (operator == null) {
-					operator = Soql.EQUALS;
-				}
 				return new Soql.Condition(fieldName, operator, this.parseValue(value));
 			}
 		}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -370,7 +370,12 @@ public class SoqlParser {
 				} else if (c == ')') {
 					parenDepth--;
 				} else if (parenDepth == 0 && str.substring(i).toUpperCase().startsWith(operator)) {
-					return i;
+					Integer afterPos = i + operator.length();
+					Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
+					Boolean afterOk = (afterPos >= str.length() || str.substring(afterPos, afterPos + 1) == ' ' || str.substring(afterPos, afterPos + 1) == '(');
+					if (beforeOk && afterOk) {
+						return i;
+					}
 				}
 			}
 		}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -54,8 +54,8 @@ public class SoqlParser {
 		'<=' => Soql.LESS_OR_EQUAL,
 		'IN' => Soql.IN_COLLECTION,
 		'NOT IN' => Soql.NOT_IN_COLLECTION,
-		'LIKE' => Soql.CONTAINS,
-		'NOT LIKE' => Soql.NOT_CONTAINS
+		'LIKE' => Soql.LIKE_RAW,
+		'NOT LIKE' => Soql.NOT_LIKE_RAW
 	};
 
 	public void parse(Soql.Builder builder, String queryString) {

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -1,3 +1,9 @@
+/**
+ * @description Parses SOQL query strings into structured {@link Soql.Builder} representations.
+ * Handles all standard SOQL clauses including SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY,
+ * LIMIT, OFFSET, USING SCOPE, WITH, FOR, and ALL ROWS.
+ */
+@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity')
 public class SoqlParser {
 	private static final String SELECT_KEYWORD = 'SELECT';
 	private static final String FROM_KEYWORD = 'FROM';
@@ -59,11 +65,22 @@ public class SoqlParser {
 		'NOT LIKE' => Soql.NOT_LIKE_RAW
 	};
 
+	/**
+	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder.
+	 * @param builder The {@link Soql.Builder} to populate with parsed clauses
+	 * @param queryString The SOQL query string to parse
+	 */
 	public void parse(Soql.Builder builder, String queryString) {
 		Map<String, Integer> positions = this.findKeywordPositions(queryString);
 		this.applyParsers(builder, queryString, positions);
 	}
 
+	/**
+	 * @description Scans a query string and returns the character position of each SOQL keyword found
+	 * at the top level (not inside parentheses or string literals).
+	 * @param queryString The SOQL query string to scan
+	 * @return A map of keyword to its starting character position
+	 */
 	public Map<String, Integer> findKeywordPositions(String queryString) {
 		Map<String, Integer> positions = new Map<String, Integer>();
 		List<String> keywords = new List<String>{
@@ -84,14 +101,7 @@ public class SoqlParser {
 				parenDepth--;
 			} else if (parenDepth == 0 && !inString) {
 				for (String keyword : keywords) {
-					Integer endIndex = i + keyword.length();
-					if (endIndex <= upper.length() && upper.substring(i, endIndex) == keyword) {
-						Boolean beforeOk = (i == 0 || upper.substring(i - 1, i) == ' ');
-						Boolean afterOk = (endIndex >= upper.length() || upper.substring(endIndex, endIndex + 1) == ' ');
-						if (beforeOk && afterOk && !positions.containsKey(keyword)) {
-							positions.put(keyword, i);
-						}
-					}
+					this.tryRecordKeyword(positions, upper, keyword, i);
 				}
 			}
 		}
@@ -99,6 +109,13 @@ public class SoqlParser {
 		return positions;
 	}
 
+	/**
+	 * @description Returns the keyword that immediately follows the given keyword in the query,
+	 * based on character positions.
+	 * @param positions The keyword position map from {@link #findKeywordPositions}
+	 * @param currentKeyword The keyword to find the successor of
+	 * @return The next keyword name, or null if there is none
+	 */
 	public String getNextKeyword(Map<String, Integer> positions, String currentKeyword) {
 		List<String> allKeywords = new List<String>{
 			SELECT_KEYWORD, FROM_KEYWORD, WHERE_KEYWORD, GROUP_BY_KEYWORD, HAVING_KEYWORD,
@@ -121,6 +138,16 @@ public class SoqlParser {
 		return nextKeyword;
 	}
 
+	/**
+	 * @description Extracts the text of a clause by slicing between the start of one keyword and
+	 * the start of the next, trimming the keyword itself and surrounding whitespace.
+	 * @param queryString The full SOQL query string
+	 * @param positions The keyword position map from {@link #findKeywordPositions}
+	 * @param keyword The keyword whose clause content to extract
+	 * @param nextKeyword The keyword that terminates the clause, or null if none follows
+	 * @return The trimmed clause text, or an empty string if the keyword is not present
+	 */
+	@SuppressWarnings('PMD.ExcessiveParameterList')
 	public String extractClause(String queryString, Map<String, Integer> positions, String keyword, String nextKeyword) {
 		Integer startPos = positions.get(keyword);
 		if (startPos == null) {
@@ -130,6 +157,12 @@ public class SoqlParser {
 		return queryString.substring(startPos + keyword.length(), endPos).trim();
 	}
 
+	/**
+	 * @description Parses a single WHERE/HAVING condition expression of the form
+	 * {@code field operator value}.
+	 * @param str The condition string to parse
+	 * @return A {@link Soql.Condition} representing the parsed condition
+	 */
 	public Soql.Condition parseCondition(String str) {
 		List<String> operators = new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
 		for (String op : operators) {
@@ -143,6 +176,13 @@ public class SoqlParser {
 		return new Soql.Condition(str, Soql.EQUALS, null);
 	}
 
+	/**
+	 * @description Finds the index of the closing parenthesis that matches the opening parenthesis
+	 * at {@code openIndex}, accounting for nested parentheses.
+	 * @param str The string to search
+	 * @param openIndex The index of the opening parenthesis
+	 * @return The index of the matching closing parenthesis, or the string length if not found
+	 */
 	public Integer findMatchingParen(String str, Integer openIndex) {
 		Integer depth = 0;
 		for (Integer i = openIndex; i < str.length(); i++) {
@@ -159,6 +199,12 @@ public class SoqlParser {
 		return str.length();
 	}
 
+	/**
+	 * @description Parses a parenthesized subquery token and registers it as a SELECT item on the
+	 * builder.
+	 * @param builder The {@link Soql.Builder} to add the subquery to
+	 * @param subqueryStr The parenthesized subquery string, e.g. {@code (SELECT Id FROM Contacts)}
+	 */
 	public void parseSubquery(Soql.Builder builder, String subqueryStr) {
 		String inner = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
 		Integer fromPos = inner.toUpperCase().indexOf(' FROM ');
@@ -175,17 +221,23 @@ public class SoqlParser {
 		builder.addSelect((Soql.Selectable) innerQuery);
 	}
 
+	/**
+	 * @description Parses a raw SOQL value token into an appropriate Apex type (Boolean, Date,
+	 * DateTime, Integer, Decimal, List, or String).
+	 * @param token The raw value token from the query
+	 * @return The parsed value, or the original token string if no conversion applies
+	 */
 	public Object parseValue(String token) {
 		String trimmed = token.trim();
 		String upper = trimmed.toUpperCase();
-		if (upper == 'NULL') return null;
-		if (upper == 'TRUE') return true;
-		if (upper == 'FALSE') return false;
-		if (trimmed.startsWith(':')) return trimmed;
-		if (trimmed.startsWith('\'')) return this.parseStringLiteral(trimmed);
-		if (trimmed.startsWith('(')) return this.parseList(trimmed);
-		if (this.isDateTime(upper)) return this.parseDateTime(trimmed);
-		if (this.isDate(upper)) return this.parseDate(trimmed);
+		if (upper == 'NULL') { return null; }
+		if (upper == 'TRUE') { return true; }
+		if (upper == 'FALSE') { return false; }
+		if (trimmed.startsWith(':')) { return trimmed; }
+		if (trimmed.startsWith('\'')) { return this.parseStringLiteral(trimmed); }
+		if (trimmed.startsWith('(')) { return this.parseList(trimmed); }
+		if (this.isDateTime(upper)) { return this.parseDateTime(trimmed); }
+		if (this.isDate(upper)) { return this.parseDate(trimmed); }
 		return this.parseNumeric(trimmed);
 	}
 
@@ -239,6 +291,19 @@ public class SoqlParser {
 		}
 		Integer nextPos = positions.get(nextKeyword);
 		return nextPos != null ? nextPos : queryString.length();
+	}
+
+	@SuppressWarnings('PMD.ExcessiveParameterList')
+	private void tryRecordKeyword(Map<String, Integer> positions, String upper, String keyword, Integer i) {
+		Integer endIndex = i + keyword.length();
+		if (endIndex > upper.length() || upper.substring(i, endIndex) != keyword) {
+			return;
+		}
+		Boolean beforeOk = (i == 0 || upper.substring(i - 1, i) == ' ');
+		Boolean afterOk = (endIndex >= upper.length() || upper.substring(endIndex, endIndex + 1) == ' ');
+		if (beforeOk && afterOk && !positions.containsKey(keyword)) {
+			positions.put(keyword, i);
+		}
 	}
 
 	private void parseSelect(Soql.Builder builder, String selectStr) {
@@ -354,18 +419,19 @@ public class SoqlParser {
 					parenDepth++;
 				} else if (c == ')') {
 					parenDepth--;
-				} else if (parenDepth == 0 && strUpper.substring(i, i + operator.length()) == operator) {
-					Integer afterPos = i + operator.length();
-					Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
-					String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
-					Boolean afterOk = (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
-					if (beforeOk && afterOk) {
-						return i;
-					}
+				} else if (parenDepth == 0 && strUpper.substring(i, i + operator.length()) == operator && this.isAtWordBoundary(str, i, operator)) {
+					return i;
 				}
 			}
 		}
 		return -1;
+	}
+
+	private Boolean isAtWordBoundary(String str, Integer i, String operator) {
+		Integer afterPos = i + operator.length();
+		Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
+		String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
+		return beforeOk && (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
 	}
 
 	private Object parseStringLiteral(String trimmed) {
@@ -404,13 +470,13 @@ public class SoqlParser {
 	private Object parseNumeric(String trimmed) {
 		try {
 			return Integer.valueOf(trimmed);
-		} catch (Exception e) {
+		} catch (Exception intErr) {
+			try {
+				return Decimal.valueOf(trimmed);
+			} catch (Exception decErr) {
+				return trimmed;
+			}
 		}
-		try {
-			return Decimal.valueOf(trimmed);
-		} catch (Exception e) {
-		}
-		return trimmed;
 	}
 
 	private void parseOrderBy(Soql.Builder builder, String orderByStr) {

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -103,7 +103,7 @@ public class SoqlParser {
 		if (String.isNotBlank(forStr)) {
 			this.parseFor(builder, forStr);
 		}
-		if (String.isNotBlank(allRowsStr)) {
+		if (keywordPositions.containsKey(ALL_ROWS_KEYWORD)) {
 			this.parseAllRows(builder);
 		}
 	}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -108,7 +108,7 @@ public class SoqlParser {
 		}
 	}
 
-	private Map<String, Integer> findKeywordPositions(String queryString) {
+	public Map<String, Integer> findKeywordPositions(String queryString) {
 		Map<String, Integer> positions = new Map<String, Integer>();
 		List<String> keywords = new List<String>{
 			USING_SCOPE_KEYWORD, GROUP_BY_KEYWORD, ORDER_BY_KEYWORD,
@@ -154,7 +154,7 @@ public class SoqlParser {
 		return positions;
 	}
 
-	private String getNextKeyword(Map<String, Integer> positions, String currentKeyword) {
+	public String getNextKeyword(Map<String, Integer> positions, String currentKeyword) {
 		List<String> allKeywords = new List<String>{
 			SELECT_KEYWORD, FROM_KEYWORD, WHERE_KEYWORD, GROUP_BY_KEYWORD, HAVING_KEYWORD,
 			ORDER_BY_KEYWORD, LIMIT_KEYWORD, OFFSET_KEYWORD, USING_SCOPE_KEYWORD, WITH_KEYWORD,
@@ -180,7 +180,7 @@ public class SoqlParser {
 		return nextKeyword;
 	}
 
-	private String extractClause(String queryString, Map<String, Integer> positions, String keyword, String nextKeyword) {
+	public String extractClause(String queryString, Map<String, Integer> positions, String keyword, String nextKeyword) {
 		Integer startPos = positions.get(keyword);
 		if (startPos == null) {
 			return '';
@@ -227,7 +227,7 @@ public class SoqlParser {
 		return FUNCTION_MAP.containsKey(functionName);
 	}
 
-	private void parseSubquery(Soql.Builder builder, String subqueryStr) {
+	public void parseSubquery(Soql.Builder builder, String subqueryStr) {
 		String innerContent = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
 		Integer fromPos = innerContent.toUpperCase().indexOf(' FROM ');
 
@@ -271,7 +271,7 @@ public class SoqlParser {
 		builder.addSelect(agg);
 	}
 
-	private Integer findMatchingParen(String str, Integer openIndex) {
+	public Integer findMatchingParen(String str, Integer openIndex) {
 		Integer depth = 0;
 		for (Integer i = openIndex; i < str.length(); i++) {
 			String c = str.substring(i, i + 1);
@@ -339,7 +339,7 @@ public class SoqlParser {
 		return this.parseCondition(trimmed);
 	}
 
-	private Soql.Condition parseCondition(String str) {
+	public Soql.Condition parseCondition(String str) {
 		List<String> operators = new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
 
 		for (String op : operators) {
@@ -381,7 +381,7 @@ public class SoqlParser {
 		return -1;
 	}
 
-	private Object parseValue(String token) {
+	public Object parseValue(String token) {
 		String t = token.trim().toUpperCase();
 
 		if (t == 'NULL') {

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -78,7 +78,7 @@ public class SoqlParser {
 	 */
 	public void parse(Soql.Builder builder, String str) {
 		try {
-			Map<String, Integer> positions = new Scanner(str)?.scan();
+			Map<String, Integer> positions = new SoqlParser.Scanner(str)?.scan();
 			SoqlParser.ParseContext ctx = new SoqlParser.ParseContext(str, positions);
 			this.applyParsers(builder, ctx);
 		} catch (Exception error) {
@@ -495,10 +495,8 @@ public class SoqlParser {
 		}
 		String objectName = fromPart?.split(' ')?.get(0);
 		Soql.InnerQuery innerQuery = new Soql.InnerQuery(objectName);
-		SoqlParser subParser = new SoqlParser();
-		subParser.parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
-		Soql.Selectable selectable = (Soql.Selectable) innerQuery;
-		builder.addSelect(selectable);
+		this.parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
+		builder?.addSelect(innerQuery);
 	}
 
 	/**
@@ -568,20 +566,16 @@ public class SoqlParser {
 	 * @return The position immediately after the last delimiter found, or 0 if none
 	 */
 	private Integer findParts(String str, String delimiter, List<String> parts) {
-		String strUpper = str?.toUpperCase() ?? '';
 		Integer parenDepth = 0;
 		Boolean inString = false;
 		Integer lastPos = 0;
 		for (Integer i = 0; i <= str.length() - delimiter.length(); i++) {
 			String character = str.substring(i, i + 1);
-			if (character == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+			if (SoqlParser.isUnescapedQuote(str, i)) {
 				inString = (inString == false);
 			} else if (inString == false) {
-				if (character == '(') {
-					parenDepth++;
-				} else if (character == ')') {
-					parenDepth--;
-				} else if (parenDepth == 0 && strUpper.substring(i, i + delimiter.length()) == delimiter) {
+				parenDepth += character == '(' ? 1 : character == ')' ? -1 : 0;
+				if (parenDepth == 0 && isDelimiterAt(str, i, delimiter)) {
 					parts.add(str.substring(lastPos, i));
 					lastPos = i + delimiter.length();
 					i = lastPos - 1;
@@ -592,6 +586,17 @@ public class SoqlParser {
 	}
 
 	/**
+	 * @description Returns true if {@code delimiter} appears at position {@code i} in {@code str}
+	 * @param str The string to inspect
+	 * @param i The position to test
+	 * @param delimiter The delimiter to match (case-insensitive)
+	 * @return True if the delimiter matches at this position
+	 */
+	private static Boolean isDelimiterAt(String str, Integer i, String delimiter) {
+		return str?.substring(i, i + delimiter?.length())?.toUpperCase() == delimiter;
+	}
+
+	/**
 	 * @description Appends any remaining segment of {@code str} after the last delimiter to
 	 * {@code parts}. If no delimiter was found, appends the entire string.
 	 * @param str The original string
@@ -599,14 +604,234 @@ public class SoqlParser {
 	 * @param parts The list to append the trailing segment to
 	 */
 	private void addTrailingPart(String str, Integer lastPos, List<String> parts) {
-		if (lastPos < str.length()) {
-			parts.add(str.substring(lastPos));
-		} else if (parts.isEmpty()) {
+		if (lastPos < str?.length()) {
+			parts.add(str?.substring(lastPos));
+		} else if (parts?.isEmpty() == true) {
 			parts.add(str);
 		}
 	}
 
+	/**
+	 * @description Returns true if the character at position {@code i} in {@code str} is an
+	 * unescaped single quote
+	 * @param str The string to inspect
+	 * @param i The character index to test
+	 * @return True if the character is {@code '} and not preceded by a backslash
+	 */
+	private static Boolean isUnescapedQuote(String str, Integer i) {
+		return str.substring(i, i + 1) == '\'' && (i == 0 || str.substring(i - 1, i) != '\\');
+	}
+
 	// **** INNER **** //
+	/**
+	 * @description Maps SOQL operator symbols to their {@link Soql.Operator} enum values,
+	 * ordered by precedence (multi-word and longer tokens first to prevent partial matches).
+	 */
+	private class OperatorLexer {
+		/**
+		 * @description Returns SOQL operator symbols ordered by matching precedence, longest first
+		 * @return An ordered list of operator symbol strings
+		 */
+		private List<String> precedence() {
+			// prettier-ignore
+			return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
+		}
+
+		/**
+		 * @description Resolves an operator symbol string to its {@link Soql.Operator} enum value
+		 * @param symbol The operator symbol (e.g. {@code !=}, {@code IN}, {@code LIKE})
+		 * @return The corresponding {@link Soql.Operator}, or null if unrecognized
+		 */
+		private Soql.Operator resolve(String symbol) {
+			// prettier-ignore
+			return new Map<String, Soql.Operator>{
+				'!=' => Soql.NOT_EQUALS,
+				'<' => Soql.LESS_THAN,
+				'<=' => Soql.LESS_OR_EQUAL,
+				'=' => Soql.EQUALS,
+				'>' => Soql.GREATER_THAN,
+				'>=' => Soql.GREATER_OR_EQUAL,
+				'IN' => Soql.IN_COLLECTION,
+				'LIKE' => Soql.LIKE_RAW,
+				'NOT IN' => Soql.NOT_IN_COLLECTION,
+				'NOT LIKE' => Soql.NOT_LIKE_RAW
+			}.get(symbol);
+		}
+
+		/**
+		 * @description Finds the character index of the first top-level occurrence of {@code operator}
+		 * in {@code str}, skipping occurrences inside parentheses or string literals
+		 * @param str The expression string to search
+		 * @param operator The operator symbol to find
+		 * @return The index of the operator, or -1 if not found
+		 */
+		private Integer findPosition(String str, String operator) {
+			Integer parenDepth = 0;
+			Boolean inString = false;
+			for (Integer i = 0; i <= str.length() - operator.length(); i++) {
+				String character = str.substring(i, i + 1);
+				if (SoqlParser.isUnescapedQuote(str, i)) {
+					inString = (inString == false);
+				} else if (inString == false) {
+					parenDepth += character == '(' ? 1 : character == ')' ? -1 : 0;
+					if (parenDepth == 0 && this.isOperatorAt(str, i, operator)) {
+						return i;
+					}
+				}
+			}
+			return -1;
+		}
+
+		/**
+		 * @description Returns true if {@code operator} appears at position {@code i} in {@code str}
+		 * and is at a valid word boundary
+		 * @param str The expression string
+		 * @param i The position to test
+		 * @param operator The operator symbol to match
+		 * @return True if the operator matches at this position with valid word boundaries
+		 */
+		private Boolean isOperatorAt(String str, Integer i, String operator) {
+			return str.substring(i, i + operator.length()).toUpperCase() == operator
+				&& this.isAtWordBoundary(str, i, operator);
+		}
+
+		/**
+		 * @description Returns true if the substring at position {@code i} is surrounded by spaces
+		 * or string boundaries, ensuring it is a standalone operator token
+		 * @param str The expression string
+		 * @param i The start index of the potential operator match
+		 * @param operator The operator symbol being tested
+		 * @return True if the match is at a word boundary
+		 */
+		private Boolean isAtWordBoundary(String str, Integer i, String operator) {
+			Integer afterPos = i + operator.length();
+			Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
+			String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
+			return beforeOk && (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
+		}
+	}
+
+	/**
+	 * @description Holds a parsed query's raw string and keyword position map, used to pass
+	 * context through the parse pipeline without excessive parameter lists.
+	 */
+	private class ParseContext {
+		/** @description The raw query string being parsed. */
+		private final String queryString;
+		/** @description Map of keyword name to its starting character position in the query. */
+		private final Map<String, Integer> positions;
+
+		/**
+		 * @description Constructs a SoqlParser.ParseContext with the given query and positions.
+		 * @param queryString The raw SOQL query string
+		 * @param positions The keyword position map produced by {@link SoqlParser.Scanner#scan}
+		 */
+		private ParseContext(String queryString, Map<String, Integer> positions) {
+			this.queryString = queryString;
+			this.positions = positions;
+		}
+	}
+
+	/**
+	 * @description Stateful scanner that walks a SOQL query string character-by-character
+	 * and records the starting position of each top-level keyword.
+	 */
+	private class Scanner {
+		/** @description Map of recognized SOQL keyword to its starting character index in the query */
+		private final Map<String, Integer> positions;
+		/** @description The raw query string being scanned */
+		private final String rawQuery;
+		/** @description Uppercase version of the query string, used for case-insensitive keyword matching */
+		private final String upperQuery;
+		/** @description Tracks whether the scanner is currently inside a string literal */
+		private Boolean inString;
+		/** @description Tracks the current parenthesis nesting depth */
+		private Integer parenDepth;
+
+		/**
+		 * @description Constructs a SoqlParser.Scanner for the given query string.
+		 * @param queryString The SOQL query string to scan
+		 */
+		private Scanner(String queryString) {
+			this.inString = false;
+			this.parenDepth = 0;
+			this.positions = new Map<String, Integer>();
+			this.rawQuery = queryString;
+			this.upperQuery = queryString?.toUpperCase() ?? '';
+		}
+
+		/**
+		 * @description Walks the query and returns a map of keyword to character position.
+		 * SELECT is always recorded at position 0; all other keywords are detected at top level only.
+		 * @return The keyword position map
+		 */
+		private Map<String, Integer> scan() {
+			for (Integer i = 0; i < this.upperQuery.length(); i++) {
+				this.processChar(i);
+			}
+			this.positions?.put(SELECT_KEYWORD, 0);
+			return this.positions;
+		}
+
+		/**
+		 * @description Processes a single character: toggles string mode on unescaped quotes,
+		 * tracks paren depth, and attempts to record keyword positions at top level.
+		 * @param i The character index to process
+		 */
+		private void processChar(Integer i) {
+			String character = this.rawQuery.substring(i, i + 1);
+			if (character == '\'' && this.isNotEscaped(i)) {
+				this.inString = (this.inString == false);
+			} else if (character == '(' && this.inString == false) {
+				this.parenDepth++;
+			} else if (character == ')' && this.inString == false) {
+				this.parenDepth--;
+			} else if (this.parenDepth == 0 && this.inString == false) {
+				this.tryRecordAllKeywords(i);
+			}
+		}
+
+		/**
+		 * @description Returns true if the character at {@code i} is not preceded by a backslash.
+		 * @param i The character index to test
+		 * @return True if the character is unescaped
+		 */
+		private Boolean isNotEscaped(Integer i) {
+			return i == 0 || this.rawQuery.substring(i - 1, i) != '\\';
+		}
+
+		/**
+		 * @description Attempts to match and record every non-SELECT keyword at position {@code i}.
+		 * @param i The character index to test
+		 */
+		private void tryRecordAllKeywords(Integer i) {
+			for (String keyword : ALL_KEYWORDS) {
+				if (keyword != SELECT_KEYWORD) {
+					this.tryRecordKeyword(keyword, i);
+				}
+			}
+		}
+
+		/**
+		 * @description Records {@code keyword} at position {@code i} if the query text matches it
+		 * there with valid surrounding word boundaries, and it has not already been recorded.
+		 * @param keyword The keyword to attempt to match
+		 * @param i The character index to test
+		 */
+		private void tryRecordKeyword(String keyword, Integer i) {
+			Integer endIndex = i + keyword.length();
+			if (endIndex > this.upperQuery.length() || this.upperQuery.substring(i, endIndex) != keyword) {
+				return;
+			}
+			Boolean beforeOk = (i == 0 || this.upperQuery.substring(i - 1, i) == ' ');
+			Boolean afterOk = (endIndex >= this.upperQuery.length() ||
+			this.upperQuery.substring(endIndex, endIndex + 1) == ' ');
+			if (beforeOk && afterOk && this.positions?.containsKey(keyword) == false) {
+				this.positions?.put(keyword, i);
+			}
+		}
+	}
+
 	/**
 	 * @description Converts raw SOQL value tokens into their corresponding Apex types.
 	 */
@@ -737,7 +962,7 @@ public class SoqlParser {
 			Integer lastPos = 0;
 			for (Integer i = 0; i < str.length(); i++) {
 				String character = str.substring(i, i + 1);
-				if (character == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+				if (SoqlParser.isUnescapedQuote(str, i)) {
 					inString = (inString == false);
 				} else if (!inString && character == ',') {
 					parts.add(str.substring(lastPos, i));
@@ -772,217 +997,6 @@ public class SoqlParser {
 		 */
 		private Object parseStringLiteral(String trimmed) {
 			return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
-		}
-	}
-
-	/**
-	 * @description Maps SOQL operator symbols to their {@link Soql.Operator} enum values,
-	 * ordered by precedence (multi-word and longer tokens first to prevent partial matches).
-	 */
-	private class OperatorLexer {
-		/**
-		 * @description Returns SOQL operator symbols ordered by matching precedence, longest first
-		 * @return An ordered list of operator symbol strings
-		 */
-		private List<String> precedence() {
-			// prettier-ignore
-			return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
-		}
-
-		/**
-		 * @description Resolves an operator symbol string to its {@link Soql.Operator} enum value
-		 * @param symbol The operator symbol (e.g. {@code !=}, {@code IN}, {@code LIKE})
-		 * @return The corresponding {@link Soql.Operator}, or null if unrecognized
-		 */
-		private Soql.Operator resolve(String symbol) {
-			// prettier-ignore
-			return new Map<String, Soql.Operator>{
-				'!=' => Soql.NOT_EQUALS,
-				'<' => Soql.LESS_THAN,
-				'<=' => Soql.LESS_OR_EQUAL,
-				'=' => Soql.EQUALS,
-				'>' => Soql.GREATER_THAN,
-				'>=' => Soql.GREATER_OR_EQUAL,
-				'IN' => Soql.IN_COLLECTION,
-				'LIKE' => Soql.LIKE_RAW,
-				'NOT IN' => Soql.NOT_IN_COLLECTION,
-				'NOT LIKE' => Soql.NOT_LIKE_RAW
-			}.get(symbol);
-		}
-
-		/**
-		 * @description Finds the character index of the first top-level occurrence of {@code operator}
-		 * in {@code str}, skipping occurrences inside parentheses or string literals
-		 * @param str The expression string to search
-		 * @param operator The operator symbol to find
-		 * @return The index of the operator, or -1 if not found
-		 */
-		private Integer findPosition(String str, String operator) {
-			String strUpper = str.toUpperCase();
-			Integer parenDepth = 0;
-			Boolean inString = false;
-			for (Integer i = 0; i <= str.length() - operator.length(); i++) {
-				String character = str.substring(i, i + 1);
-				if (character == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
-					inString = (inString == false);
-				} else if (inString == false) {
-					parenDepth += character == '(' ? 1 : character == ')' ? -1 : 0;
-					if (parenDepth == 0 && this.isOperatorAt(strUpper, str, i, operator)) {
-						return i;
-					}
-				}
-			}
-			return -1;
-		}
-
-		/**
-		 * @description Returns true if {@code operator} appears at position {@code i} in {@code strUpper}
-		 * and is at a valid word boundary
-		 * @param strUpper The uppercase version of the expression string
-		 * @param str The original expression string (used for boundary check)
-		 * @param i The position to test
-		 * @param operator The operator symbol to match
-		 * @return True if the operator matches at this position with valid word boundaries
-		 */
-		private Boolean isOperatorAt(String strUpper, String str, Integer i, String operator) {
-			return strUpper.substring(i, i + operator.length()) == operator
-				&& this.isAtWordBoundary(str, i, operator);
-		}
-
-		/**
-		 * @description Returns true if the substring at position {@code i} is surrounded by spaces
-		 * or string boundaries, ensuring it is a standalone operator token
-		 * @param str The expression string
-		 * @param i The start index of the potential operator match
-		 * @param operator The operator symbol being tested
-		 * @return True if the match is at a word boundary
-		 */
-		private Boolean isAtWordBoundary(String str, Integer i, String operator) {
-			Integer afterPos = i + operator.length();
-			Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
-			String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
-			return beforeOk && (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
-		}
-	}
-
-	/**
-	 * @description Holds a parsed query's raw string and keyword position map, used to pass
-	 * context through the parse pipeline without excessive parameter lists.
-	 */
-	private class ParseContext {
-		/** @description The raw query string being parsed. */
-		private final String queryString;
-		/** @description Map of keyword name to its starting character position in the query. */
-		private final Map<String, Integer> positions;
-
-		/**
-		 * @description Constructs a SoqlParser.ParseContext with the given query and positions.
-		 * @param queryString The raw SOQL query string
-		 * @param positions The keyword position map produced by {@link Scanner#scan}
-		 */
-		private ParseContext(String queryString, Map<String, Integer> positions) {
-			this.queryString = queryString;
-			this.positions = positions;
-		}
-	}
-
-	/**
-	 * @description Stateful scanner that walks a SOQL query string character-by-character
-	 * and records the starting position of each top-level keyword.
-	 */
-	private class Scanner {
-		/** @description Map of recognized SOQL keyword to its starting character index in the query */
-		private final Map<String, Integer> positions;
-		/** @description The raw query string being scanned */
-		private final String rawQuery;
-		/** @description Uppercase version of the query string, used for case-insensitive keyword matching */
-		private final String upperQuery;
-		/** @description Tracks whether the scanner is currently inside a string literal */
-		private Boolean inString;
-		/** @description Tracks the current parenthesis nesting depth */
-		private Integer parenDepth;
-
-		/**
-		 * @description Constructs a Scanner for the given query string.
-		 * @param queryString The SOQL query string to scan
-		 */
-		private Scanner(String queryString) {
-			this.inString = false;
-			this.parenDepth = 0;
-			this.positions = new Map<String, Integer>();
-			this.rawQuery = queryString;
-			this.upperQuery = queryString?.toUpperCase() ?? '';
-		}
-
-		/**
-		 * @description Walks the query and returns a map of keyword to character position.
-		 * SELECT is always recorded at position 0; all other keywords are detected at top level only.
-		 * @return The keyword position map
-		 */
-		private Map<String, Integer> scan() {
-			for (Integer i = 0; i < this.upperQuery.length(); i++) {
-				this.processChar(i);
-			}
-			this.positions?.put(SELECT_KEYWORD, 0);
-			return this.positions;
-		}
-
-		/**
-		 * @description Processes a single character: toggles string mode on unescaped quotes,
-		 * tracks paren depth, and attempts to record keyword positions at top level.
-		 * @param i The character index to process
-		 */
-		private void processChar(Integer i) {
-			String character = this.rawQuery.substring(i, i + 1);
-			if (character == '\'' && this.isNotEscaped(i)) {
-				this.inString = (this.inString == false);
-			} else if (character == '(' && this.inString == false) {
-				this.parenDepth++;
-			} else if (character == ')' && this.inString == false) {
-				this.parenDepth--;
-			} else if (this.parenDepth == 0 && this.inString == false) {
-				this.tryRecordAllKeywords(i);
-			}
-		}
-
-		/**
-		 * @description Returns true if the character at {@code i} is not preceded by a backslash.
-		 * @param i The character index to test
-		 * @return True if the character is unescaped
-		 */
-		private Boolean isNotEscaped(Integer i) {
-			return i == 0 || this.rawQuery.substring(i - 1, i) != '\\';
-		}
-
-		/**
-		 * @description Attempts to match and record every non-SELECT keyword at position {@code i}.
-		 * @param i The character index to test
-		 */
-		private void tryRecordAllKeywords(Integer i) {
-			for (String keyword : ALL_KEYWORDS) {
-				if (keyword != SELECT_KEYWORD) {
-					this.tryRecordKeyword(keyword, i);
-				}
-			}
-		}
-
-		/**
-		 * @description Records {@code keyword} at position {@code i} if the query text matches it
-		 * there with valid surrounding word boundaries, and it has not already been recorded.
-		 * @param keyword The keyword to attempt to match
-		 * @param i The character index to test
-		 */
-		private void tryRecordKeyword(String keyword, Integer i) {
-			Integer endIndex = i + keyword.length();
-			if (endIndex > this.upperQuery.length() || this.upperQuery.substring(i, endIndex) != keyword) {
-				return;
-			}
-			Boolean beforeOk = (i == 0 || this.upperQuery.substring(i - 1, i) == ' ');
-			Boolean afterOk = (endIndex >= this.upperQuery.length() ||
-			this.upperQuery.substring(endIndex, endIndex + 1) == ' ');
-			if (beforeOk && afterOk && this.positions?.containsKey(keyword) == false) {
-				this.positions.put(keyword, i);
-			}
 		}
 	}
 }

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -3,7 +3,7 @@
  * Handles all standard SOQL clauses including SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY,
  * LIMIT, OFFSET, USING SCOPE, WITH, FOR, and ALL ROWS.
  */
-@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.PropertyNamingConventions')
+@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.EmptyCatchBlock,PMD.PropertyNamingConventions')
 public class SoqlParser {
 	// prettier-ignore
 	private static final String ALL_ROWS_KEYWORD { get { return 'ALL ROWS'; } }
@@ -49,32 +49,6 @@ public class SoqlParser {
 			};
 		}
 	}
-	private static final Map<String, Soql.Function> FUNCTION_MAP {
-		get {
-			return new Map<String, Soql.Function>{
-				'AVG' => Soql.Function.AVG,
-				'CALENDAR_MONTH' => Soql.Function.CALENDAR_MONTH,
-				'CALENDAR_QUARTER' => Soql.Function.CALENDAR_QUARTER,
-				'CALENDAR_YEAR' => Soql.Function.CALENDAR_YEAR,
-				'COUNT' => Soql.Function.COUNT,
-				'COUNT_DISTINCT' => Soql.Function.COUNT_DISTINCT,
-				'DAY_IN_MONTH' => Soql.Function.DAY_IN_MONTH,
-				'DAY_IN_WEEK' => Soql.Function.DAY_IN_WEEK,
-				'DAY_IN_YEAR' => Soql.Function.DAY_IN_YEAR,
-				'DAY_ONLY' => Soql.Function.DAY_ONLY,
-				'FISCAL_MONTH' => Soql.Function.FISCAL_MONTH,
-				'FISCAL_QUARTER' => Soql.Function.FISCAL_QUARTER,
-				'FISCAL_YEAR' => Soql.Function.FISCAL_YEAR,
-				'FORMAT' => Soql.Function.FORMAT,
-				'HOUR_IN_DAY' => Soql.Function.HOUR_IN_DAY,
-				'MAX' => Soql.Function.MAX,
-				'MIN' => Soql.Function.MIN,
-				'SUM' => Soql.Function.SUM,
-				'WEEK_IN_MONTH' => Soql.Function.WEEK_IN_MONTH,
-				'WEEK_IN_YEAR' => Soql.Function.WEEK_IN_YEAR
-			};
-		}
-	}
 	// Operators ordered by precedence: multi-word and longer tokens first to prevent partial matches
 	private static final Map<String, Soql.Operator> OPERATOR_MAP {
 		get {
@@ -97,20 +71,6 @@ public class SoqlParser {
 			return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
 		}
 	}
-	private static final Map<String, Soql.Scope> SCOPE_MAP {
-		get {
-			return new Map<String, Soql.Scope>{
-				'DELEGATED' => Soql.Scope.DELEGATED,
-				'EVERYTHING' => Soql.Scope.EVERYTHING,
-				'MINE' => Soql.Scope.MINE,
-				'MINE_AND_MY_GROUPS' => Soql.Scope.MINE_AND_MY_GROUPS,
-				'MY_TEAM_TERRITORY' => Soql.Scope.MY_TEAM_TERRITORY,
-				'MY_TERRITORY' => Soql.Scope.MY_TERRITORY,
-				'TEAM' => Soql.Scope.TEAM
-			};
-		}
-	}
-
 	/**
 	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder.
 	 * @param builder The {@link Soql.Builder} to populate with parsed clauses
@@ -181,7 +141,7 @@ public class SoqlParser {
 		Integer openParen = upper.indexOf('(');
 		Integer closeParen = this.findMatchingParen(token, openParen);
 		Soql.Aggregation agg = new Soql.Aggregation(
-			FUNCTION_MAP.get(upper.substring(0, openParen).trim()),
+			Soql.Function.valueOf(upper.substring(0, openParen).trim()),
 			token.substring(openParen + 1, closeParen).trim()
 		);
 		String alias = token.substring(closeParen + 1).trim();
@@ -310,7 +270,15 @@ public class SoqlParser {
 	private Boolean isAggregation(String token) {
 		String upper = token.toUpperCase();
 		Integer parenPos = upper.indexOf('(');
-		return parenPos > 0 && FUNCTION_MAP.containsKey(upper.substring(0, parenPos).trim());
+		if (parenPos <= 0) {
+			return false;
+		}
+		try {
+			Soql.Function.valueOf(upper.substring(0, parenPos).trim());
+			return true;
+		} catch (Exception e) {
+			return false;
+		}
 	}
 
 	/**
@@ -666,9 +634,10 @@ public class SoqlParser {
 	 * @param usingScopeStr The scope name string
 	 */
 	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
-		Soql.Scope scope = SCOPE_MAP.get(usingScopeStr?.toUpperCase());
-		if (scope != null) {
-			builder.setScope(scope);
+		try {
+			builder.setScope(Soql.Scope.valueOf(usingScopeStr?.toUpperCase()));
+		} catch (Exception e) {
+			// Unrecognized scope — ignore
 		}
 	}
 
@@ -684,29 +653,23 @@ public class SoqlParser {
 		String upper = trimmed?.toUpperCase();
 		if (upper == 'NULL') {
 			return null;
-		}
-		if (upper == 'TRUE') {
+		} else if (upper == 'TRUE') {
 			return true;
-		}
-		if (upper == 'FALSE') {
+		} else if (upper == 'FALSE') {
 			return false;
-		}
-		if (trimmed?.startsWith(':') == true) {
+		} else if (trimmed?.startsWith(':') == true) {
 			return trimmed;
-		}
-		if (trimmed?.startsWith('\'') == true) {
+		} else if (trimmed?.startsWith('\'') == true) {
 			return this.parseStringLiteral(trimmed);
-		}
-		if (trimmed?.startsWith('(') == true) {
+		} else if (trimmed?.startsWith('(') == true) {
 			return this.parseList(trimmed);
-		}
-		if (this.isDateTime(upper)) {
+		} else if (this.isDateTime(upper)) {
 			return this.parseDateTime(trimmed);
-		}
-		if (this.isDate(upper)) {
+		} else if (this.isDate(upper)) {
 			return this.parseDate(trimmed);
+		} else {
+			return this.parseNumeric(trimmed);
 		}
-		return this.parseNumeric(trimmed);
 	}
 
 	/**

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -3,7 +3,7 @@
  * Handles all standard SOQL clauses including SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY,
  * LIMIT, OFFSET, USING SCOPE, WITH, FOR, and ALL ROWS.
  */
-@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.EmptyCatchBlock,PMD.PropertyNamingConventions')
+@SuppressWarnings('PMD.CognitiveComplexity,PMD.CyclomaticComplexity,PMD.PropertyNamingConventions')
 public class SoqlParser {
 	// prettier-ignore
 	private static final String ALL_ROWS_KEYWORD { get { return 'ALL ROWS'; } }
@@ -49,30 +49,11 @@ public class SoqlParser {
 			};
 		}
 	}
-	// Operators ordered by precedence: multi-word and longer tokens first to prevent partial matches
-	private static final Map<String, Soql.Operator> OPERATOR_MAP {
-		get {
-			return new Map<String, Soql.Operator>{
-				'!=' => Soql.NOT_EQUALS,
-				'<' => Soql.LESS_THAN,
-				'<=' => Soql.LESS_OR_EQUAL,
-				'=' => Soql.EQUALS,
-				'>' => Soql.GREATER_THAN,
-				'>=' => Soql.GREATER_OR_EQUAL,
-				'IN' => Soql.IN_COLLECTION,
-				'LIKE' => Soql.LIKE_RAW,
-				'NOT IN' => Soql.NOT_IN_COLLECTION,
-				'NOT LIKE' => Soql.NOT_LIKE_RAW
-			};
-		}
-	}
-	private static final List<String> OPERATOR_PRECEDENCE {
-		get {
-			return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
-		}
-	}
+	// prettier-ignore
+	private static final OperatorLexer OPERATORS { get { return new OperatorLexer(); }}
+	// prettier-ignore
+	private static final ValueParser VALUE_PARSER { get { return new ValueParser(); }}
 	/**
-	 * @description Parses a SOQL query string and applies the parsed clauses to the given builder.
 	 * @param builder The {@link Soql.Builder} to populate with parsed clauses
 	 * @param queryString The SOQL query string to parse
 	 */
@@ -99,7 +80,7 @@ public class SoqlParser {
 		this.parseUsingScope(builder, this.extractClause(ctx, USING_SCOPE_KEYWORD));
 		this.parseWith(builder, this.extractClause(ctx, WITH_KEYWORD));
 		this.parseFor(builder, this.extractClause(ctx, FOR_KEYWORD));
-		if (ctx.positions?.containsKey(ALL_ROWS_KEYWORD) == true) {
+		if (ctx?.positions?.containsKey(ALL_ROWS_KEYWORD) == true) {
 			this.parseAllRows(builder);
 		}
 	}
@@ -114,7 +95,8 @@ public class SoqlParser {
 		String upper = token.toUpperCase();
 		Integer openParen = upper.indexOf('(');
 		Integer closeParen = this.findMatchingParen(token, openParen);
-		Soql.Function func = Soql.Function.valueOf(upper.substring(0, openParen)?.trim());
+		String functionName = upper.substring(0, openParen)?.trim();
+		Soql.Function func = Soql.Function.valueOf(functionName);
 		String field = token?.substring(openParen + 1, closeParen)?.trim();
 		Soql.Aggregation agg = new Soql.Aggregation(func, field);
 		String alias = token?.substring(closeParen + 1)?.trim();
@@ -142,16 +124,6 @@ public class SoqlParser {
 	}
 
 	/**
-	 * @description Scans {@code queryString} and returns the starting position of each SOQL
-	 * keyword found at the top level (not inside parentheses or string literals).
-	 * @param queryString The SOQL query string to scan
-	 * @return A map of keyword to its starting character position
-	 */
-	private Map<String, Integer> findKeywordPositions(String queryString) {
-		return new Scanner(queryString).scan();
-	}
-
-	/**
 	 * @description Finds the index of the closing parenthesis that matches the opening parenthesis
 	 * at {@code openIndex}, accounting for nested parentheses.
 	 * @param str The string to search
@@ -173,39 +145,6 @@ public class SoqlParser {
 			}
 		}
 		return str.length();
-	}
-
-	/**
-	 * @description Finds the starting index of {@code operator} in {@code str} at the top level
-	 * (not inside parentheses or string literals), respecting word boundaries for alphabetic
-	 * operators.
-	 * @param str The condition string to scan
-	 * @param operator The operator token to locate
-	 * @return The index of the operator, or -1 if not found
-	 */
-	private Integer findOperatorPosition(String str, String operator) {
-		String strUpper = str.toUpperCase();
-		Integer parenDepth = 0;
-		Boolean inString = false;
-		for (Integer i = 0; i <= str.length() - operator.length(); i++) {
-			String c = str.substring(i, i + 1);
-			if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
-				inString = (inString == false);
-			} else if (inString == false) {
-				if (c == '(') {
-					parenDepth++;
-				} else if (c == ')') {
-					parenDepth--;
-				} else if (
-					parenDepth == 0 &&
-					strUpper.substring(i, i + operator.length()) == operator &&
-					this.isAtWordBoundary(str, i, operator)
-				) {
-					return i;
-				}
-			}
-		}
-		return -1;
 	}
 
 	/**
@@ -239,70 +178,16 @@ public class SoqlParser {
 	 * @return True if the token begins with a known aggregate function name followed by {@code (}
 	 */
 	private Boolean isAggregation(String token) {
-		String upper = token.toUpperCase();
-		Integer parenPos = upper.indexOf('(');
+		String upper = token?.toUpperCase();
+		Integer parenPos = upper?.indexOf('(');
 		if (parenPos <= 0) {
 			return false;
 		}
 		try {
-			Soql.Function.valueOf(upper.substring(0, parenPos).trim());
+			String functionName = upper?.substring(0, parenPos).trim();
+			Soql.Function.valueOf(functionName);
 			return true;
-		} catch (Exception e) {
-			return false;
-		}
-	}
-
-	/**
-	 * @description Returns true if the operator at position {@code i} in {@code str} is surrounded
-	 * by word boundaries (spaces, parentheses, or string start/end).
-	 * @param str The condition string
-	 * @param i The starting index of the operator
-	 * @param operator The operator text
-	 * @return True if both the before and after characters qualify as word boundaries
-	 */
-	private Boolean isAtWordBoundary(String str, Integer i, String operator) {
-		Integer afterPos = i + operator.length();
-		Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
-		String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
-		return beforeOk && (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
-	}
-
-	/**
-	 * @description Returns true if {@code str} looks like an ISO 8601 date (10 characters,
-	 * YYYY-MM-DD format).
-	 * @param str The uppercase string to test
-	 * @return True if it matches a date pattern
-	 */
-	private Boolean isDate(String str) {
-		return str?.length() == 10 && this.isValidDatePrefix(str);
-	}
-
-	/**
-	 * @description Returns true if {@code str} looks like an ISO 8601 datetime (at least 10
-	 * characters, contains 'T', and starts with a valid date prefix).
-	 * @param str The uppercase string to test
-	 * @return True if it matches a datetime pattern
-	 */
-	private Boolean isDateTime(String str) {
-		return str?.length() >= 10 && str.contains('T') && this.isValidDatePrefix(str.substring(0, 10));
-	}
-
-	/**
-	 * @description Returns true if {@code datePrefix} is a plausible YYYY-MM-DD date prefix
-	 * within the range 1900–2100.
-	 * @param datePrefix A 10-character string to validate
-	 * @return True if it parses as a valid calendar date
-	 */
-	private Boolean isValidDatePrefix(String datePrefix) {
-		if (datePrefix?.length() != 10 || datePrefix.substring(4, 5) != '-' || datePrefix.substring(7, 8) != '-') {
-			return false;
-		}
-		try {
-			Integer year = Integer.valueOf(datePrefix.substring(0, 4));
-			Integer month = Integer.valueOf(datePrefix.substring(5, 7));
-			Integer day = Integer.valueOf(datePrefix.substring(8, 10));
-			return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
-		} catch (Exception e) {
+		} catch (System.NoSuchElementException errorrror) {
 			return false;
 		}
 	}
@@ -312,7 +197,7 @@ public class SoqlParser {
 	 * @param builder The {@link Soql.Builder} to modify
 	 */
 	private void parseAllRows(Soql.Builder builder) {
-		builder.setUsage(Soql.Usage.ALL_ROWS);
+		builder?.setUsage(Soql.Usage.ALL_ROWS);
 	}
 
 	/**
@@ -333,7 +218,8 @@ public class SoqlParser {
 	private Soql.Criteria parseAndExpr(String str) {
 		List<String> andParts = this.splitTopLevelKeyword(str, ' AND ');
 		if (andParts.size() == 1) {
-			return this.parseFactor(andParts[0]);
+			String andPart = andParts?.get(0);
+			return this.parseFactor(andPart);
 		}
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
 		logic.setLogicType(Soql.LogicType.ALL_CONDITIONS);
@@ -352,12 +238,12 @@ public class SoqlParser {
 	 */
 	@TestVisible
 	private Soql.Condition parseCondition(String str) {
-		for (String op : OPERATOR_PRECEDENCE) {
-			Integer opPos = this.findOperatorPosition(str, op);
+		for (String op : OPERATORS.precedence()) {
+			Integer opPos = OPERATORS.findPosition(str, op);
 			if (opPos >= 0) {
 				String fieldName = str.substring(0, opPos).trim();
 				String rawValue = str.substring(opPos + op.length()).trim();
-				Soql.Operator operator = OPERATOR_MAP.get(op);
+				Soql.Operator operator = OPERATORS.resolve(op);
 				Object value = this.parseValue(rawValue);
 				return new Soql.Condition(fieldName, operator, value);
 			}
@@ -381,34 +267,6 @@ public class SoqlParser {
 	}
 
 	/**
-	 * @description Parses a raw date string into a {@link Date}, falling back to the raw string
-	 * on failure.
-	 * @param trimmed The date string to parse
-	 * @return A {@link Date} or the original string
-	 */
-	private Object parseDate(String trimmed) {
-		try {
-			return Date.valueOf(trimmed);
-		} catch (Exception e) {
-			return trimmed;
-		}
-	}
-
-	/**
-	 * @description Parses a raw datetime string into a {@link DateTime}, falling back to the raw
-	 * string on failure.
-	 * @param trimmed The datetime string to parse
-	 * @return A {@link DateTime} or the original string
-	 */
-	private Object parseDateTime(String trimmed) {
-		try {
-			return DateTime.valueOfGmt(trimmed);
-		} catch (Exception e) {
-			return trimmed;
-		}
-	}
-
-	/**
 	 * @description Recursively parses a WHERE/HAVING expression, handling OR at the top level.
 	 * @param str The expression string to parse
 	 * @return A {@link Soql.Criteria} tree
@@ -416,7 +274,7 @@ public class SoqlParser {
 	private Soql.Criteria parseExpr(String str) {
 		List<String> orParts = this.splitTopLevelKeyword(str, ' OR ');
 		if (orParts.size() == 1) {
-			return this.parseAndExpr(orParts[0]);
+			return this.parseAndExpr(orParts?.get(0));
 		}
 		Soql.ConditionalLogic logic = new Soql.ConditionalLogic();
 		logic.setLogicType(Soql.LogicType.ANY_CONDITIONS);
@@ -511,46 +369,6 @@ public class SoqlParser {
 	}
 
 	/**
-	 * @description Parses a parenthesized list value token into a {@link List<String>}.
-	 * Returns the raw string unchanged if the list body contains a subquery.
-	 * @param trimmed The parenthesized token to parse
-	 * @return A {@link List<String>} of values, or the original string for subqueries
-	 */
-	private Object parseList(String trimmed) {
-		String body = trimmed.substring(1, trimmed.length() - 1);
-		String bodyUpper = body.toUpperCase();
-		if (bodyUpper.contains('SELECT')) {
-			return trimmed;
-		}
-		List<String> result = new List<String>();
-		List<String> items = this.splitTopLevelKeyword(body, ',');
-		for (String item : items) {
-			String val = item.trim();
-			String unquoted = val.substring(1, val.length() - 1);
-			result.add((val.startsWith('\'') && val.endsWith('\'')) ? unquoted : val);
-		}
-		return result;
-	}
-
-	/**
-	 * @description Parses a raw numeric string into an {@link Integer} or {@link Decimal},
-	 * falling back to the original string if parsing fails.
-	 * @param trimmed The numeric string to parse
-	 * @return An {@link Integer}, {@link Decimal}, or the original string
-	 */
-	private Object parseNumeric(String trimmed) {
-		try {
-			return Integer.valueOf(trimmed);
-		} catch (Exception intErr) {
-			try {
-				return Decimal.valueOf(trimmed);
-			} catch (Exception decErr) {
-				return trimmed;
-			}
-		}
-	}
-
-	/**
 	 * @description Sets the OFFSET clause on the builder.
 	 * @param builder The {@link Soql.Builder} to modify
 	 * @param offsetStr The OFFSET value string
@@ -598,15 +416,6 @@ public class SoqlParser {
 	}
 
 	/**
-	 * @description Unquotes a single-quoted string literal, unescaping internal quotes.
-	 * @param trimmed The quoted token, including surrounding single quotes
-	 * @return The unquoted string value
-	 */
-	private Object parseStringLiteral(String trimmed) {
-		return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
-	}
-
-	/**
 	 * @description Parses a parenthesized subquery token and registers it as a SELECT item on the
 	 * builder. If the subquery body has no FROM clause, it is silently ignored.
 	 * @param builder The {@link Soql.Builder} to add the subquery to
@@ -624,7 +433,7 @@ public class SoqlParser {
 		if (selectPart.toUpperCase().startsWith('SELECT ')) {
 			selectPart = selectPart.substring(7).trim();
 		}
-		String objectName = fromPart.split(' ')[0];
+		String objectName = fromPart.split(' ')?.get(0);
 		Soql.InnerQuery innerQuery = new Soql.InnerQuery(objectName);
 		SoqlParser subParser = new SoqlParser();
 		subParser.parse(innerQuery, 'SELECT ' + selectPart + ' FROM ' + fromPart);
@@ -651,27 +460,7 @@ public class SoqlParser {
 	 */
 	@TestVisible
 	private Object parseValue(String token) {
-		String trimmed = token?.trim();
-		String upper = trimmed?.toUpperCase();
-		if (upper == 'NULL') {
-			return null;
-		} else if (upper == 'TRUE') {
-			return true;
-		} else if (upper == 'FALSE') {
-			return false;
-		} else if (trimmed?.startsWith(':') == true) {
-			return trimmed;
-		} else if (trimmed?.startsWith('\'') == true) {
-			return this.parseStringLiteral(trimmed);
-		} else if (trimmed?.startsWith('(') == true) {
-			return this.parseList(trimmed);
-		} else if (this.isDateTime(upper)) {
-			return this.parseDateTime(trimmed);
-		} else if (this.isDate(upper)) {
-			return this.parseDate(trimmed);
-		} else {
-			return this.parseNumeric(trimmed);
-		}
+		return VALUE_PARSER.parse(token);
 	}
 
 	/**
@@ -733,6 +522,180 @@ public class SoqlParser {
 	}
 
 	// **** INNER **** //
+	/**
+	 * @description Converts raw SOQL value tokens into their corresponding Apex types.
+	 */
+	private class ValueParser {
+		private Object parse(String token) {
+			String trimmed = token?.trim();
+			String upper = trimmed?.toUpperCase();
+			if (upper == 'NULL') {
+				return null;
+			} else if (upper == 'TRUE') {
+				return true;
+			} else if (upper == 'FALSE') {
+				return false;
+			} else if (trimmed?.startsWith(':') == true) {
+				return trimmed;
+			} else if (trimmed?.startsWith('\'') == true) {
+				return this.parseStringLiteral(trimmed);
+			} else if (trimmed?.startsWith('(') == true) {
+				return this.parseList(trimmed);
+			} else if (this.isDateTime(upper)) {
+				return this.parseDateTime(trimmed);
+			} else if (this.isDate(upper)) {
+				return this.parseDate(trimmed);
+			} else {
+				return this.parseNumeric(trimmed);
+			}
+		}
+
+		private Boolean isDate(String str) {
+			return str?.length() == 10 && this.isValidDatePrefix(str);
+		}
+
+		private Boolean isDateTime(String str) {
+			return str?.length() >= 10 && str.contains('T') && this.isValidDatePrefix(str.substring(0, 10));
+		}
+
+		private Boolean isValidDatePrefix(String datePrefix) {
+			if (datePrefix?.length() != 10 || datePrefix.substring(4, 5) != '-' || datePrefix.substring(7, 8) != '-') {
+				return false;
+			}
+			try {
+				Integer year = Integer.valueOf(datePrefix.substring(0, 4));
+				Integer month = Integer.valueOf(datePrefix.substring(5, 7));
+				Integer day = Integer.valueOf(datePrefix.substring(8, 10));
+				return year >= 1900 && year <= 2100 && month >= 1 && month <= 12 && day >= 1 && day <= 31;
+			} catch (Exception error) {
+				return false;
+			}
+		}
+
+		private Object parseDate(String trimmed) {
+			try {
+				return Date.valueOf(trimmed);
+			} catch (Exception error) {
+				return trimmed;
+			}
+		}
+
+		private Object parseDateTime(String trimmed) {
+			try {
+				return DateTime.valueOfGmt(trimmed);
+			} catch (Exception error) {
+				return trimmed;
+			}
+		}
+
+		private Object parseList(String trimmed) {
+			String body = trimmed.substring(1, trimmed.length() - 1);
+			if (body.toUpperCase().contains('SELECT')) {
+				return trimmed;
+			}
+			List<String> result = new List<String>();
+			for (String item : this.splitList(body)) {
+				String val = item.trim();
+				String unquoted = val.substring(1, val.length() - 1);
+				result.add((val.startsWith('\'') && val.endsWith('\'')) ? unquoted : val);
+			}
+			return result;
+		}
+
+		// String-aware comma split for list bodies (no paren tracking needed for IN list items)
+		private List<String> splitList(String str) {
+			List<String> parts = new List<String>();
+			Boolean inString = false;
+			Integer lastPos = 0;
+			for (Integer i = 0; i < str.length(); i++) {
+				String c = str.substring(i, i + 1);
+				if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+					inString = (inString == false);
+				} else if (!inString && c == ',') {
+					parts.add(str.substring(lastPos, i));
+					lastPos = i + 1;
+				}
+			}
+			parts.add(str.substring(lastPos));
+			return parts;
+		}
+
+		private Object parseNumeric(String trimmed) {
+			try {
+				return Integer.valueOf(trimmed);
+			} catch (Exception intErr) {
+				try {
+					return Decimal.valueOf(trimmed);
+				} catch (Exception decErr) {
+					return trimmed;
+				}
+			}
+		}
+
+		private Object parseStringLiteral(String trimmed) {
+			return trimmed.substring(1, trimmed.length() - 1).replace('\\\'', '\'');
+		}
+	}
+
+	/**
+	 * @description Maps SOQL operator symbols to their {@link Soql.Operator} enum values,
+	 * ordered by precedence (multi-word and longer tokens first to prevent partial matches).
+	 */
+	private class OperatorLexer {
+		private List<String> precedence() {
+			// prettier-ignore
+			return new List<String>{ 'NOT IN', 'NOT LIKE', '!=', '>=', '<=', '>', '<', '=', 'IN', 'LIKE' };
+		}
+
+		private Soql.Operator resolve(String symbol) {
+			// prettier-ignore
+			return new Map<String, Soql.Operator>{
+				'!=' => Soql.NOT_EQUALS,
+				'<' => Soql.LESS_THAN,
+				'<=' => Soql.LESS_OR_EQUAL,
+				'=' => Soql.EQUALS,
+				'>' => Soql.GREATER_THAN,
+				'>=' => Soql.GREATER_OR_EQUAL,
+				'IN' => Soql.IN_COLLECTION,
+				'LIKE' => Soql.LIKE_RAW,
+				'NOT IN' => Soql.NOT_IN_COLLECTION,
+				'NOT LIKE' => Soql.NOT_LIKE_RAW
+			}.get(symbol);
+		}
+
+		private Integer findPosition(String str, String operator) {
+			String strUpper = str.toUpperCase();
+			Integer parenDepth = 0;
+			Boolean inString = false;
+			for (Integer i = 0; i <= str.length() - operator.length(); i++) {
+				String c = str.substring(i, i + 1);
+				if (c == '\'' && (i == 0 || str.substring(i - 1, i) != '\\')) {
+					inString = (inString == false);
+				} else if (inString == false) {
+					if (c == '(') {
+						parenDepth++;
+					} else if (c == ')') {
+						parenDepth--;
+					} else if (
+						parenDepth == 0 &&
+						strUpper.substring(i, i + operator.length()) == operator &&
+						this.isAtWordBoundary(str, i, operator)
+					) {
+						return i;
+					}
+				}
+			}
+			return -1;
+		}
+
+		private Boolean isAtWordBoundary(String str, Integer i, String operator) {
+			Integer afterPos = i + operator.length();
+			Boolean beforeOk = (i == 0 || str.substring(i - 1, i) == ' ');
+			String afterChar = afterPos < str.length() ? str.substring(afterPos, afterPos + 1) : '';
+			return beforeOk && (afterPos >= str.length() || afterChar == ' ' || afterChar == '(');
+		}
+	}
+
 	/**
 	 * @description Holds a parsed query's raw string and keyword position map, used to pass
 	 * context through the parse pipeline without excessive parameter lists.

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -89,42 +89,15 @@ public class SoqlParser {
 	private void applyParsers(Soql.Builder builder, ParseContext ctx) {
 		this.parseSelect(builder, this.extractClause(ctx, SELECT_KEYWORD));
 		this.parseFrom(builder, this.extractClause(ctx, FROM_KEYWORD));
-		String whereClause = this.extractClause(ctx, WHERE_KEYWORD);
-		if (String.isNotBlank(whereClause)) {
-			this.parseWhere(builder, whereClause);
-		}
-		String groupBy = this.extractClause(ctx, GROUP_BY_KEYWORD);
-		if (String.isNotBlank(groupBy)) {
-			this.parseGroupBy(builder, groupBy);
-		}
-		String havingClause = this.extractClause(ctx, HAVING_KEYWORD);
-		if (String.isNotBlank(havingClause)) {
-			this.parseHaving(builder, havingClause);
-		}
-		String orderBy = this.extractClause(ctx, ORDER_BY_KEYWORD);
-		if (String.isNotBlank(orderBy)) {
-			this.parseOrderBy(builder, orderBy);
-		}
-		String lim = this.extractClause(ctx, LIMIT_KEYWORD);
-		if (String.isNotBlank(lim)) {
-			this.parseLimit(builder, lim);
-		}
-		String off = this.extractClause(ctx, OFFSET_KEYWORD);
-		if (String.isNotBlank(off)) {
-			this.parseOffset(builder, off);
-		}
-		String usingScope = this.extractClause(ctx, USING_SCOPE_KEYWORD);
-		if (String.isNotBlank(usingScope)) {
-			this.parseUsingScope(builder, usingScope);
-		}
-		String withClause = this.extractClause(ctx, WITH_KEYWORD);
-		if (String.isNotBlank(withClause)) {
-			this.parseWith(builder, withClause);
-		}
-		String forClause = this.extractClause(ctx, FOR_KEYWORD);
-		if (String.isNotBlank(forClause)) {
-			this.parseFor(builder, forClause);
-		}
+		this.parseWhere(builder, this.extractClause(ctx, WHERE_KEYWORD));
+		this.parseGroupBy(builder, this.extractClause(ctx, GROUP_BY_KEYWORD));
+		this.parseHaving(builder, this.extractClause(ctx, HAVING_KEYWORD));
+		this.parseOrderBy(builder, this.extractClause(ctx, ORDER_BY_KEYWORD));
+		this.parseLimit(builder, this.extractClause(ctx, LIMIT_KEYWORD));
+		this.parseOffset(builder, this.extractClause(ctx, OFFSET_KEYWORD));
+		this.parseUsingScope(builder, this.extractClause(ctx, USING_SCOPE_KEYWORD));
+		this.parseWith(builder, this.extractClause(ctx, WITH_KEYWORD));
+		this.parseFor(builder, this.extractClause(ctx, FOR_KEYWORD));
 		if (ctx.positions?.containsKey(ALL_ROWS_KEYWORD) == true) {
 			this.parseAllRows(builder);
 		}
@@ -472,6 +445,9 @@ public class SoqlParser {
 	 * @param forStr The FOR clause value (e.g. UPDATE, VIEW, REFERENCE)
 	 */
 	private void parseFor(Soql.Builder builder, String forStr) {
+		if (String.isBlank(forStr)) {
+			return;
+		}
 		String upper = forStr.toUpperCase();
 		if (upper.startsWith('UPDATE')) {
 			builder.setUsage(Soql.Usage.FOR_UPDATE);
@@ -497,6 +473,9 @@ public class SoqlParser {
 	 * @param groupByStr The GROUP BY clause content
 	 */
 	private void parseGroupBy(Soql.Builder builder, String groupByStr) {
+		if (String.isBlank(groupByStr)) {
+			return;
+		}
 		for (String item : this.splitTopLevelKeyword(groupByStr, ',')) {
 			builder.addGroupBy(item.trim());
 		}
@@ -508,6 +487,9 @@ public class SoqlParser {
 	 * @param havingStr The HAVING clause content
 	 */
 	private void parseHaving(Soql.Builder builder, String havingStr) {
+		if (String.isBlank(havingStr)) {
+			return;
+		}
 		builder.setHavingCriteria(this.parseCriteriaLogic(havingStr));
 	}
 
@@ -517,6 +499,9 @@ public class SoqlParser {
 	 * @param limitStr The LIMIT value string
 	 */
 	private void parseLimit(Soql.Builder builder, String limitStr) {
+		if (String.isBlank(limitStr)) {
+			return;
+		}
 		builder.setRowLimit(Integer.valueOf(limitStr));
 	}
 
@@ -563,6 +548,9 @@ public class SoqlParser {
 	 * @param offsetStr The OFFSET value string
 	 */
 	private void parseOffset(Soql.Builder builder, String offsetStr) {
+		if (String.isBlank(offsetStr)) {
+			return;
+		}
 		builder.setRowOffset(Integer.valueOf(offsetStr));
 	}
 
@@ -572,6 +560,9 @@ public class SoqlParser {
 	 * @param orderByStr The ORDER BY clause content
 	 */
 	private void parseOrderBy(Soql.Builder builder, String orderByStr) {
+		if (String.isBlank(orderByStr)) {
+			return;
+		}
 		for (String item : this.splitTopLevelKeyword(orderByStr, ',')) {
 			builder.addRawOrderBy(item.trim());
 		}
@@ -634,6 +625,9 @@ public class SoqlParser {
 	 * @param usingScopeStr The scope name string
 	 */
 	private void parseUsingScope(Soql.Builder builder, String usingScopeStr) {
+		if (String.isBlank(usingScopeStr)) {
+			return;
+		}
 		try {
 			builder.setScope(Soql.Scope.valueOf(usingScopeStr?.toUpperCase()));
 		} catch (Exception e) {
@@ -678,6 +672,9 @@ public class SoqlParser {
 	 * @param whereStr The WHERE clause content
 	 */
 	private void parseWhere(Soql.Builder builder, String whereStr) {
+		if (String.isBlank(whereStr)) {
+			return;
+		}
 		builder.setWhereCriteria(this.parseCriteriaLogic(whereStr));
 	}
 
@@ -687,6 +684,9 @@ public class SoqlParser {
 	 * @param withStr The WITH clause value
 	 */
 	private void parseWith(Soql.Builder builder, String withStr) {
+		if (String.isBlank(withStr)) {
+			return;
+		}
 		builder.setWithClause(withStr);
 	}
 

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -438,8 +438,8 @@ public class SoqlParser {
 		Integer closeParen = this.findMatchingParen(trimmed, 0);
 		Boolean isWrapped = trimmed.startsWith('(') && closeParen == trimmed.length() - 1;
 		if (isWrapped) {
-			String inner = trimmed.substring(1, trimmed.length() - 1).trim();
-			return this.parseExpr(inner);
+			String body = trimmed.substring(1, trimmed.length() - 1).trim();
+			return this.parseExpr(body);
 		}
 		return this.parseCondition(trimmed);
 	}

--- a/src/core/classes/SoqlParser.cls
+++ b/src/core/classes/SoqlParser.cls
@@ -206,13 +206,13 @@ public class SoqlParser {
 	 * @param subqueryStr The parenthesized subquery string, e.g. {@code (SELECT Id FROM Contacts)}
 	 */
 	public void parseSubquery(Soql.Builder builder, String subqueryStr) {
-		String inner = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
-		Integer fromPos = inner.toUpperCase().indexOf(' FROM ');
+		String body = subqueryStr.substring(1, subqueryStr.length() - 1).trim();
+		Integer fromPos = body.toUpperCase().indexOf(' FROM ');
 		if (fromPos < 0) {
 			return;
 		}
-		String selectPart = inner.substring(0, fromPos).trim();
-		String fromPart = inner.substring(fromPos + 6).trim();
+		String selectPart = body.substring(0, fromPos).trim();
+		String fromPart = body.substring(fromPos + 6).trim();
 		if (selectPart.toUpperCase().startsWith('SELECT ')) {
 			selectPart = selectPart.substring(7).trim();
 		}
@@ -244,17 +244,17 @@ public class SoqlParser {
 	private void applyParsers(Soql.Builder builder, String queryString, Map<String, Integer> positions) {
 		this.parseSelect(builder, this.extractClause(queryString, positions, SELECT_KEYWORD, FROM_KEYWORD));
 		this.parseFrom(builder, this.extractClause(queryString, positions, FROM_KEYWORD, this.getNextKeyword(positions, FROM_KEYWORD)));
-		String where = this.extractClause(queryString, positions, WHERE_KEYWORD, this.getNextKeyword(positions, WHERE_KEYWORD));
-		if (String.isNotBlank(where)) {
-			this.parseWhere(builder, where);
+		String whereClause = this.extractClause(queryString, positions, WHERE_KEYWORD, this.getNextKeyword(positions, WHERE_KEYWORD));
+		if (String.isNotBlank(whereClause)) {
+			this.parseWhere(builder, whereClause);
 		}
 		String groupBy = this.extractClause(queryString, positions, GROUP_BY_KEYWORD, this.getNextKeyword(positions, GROUP_BY_KEYWORD));
 		if (String.isNotBlank(groupBy)) {
 			this.parseGroupBy(builder, groupBy);
 		}
-		String having = this.extractClause(queryString, positions, HAVING_KEYWORD, this.getNextKeyword(positions, HAVING_KEYWORD));
-		if (String.isNotBlank(having)) {
-			this.parseHaving(builder, having);
+		String havingClause = this.extractClause(queryString, positions, HAVING_KEYWORD, this.getNextKeyword(positions, HAVING_KEYWORD));
+		if (String.isNotBlank(havingClause)) {
+			this.parseHaving(builder, havingClause);
 		}
 		String orderBy = this.extractClause(queryString, positions, ORDER_BY_KEYWORD, this.getNextKeyword(positions, ORDER_BY_KEYWORD));
 		if (String.isNotBlank(orderBy)) {
@@ -439,12 +439,12 @@ public class SoqlParser {
 	}
 
 	private Object parseList(String trimmed) {
-		String inner = trimmed.substring(1, trimmed.length() - 1);
-		if (inner.toUpperCase().contains('SELECT')) {
+		String body = trimmed.substring(1, trimmed.length() - 1);
+		if (body.toUpperCase().contains('SELECT')) {
 			return trimmed;
 		}
 		List<String> result = new List<String>();
-		for (String item : this.splitTopLevelKeyword(inner, ',')) {
+		for (String item : this.splitTopLevelKeyword(body, ',')) {
 			String val = item.trim();
 			result.add((val.startsWith('\'') && val.endsWith('\'')) ? val.substring(1, val.length() - 1) : val);
 		}

--- a/src/core/classes/SoqlParser.cls-meta.xml
+++ b/src/core/classes/SoqlParser.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/core/classes/SoqlParser.cls-meta.xml
+++ b/src/core/classes/SoqlParser.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>66.0</apiVersion>
     <status>Active</status>

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -586,6 +586,64 @@ private class SoqlParserTest {
 		Assert.areEqual('XXXX-06-15', (String) result, 'Expected raw string for non-numeric year');
 	}
 
+	@IsTest
+	private static void shouldFallbackForUnrecognizedOperator() {
+		// Unrecognized operators are not matched; the full string becomes the field name with EQUALS null
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
+		Soql.Condition condition = parser.parseCondition('Name INVALIDOP value');
+		Test.stopTest();
+
+		Assert.areEqual('Name INVALIDOP value', condition.property, 'Expected full string preserved as field');
+		Assert.areEqual('=', condition.operator.toString(), 'Expected default = operator');
+		Assert.isNull(condition.value, 'Expected null value');
+	}
+
+	@IsTest
+	private static void shouldRoundTripUnicodeStringLiteral() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account WHERE Name = \'Ünïcödé\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected unicode string literal to round-trip');
+	}
+
+	@IsTest
+	private static void shouldParseEscapedQuoteInStringLiteral() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
+		Object result = parser.parseValue('\'O\\\'Brien\'');
+		Test.stopTest();
+
+		Assert.areEqual('O\'Brien', (String) result, 'Expected escaped quote to be unescaped');
+	}
+
+	@IsTest
+	private static void shouldHandleDeeplyNestedParentheses() {
+		// Triple-wrapped single condition — recursion should resolve without error and simplify
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account WHERE (((Name = \'test\')))';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(
+			'SELECT Id FROM Account WHERE Name = \'test\'',
+			result,
+			'Expected redundant parens to simplify'
+		);
+	}
+
 	@SuppressWarnings('PMD.EmptyCatchBlock')
 	@IsTest
 	private static void shouldThrowQueryExceptionOnParseFailure() {

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -463,4 +463,12 @@ private class SoqlParserTest {
 		Assert.areEqual('2020-06', (String) result);
 	}
 
+	@IsTest
+	private static void testLikeOperator() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE Name LIKE \'%Test%\'';
+		Soql query = DatabaseLayer.newSoql(input);
+		Assert.areEqual(input, query?.toString());
+	}
+
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -535,14 +535,18 @@ private class SoqlParserTest {
 	}
 
 	@IsTest
-	private static void shouldReturnStringForPartialDateString() {
+	private static void shouldThrowQueryExceptionOnParseFailure() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+		Soql soql = DatabaseLayer.newSoql('SELECT Id FROM Account');
 
 		Test.startTest();
-		Object result = parser.parseValue('2020-06');
+		try {
+			parser.parse(soql, null);
+			Assert.fail('Expected a QueryException');
+		} catch (System.QueryException e) {
+			// expected
+		}
 		Test.stopTest();
-
-		Assert.areEqual('2020-06', (String) result, 'Expected raw string for partial date');
 	}
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -134,6 +134,14 @@ private class SoqlParserTest {
 	}
 
 	@IsTest
+	private static void testInOperatorOnFieldStartingWithIn() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE Industry IN (\'Technology\', \'Finance\')';
+		Soql query = DatabaseLayer.newSoql(input);
+		Assert.areEqual(input, query?.toString());
+	}
+
+	@IsTest
 	private static void testNestedAndInsideOr() {
 		DatabaseLayer.useMocks();
 		String input = 'SELECT Id FROM Opportunity WHERE (Amount > 1000 AND IsClosed = false) OR (Amount > 5000 AND IsClosed = true)';

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -439,4 +439,28 @@ private class SoqlParserTest {
 		Assert.areEqual(input, output);
 	}
 
+	@IsTest
+	private static void testParseValueWithInvalidDateFormat() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('20200615XX');
+		Assert.areEqual('20200615XX', (String) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithNonNumericDateParts() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('XXXX-06-15');
+		Assert.areEqual('XXXX-06-15', (String) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithTooShortDateLiteral() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('2020-06');
+		Assert.areEqual('2020-06', (String) result);
+	}
+
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -534,6 +534,7 @@ private class SoqlParserTest {
 		Assert.areEqual('XXXX-06-15', (String) result, 'Expected raw string for non-numeric year');
 	}
 
+	@SuppressWarnings('PMD.EmptyCatchBlock')
 	@IsTest
 	private static void shouldThrowQueryExceptionOnParseFailure() {
 		DatabaseLayer.useMocks();
@@ -543,9 +544,9 @@ private class SoqlParserTest {
 		Test.startTest();
 		try {
 			parser.parse(soql, null);
-			Assert.fail('Expected a QueryException');
-		} catch (System.QueryException e) {
-			// expected
+			Assert.fail('Expected a System.QueryException');
+		} catch (System.QueryException error) {
+			// As expected...
 		}
 		Test.stopTest();
 	}

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -18,12 +18,12 @@ private class SoqlParserTest {
 	private static void shouldPreserveStateAfterMutation() {
 		DatabaseLayer.useMocks();
 		String queryStr = 'SELECT Id, AccountId FROM Opportunity WHERE IsClosed = true ORDER BY CloseDate DESC LIMIT 1';
-		Soql soql = DatabaseLayer.newSoql(queryStr);
-		soql.addSelect('CloseDate');
-		soql.addWhere('Amount', Soql.GREATER_THAN, 100000);
+		Soql query = DatabaseLayer.newSoql(queryStr);
+		query.addSelect('CloseDate');
+		query.addWhere('Amount', Soql.GREATER_THAN, 100000);
 
 		Test.startTest();
-		String result = soql?.toString();
+		String result = query?.toString();
 		Test.stopTest();
 
 		String expected = 'SELECT Id, AccountId, CloseDate FROM Opportunity WHERE IsClosed = true AND Amount > 100000 ORDER BY CloseDate DESC LIMIT 1';

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -1,482 +1,698 @@
 @IsTest
 private class SoqlParserTest {
-	private static final String OPPORTUNITY = 'Opportunity';
-	private static final String ACCOUNT = 'Account';
-	private static final String CONTACT = 'Contact';
-
 	@IsTest
-	private static void testSimpleRoundTrip() {
+	private static void shouldRoundTripSimpleQuery() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id, AccountId FROM Opportunity WHERE IsClosed = true ORDER BY CloseDate DESC LIMIT 1';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id, AccountId FROM Opportunity WHERE IsClosed = true ORDER BY CloseDate DESC LIMIT 1';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testMutationAfterParse() {
+	private static void shouldPreserveStateAfterMutation() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id, AccountId FROM Opportunity WHERE IsClosed = true ORDER BY CloseDate DESC LIMIT 1';
-		Soql query = DatabaseLayer.newSoql(input);
-		query.addSelect('CloseDate');
-		query.addWhere('Amount', Soql.GREATER_THAN, 100000);
-		String output = query?.toString();
+		String queryStr = 'SELECT Id, AccountId FROM Opportunity WHERE IsClosed = true ORDER BY CloseDate DESC LIMIT 1';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+		soql.addSelect('CloseDate');
+		soql.addWhere('Amount', Soql.GREATER_THAN, 100000);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
 		String expected = 'SELECT Id, AccountId, CloseDate FROM Opportunity WHERE IsClosed = true AND Amount > 100000 ORDER BY CloseDate DESC LIMIT 1';
-		Assert.areEqual(expected, output);
+		Assert.areEqual(expected, result, 'Expected fields and conditions appended after parse');
 	}
 
 	@IsTest
-	private static void testFlatOrWhere() {
+	private static void shouldRoundTripOrWhere() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE Name = \'Foo\' OR Name = \'Bar\'';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE Name = \'Foo\' OR Name = \'Bar\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testNestedAndOr() {
+	private static void shouldRoundTripNestedAndOr() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Contact WHERE (FirstName = \'John\' AND LastName = \'Doe\') OR Email != null';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Contact WHERE (FirstName = \'John\' AND LastName = \'Doe\') OR Email != null';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testAggregateSelect() {
+	private static void shouldRoundTripAggregateSelect() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT COUNT(Id), SUM(Amount) totalAmount FROM Opportunity';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT COUNT(Id), SUM(Amount) totalAmount FROM Opportunity';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testSubqueryInSelect() {
+	private static void shouldRoundTripSubqueryInSelect() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id, (SELECT Id, LastName FROM Contacts) FROM Account';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id, (SELECT Id, LastName FROM Contacts) FROM Account';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testOrderByMultiField() {
+	private static void shouldRoundTripMultiFieldOrderBy() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account ORDER BY Name ASC, CreatedDate DESC';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account ORDER BY Name ASC, CreatedDate DESC';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testGroupByAndHaving() {
+	private static void shouldRoundTripGroupByWithHaving() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT AccountId, COUNT(Id) FROM Opportunity GROUP BY AccountId HAVING COUNT(Id) > 5';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT AccountId, COUNT(Id) FROM Opportunity GROUP BY AccountId HAVING COUNT(Id) > 5';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testUsingScope() {
+	private static void shouldRoundTripUsingScope() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account USING SCOPE MINE';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account USING SCOPE MINE';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testWithSecurityEnforced() {
+	private static void shouldRoundTripWithSecurityEnforced() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WITH SECURITY_ENFORCED';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WITH SECURITY_ENFORCED';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testLimitAndOffset() {
+	private static void shouldRoundTripLimitAndOffset() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account LIMIT 10 OFFSET 20';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account LIMIT 10 OFFSET 20';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testForUpdate() {
+	private static void shouldRoundTripForUpdate() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account FOR UPDATE';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account FOR UPDATE';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testParentFieldDotNotation() {
+	private static void shouldRoundTripParentFieldNotation() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id, Account.Name FROM Contact WHERE Account.Industry = \'Technology\'';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id, Account.Name FROM Contact WHERE Account.Industry = \'Technology\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testInList() {
+	private static void shouldRoundTripInList() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE Name IN (\'Acme\', \'Salesforce\')';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE Name IN (\'Acme\', \'Salesforce\')';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testInOperatorOnFieldStartingWithIn() {
+	private static void shouldRoundTripInOperatorOnInPrefixedField() {
+		// Regression: word-boundary guard must prevent 'IN' matching at position 0 of 'INDUSTRY'
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE Industry IN (\'Technology\', \'Finance\')';
-		Soql query = DatabaseLayer.newSoql(input);
-		Assert.areEqual(input, query?.toString());
+		String queryStr = 'SELECT Id FROM Account WHERE Industry IN (\'Technology\', \'Finance\')';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testNestedAndInsideOr() {
+	private static void shouldRoundTripNestedAndInsideOr() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Opportunity WHERE (Amount > 1000 AND IsClosed = false) OR (Amount > 5000 AND IsClosed = true)';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Opportunity WHERE (Amount > 1000 AND IsClosed = false) OR (Amount > 5000 AND IsClosed = true)';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testAllRows() {
+	private static void shouldRoundTripAllRows() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account ALL ROWS';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account ALL ROWS';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testDateFiltering() {
+	private static void shouldRoundTripDateFilter() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE CreatedDate > 2020-01-01';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE CreatedDate > 2020-01-01';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testBindVariables() {
+	private static void shouldRoundTripBindVariable() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE Name = :accountName';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE Name = :accountName';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testMultipleGroupByFields() {
+	private static void shouldRoundTripMultiFieldGroupBy() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT AccountId, StageName, COUNT(Id) FROM Opportunity GROUP BY AccountId, StageName';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT AccountId, StageName, COUNT(Id) FROM Opportunity GROUP BY AccountId, StageName';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testComplexWhereWithNesting() {
+	private static void shouldRoundTripComplexNestedWhere() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE (Name = \'test\' AND Industry = \'Tech\') OR (BillingCity = \'SF\' AND BillingState = \'CA\')';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE (Name = \'test\' AND Industry = \'Tech\') OR (BillingCity = \'SF\' AND BillingState = \'CA\')';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testNotInOperator() {
+	private static void shouldRoundTripNotInOperator() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE Name NOT IN (\'A\', \'B\')';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE Name NOT IN (\'A\', \'B\')';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testMultipleAggregations() {
+	private static void shouldRoundTripMultipleAggregations() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT COUNT(Id) count, AVG(Amount) avgAmount, MAX(Amount) maxAmount FROM Opportunity';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT COUNT(Id) count, AVG(Amount) avgAmount, MAX(Amount) maxAmount FROM Opportunity';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testDateTimeValue() {
+	private static void shouldRoundTripDateTimeValue() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE CreatedDate > 2020-01-01T10:00:00Z';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE CreatedDate > 2020-01-01T10:00:00Z';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testNullInWhere() {
+	private static void shouldRoundTripNullComparison() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE BillingCity = null';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE BillingCity = null';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testBooleanInWhere() {
+	private static void shouldRoundTripBooleanComparison() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Opportunity WHERE IsClosed = true';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Opportunity WHERE IsClosed = true';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testGreaterThanOperator() {
+	private static void shouldRoundTripGreaterOrEqualFilter() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Opportunity WHERE Amount >= 10000';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Opportunity WHERE Amount >= 10000';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testLessThanOperator() {
+	private static void shouldRoundTripLessOrEqualFilter() {
 		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE NumberOfEmployees <= 100';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
+		String queryStr = 'SELECT Id FROM Account WHERE NumberOfEmployees <= 100';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
 	}
 
 	@IsTest
-	private static void testMalformedSubqueryNoFrom() {
+	private static void shouldRoundTripForReference() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account FOR REFERENCE';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
+	}
+
+	@IsTest
+	private static void shouldRoundTripForView() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account FOR VIEW';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
+	}
+
+	@IsTest
+	private static void shouldRoundTripHavingWithAndLogic() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT AccountId, COUNT(Id) FROM Opportunity GROUP BY AccountId HAVING COUNT(Id) > 5 AND Amount > 10000';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
+	}
+
+	@IsTest
+	private static void shouldRoundTripLikeOperator() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account WHERE Name LIKE \'%Test%\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected exact query round-trip');
+	}
+
+	@IsTest
+	private static void shouldSkipSubqueryMissingFrom() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
 		Soql.Builder builder = DatabaseLayer.newSoql('SELECT Id FROM Account');
+
+		Test.startTest();
 		parser.parseSubquery(builder, '(SELECT Id, Name)');
-		String output = builder?.toString();
-		Assert.isNotNull(output);
+		Test.stopTest();
+
+		Assert.isNotNull(builder?.toString(), 'Expected builder to remain valid after malformed subquery');
 	}
 
 	@IsTest
-	private static void testUnmatchedParenthesis() {
+	private static void shouldReturnStringLengthForUnclosedParen() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Integer result = parser.findMatchingParen('(unclosed text here', 0);
-		Assert.areEqual(19, result);
+		Test.stopTest();
+
+		Assert.areEqual(19, result, 'Expected string length when no closing paren found');
 	}
 
 	@IsTest
-	private static void testConditionWithoutOperator() {
+	private static void shouldDefaultEqualsForNoOperator() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Soql.Condition condition = parser.parseCondition('Name');
-		Assert.areEqual('Name', condition.property);
-		Assert.areEqual('=', condition.operator.toString());
-		Assert.isNull(condition.value);
+		Test.stopTest();
+
+		Assert.areEqual('Name', condition.property, 'Expected field name preserved');
+		Assert.areEqual('=', condition.operator.toString(), 'Expected default = operator');
+		Assert.isNull(condition.value, 'Expected null value for bare field');
 	}
 
 	@IsTest
-	private static void testParseValueWithNull() {
+	private static void shouldParseNullLiteral() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('null');
-		Assert.isNull(result);
+		Test.stopTest();
+
+		Assert.isNull(result, 'Expected null for null literal');
 	}
 
 	@IsTest
-	private static void testParseValueWithTrue() {
+	private static void shouldParseTrueLiteral() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('true');
-		Assert.areEqual(true, (Boolean) result);
+		Test.stopTest();
+
+		Assert.areEqual(true, (Boolean) result, 'Expected Boolean true');
 	}
 
 	@IsTest
-	private static void testParseValueWithFalse() {
+	private static void shouldParseFalseLiteral() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('false');
-		Assert.areEqual(false, (Boolean) result);
+		Test.stopTest();
+
+		Assert.areEqual(false, (Boolean) result, 'Expected Boolean false');
 	}
 
 	@IsTest
-	private static void testParseValueWithInteger() {
+	private static void shouldParseIntegerLiteral() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('12345');
-		Assert.areEqual(12345, (Integer) result);
+		Test.stopTest();
+
+		Assert.areEqual(12345, (Integer) result, 'Expected Integer 12345');
 	}
 
 	@IsTest
-	private static void testParseValueWithDecimal() {
+	private static void shouldParseDecimalLiteral() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('123.45');
-		Assert.areEqual(123.45, (Decimal) result);
+		Test.stopTest();
+
+		Assert.areEqual(123.45, (Decimal) result, 'Expected Decimal 123.45');
 	}
 
 	@IsTest
-	private static void testParseValueWithString() {
+	private static void shouldParseQuotedString() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('\'test value\'');
-		Assert.areEqual('test value', (String) result);
+		Test.stopTest();
+
+		Assert.areEqual('test value', (String) result, 'Expected unquoted string value');
 	}
 
 	@IsTest
-	private static void testParseValueWithBindVariable() {
+	private static void shouldParseBindVariable() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue(':bindVar');
-		Assert.areEqual(':bindVar', (String) result);
+		Test.stopTest();
+
+		Assert.areEqual(':bindVar', (String) result, 'Expected bind variable passed through unchanged');
 	}
 
 	@IsTest
-	private static void testParseValueWithList() {
+	private static void shouldParseListValue() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('(\'A\', \'B\', \'C\')');
-		Assert.isNotNull(result);
+		Test.stopTest();
+
+		Assert.isNotNull(result, 'Expected non-null list result');
 	}
 
 	@IsTest
-	private static void testParseValueWithDate() {
+	private static void shouldParseDateValue() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('2020-06-15');
-		Assert.isNotNull(result);
+		Test.stopTest();
+
+		Assert.isNotNull(result, 'Expected non-null date result');
 	}
 
 	@IsTest
-	private static void testParseValueWithDateTime() {
+	private static void shouldParseDateTimeValue() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('2020-06-15T10:30:00Z');
-		Assert.isNotNull(result);
+		Test.stopTest();
+
+		Assert.isNotNull(result, 'Expected non-null datetime result');
 	}
 
 	@IsTest
-	private static void testParseValueWithDateLiteral() {
+	private static void shouldPassThroughSoqlDateLiteral() {
+		// SOQL date functions (TODAY, LAST_WEEK, etc.) are not parseable as Date/DateTime
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('TODAY');
-		Assert.areEqual('TODAY', (String) result);
+		Test.stopTest();
+
+		Assert.areEqual('TODAY', (String) result, 'Expected unrecognized token returned as-is');
 	}
 
 	@IsTest
-	private static void testConditionWithUnknownOperator() {
+	private static void shouldParseConditionFields() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Soql.Condition condition = parser.parseCondition('Amount = 5000');
-		Assert.isNotNull(condition);
-		Assert.areEqual('Amount', condition.property);
+		Test.stopTest();
+
+		Assert.isNotNull(condition, 'Expected a condition to be returned');
+		Assert.areEqual('Amount', condition.property, 'Expected field name parsed correctly');
 	}
 
 	@IsTest
-	private static void testFindKeywordPositions() {
+	private static void shouldFindAllKeywordPositions() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Map<String, Integer> positions = parser.findKeywordPositions('SELECT Id FROM Account WHERE Name = \'Test\'');
-		Assert.isTrue(positions.containsKey('SELECT'));
-		Assert.isTrue(positions.containsKey('FROM'));
-		Assert.isTrue(positions.containsKey('WHERE'));
+		Test.stopTest();
+
+		Assert.isTrue(positions.containsKey('SELECT'), 'Expected SELECT position');
+		Assert.isTrue(positions.containsKey('FROM'), 'Expected FROM position');
+		Assert.isTrue(positions.containsKey('WHERE'), 'Expected WHERE position');
 	}
 
 	@IsTest
-	private static void testExtractClause() {
+	private static void shouldExtractSelectClause() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
-		String query = 'SELECT Id, Name FROM Account WHERE Active = true';
-		Map<String, Integer> positions = parser.findKeywordPositions(query);
-		String selectClause = parser.extractClause(query, positions, 'SELECT', 'FROM');
-		Assert.isTrue(selectClause.containsIgnoreCase('Id'));
-		Assert.isTrue(selectClause.containsIgnoreCase('Name'));
+		String queryStr = 'SELECT Id, Name FROM Account WHERE Active = true';
+		Map<String, Integer> positions = parser.findKeywordPositions(queryStr);
+
+		Test.startTest();
+		String selectClause = parser.extractClause(queryStr, positions, 'SELECT', 'FROM');
+		Test.stopTest();
+
+		Assert.isTrue(selectClause.containsIgnoreCase('Id'), 'Expected Id in SELECT clause');
+		Assert.isTrue(selectClause.containsIgnoreCase('Name'), 'Expected Name in SELECT clause');
 	}
 
 	@IsTest
-	private static void testParseValueWithSubqueryInList() {
+	private static void shouldPreserveSubqueryInListValue() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('(SELECT Id FROM Account)');
-		Assert.areEqual('(SELECT Id FROM Account)', (String) result);
+		Test.stopTest();
+
+		Assert.areEqual('(SELECT Id FROM Account)', (String) result, 'Expected subquery preserved as raw string');
 	}
 
 	@IsTest
-	private static void testParseValueWithInvalidDate() {
+	private static void shouldReturnStringForOutOfRangeDate() {
+		// Feb 30 is not a real date; parser should fall back to raw string rather than throw
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('2025-02-30');
-		Assert.areEqual('2025-02-30', (String) result);
+		Test.stopTest();
+
+		Assert.areEqual('2025-02-30', (String) result, 'Expected raw string for unparseable date');
 	}
 
 	@IsTest
-	private static void testForReference() {
-		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account FOR REFERENCE';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
-	}
-
-	@IsTest
-	private static void testForView() {
-		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account FOR VIEW';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
-	}
-
-	@IsTest
-	private static void testHavingWithComplexLogic() {
-		DatabaseLayer.useMocks();
-		String input = 'SELECT AccountId, COUNT(Id) FROM Opportunity GROUP BY AccountId HAVING COUNT(Id) > 5 AND Amount > 10000';
-		Soql query = DatabaseLayer.newSoql(input);
-		String output = query?.toString();
-		Assert.areEqual(input, output);
-	}
-
-	@IsTest
-	private static void testParseValueWithInvalidDateFormat() {
+	private static void shouldReturnStringForInvalidDateFormat() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('20200615XX');
-		Assert.areEqual('20200615XX', (String) result);
+		Test.stopTest();
+
+		Assert.areEqual('20200615XX', (String) result, 'Expected raw string for non-date token');
 	}
 
 	@IsTest
-	private static void testParseValueWithNonNumericDateParts() {
+	private static void shouldReturnStringForNonNumericDate() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
+
+		Test.startTest();
 		Object result = parser.parseValue('XXXX-06-15');
-		Assert.areEqual('XXXX-06-15', (String) result);
+		Test.stopTest();
+
+		Assert.areEqual('XXXX-06-15', (String) result, 'Expected raw string for non-numeric year');
 	}
 
 	@IsTest
-	private static void testParseValueWithTooShortDateLiteral() {
+	private static void shouldReturnStringForPartialDateString() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
-		Object result = parser.parseValue('2020-06');
-		Assert.areEqual('2020-06', (String) result);
-	}
 
-	@IsTest
-	private static void testLikeOperator() {
-		DatabaseLayer.useMocks();
-		String input = 'SELECT Id FROM Account WHERE Name LIKE \'%Test%\'';
-		Soql query = DatabaseLayer.newSoql(input);
-		Assert.areEqual(input, query?.toString());
+		Test.startTest();
+		Object result = parser.parseValue('2020-06');
+		Test.stopTest();
+
+		Assert.areEqual('2020-06', (String) result, 'Expected raw string for partial date');
 	}
 
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -397,16 +397,6 @@ private class SoqlParserTest {
 	}
 
 	@IsTest
-	private static void testConditionWithUnknownOperatorFallback() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-		Soql.Condition condition = parser.parseCondition('Amount ~~~ 5000');
-		Assert.isNotNull(condition);
-		Assert.areEqual('Amount', condition.property);
-		Assert.areEqual('=', condition.operator.toString());
-	}
-
-	@IsTest
 	private static void testParseValueWithSubqueryInList() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
@@ -418,8 +408,8 @@ private class SoqlParserTest {
 	private static void testParseValueWithInvalidDate() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
-		Object result = parser.parseValue('2025-13-45');
-		Assert.areEqual('2025-13-45', (String) result);
+		Object result = parser.parseValue('2025-02-30');
+		Assert.areEqual('2025-02-30', (String) result);
 	}
 
 	@IsTest
@@ -430,4 +420,23 @@ private class SoqlParserTest {
 		String output = query?.toString();
 		Assert.areEqual(input, output);
 	}
+
+	@IsTest
+	private static void testForView() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account FOR VIEW';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testHavingWithComplexLogic() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT AccountId, COUNT(Id) FROM Opportunity GROUP BY AccountId HAVING COUNT(Id) > 5 AND Amount > 10000';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -422,6 +422,58 @@ private class SoqlParserTest {
 	}
 
 	@IsTest
+	private static void shouldRoundTripLikeStartsWith() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account WHERE Name LIKE \'Test%\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected STARTS_WITH round-trip');
+	}
+
+	@IsTest
+	private static void shouldRoundTripLikeEndsWith() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account WHERE Name LIKE \'%Test\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected ENDS_WITH round-trip');
+	}
+
+	@IsTest
+	private static void shouldRoundTripLikeRawNoWildcards() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account WHERE Name LIKE \'Test\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected raw LIKE (no wildcards) round-trip');
+	}
+
+	@IsTest
+	private static void shouldRoundTripNotLikeOperator() {
+		DatabaseLayer.useMocks();
+		String queryStr = 'SELECT Id FROM Account WHERE Name NOT LIKE \'%Test%\'';
+		Soql soql = DatabaseLayer.newSoql(queryStr);
+
+		Test.startTest();
+		String result = soql?.toString();
+		Test.stopTest();
+
+		Assert.areEqual(queryStr, result, 'Expected NOT LIKE round-trip');
+	}
+
+	@IsTest
 	private static void shouldGracefullyIgnoreMalformedSubquery() {
 		// A subquery without a FROM clause should be silently skipped, leaving other fields intact
 		DatabaseLayer.useMocks();

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -1,0 +1,144 @@
+@IsTest
+private class SoqlParserTest {
+	private static final String OPPORTUNITY = 'Opportunity';
+	private static final String ACCOUNT = 'Account';
+	private static final String CONTACT = 'Contact';
+
+	@IsTest
+	private static void testSimpleRoundTrip() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id, AccountId FROM Opportunity WHERE IsClosed = true ORDER BY CloseDate DESC LIMIT 1';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testMutationAfterParse() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id, AccountId FROM Opportunity WHERE IsClosed = true ORDER BY CloseDate DESC LIMIT 1';
+		Soql query = DatabaseLayer.newSoql(input);
+		query.addSelect('CloseDate');
+		query.addWhere('Amount', Soql.GREATER_THAN, 100000);
+		String output = query?.toString();
+		String expected = 'SELECT Id, AccountId, CloseDate FROM Opportunity WHERE IsClosed = true AND Amount > 100000 ORDER BY CloseDate DESC LIMIT 1';
+		Assert.areEqual(expected, output);
+	}
+
+	@IsTest
+	private static void testFlatOrWhere() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE Name = \'Foo\' OR Name = \'Bar\'';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testNestedAndOr() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Contact WHERE (FirstName = \'John\' AND LastName = \'Doe\') OR Email != null';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testAggregateSelect() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT COUNT(Id), SUM(Amount) totalAmount FROM Opportunity';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testSubqueryInSelect() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id, (SELECT Id, LastName FROM Contacts) FROM Account';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testOrderByMultiField() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account ORDER BY Name ASC, CreatedDate DESC';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testGroupByAndHaving() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT AccountId, COUNT(Id) FROM Opportunity GROUP BY AccountId HAVING COUNT(Id) > 5';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testUsingScope() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account USING SCOPE MINE';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testWithSecurityEnforced() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WITH SECURITY_ENFORCED';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testLimitAndOffset() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account LIMIT 10 OFFSET 20';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testForUpdate() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account FOR UPDATE';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testParentFieldDotNotation() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id, Account.Name FROM Contact WHERE Account.Industry = \'Technology\'';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testInList() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE Name IN (\'Acme\', \'Salesforce\')';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testNestedAndInsideOr() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Opportunity WHERE (Amount > 1000 AND IsClosed = false) OR (Amount > 5000 AND IsClosed = true)';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+}

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -249,4 +249,185 @@ private class SoqlParserTest {
 		String output = query?.toString();
 		Assert.areEqual(input, output);
 	}
+
+	@IsTest
+	private static void testMalformedSubqueryNoFrom() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Soql.Builder builder = DatabaseLayer.newSoql('SELECT Id FROM Account');
+		parser.parseSubquery(builder, '(SELECT Id, Name)');
+		String output = builder?.toString();
+		Assert.isNotNull(output);
+	}
+
+	@IsTest
+	private static void testUnmatchedParenthesis() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Integer result = parser.findMatchingParen('(unclosed text here', 0);
+		Assert.areEqual(19, result);
+	}
+
+	@IsTest
+	private static void testConditionWithoutOperator() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Soql.Condition condition = parser.parseCondition('Name');
+		Assert.areEqual('Name', condition.property);
+		Assert.areEqual('=', condition.operator.toString());
+		Assert.isNull(condition.value);
+	}
+
+	@IsTest
+	private static void testParseValueWithNull() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('null');
+		Assert.isNull(result);
+	}
+
+	@IsTest
+	private static void testParseValueWithTrue() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('true');
+		Assert.areEqual(true, (Boolean) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithFalse() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('false');
+		Assert.areEqual(false, (Boolean) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithInteger() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('12345');
+		Assert.areEqual(12345, (Integer) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithDecimal() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('123.45');
+		Assert.areEqual(123.45, (Decimal) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithString() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('\'test value\'');
+		Assert.areEqual('test value', (String) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithBindVariable() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue(':bindVar');
+		Assert.areEqual(':bindVar', (String) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithList() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('(\'A\', \'B\', \'C\')');
+		Assert.isNotNull(result);
+	}
+
+	@IsTest
+	private static void testParseValueWithDate() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('2020-06-15');
+		Assert.isNotNull(result);
+	}
+
+	@IsTest
+	private static void testParseValueWithDateTime() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('2020-06-15T10:30:00Z');
+		Assert.isNotNull(result);
+	}
+
+	@IsTest
+	private static void testParseValueWithDateLiteral() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('TODAY');
+		Assert.areEqual('TODAY', (String) result);
+	}
+
+	@IsTest
+	private static void testConditionWithUnknownOperator() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Soql.Condition condition = parser.parseCondition('Amount = 5000');
+		Assert.isNotNull(condition);
+		Assert.areEqual('Amount', condition.property);
+	}
+
+	@IsTest
+	private static void testFindKeywordPositions() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Map<String, Integer> positions = parser.findKeywordPositions('SELECT Id FROM Account WHERE Name = \'Test\'');
+		Assert.isTrue(positions.containsKey('SELECT'));
+		Assert.isTrue(positions.containsKey('FROM'));
+		Assert.isTrue(positions.containsKey('WHERE'));
+	}
+
+	@IsTest
+	private static void testExtractClause() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		String query = 'SELECT Id, Name FROM Account WHERE Active = true';
+		Map<String, Integer> positions = parser.findKeywordPositions(query);
+		String selectClause = parser.extractClause(query, positions, 'SELECT', 'FROM');
+		Assert.isTrue(selectClause.containsIgnoreCase('Id'));
+		Assert.isTrue(selectClause.containsIgnoreCase('Name'));
+	}
+
+	@IsTest
+	private static void testConditionWithUnknownOperatorFallback() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Soql.Condition condition = parser.parseCondition('Amount ~~~ 5000');
+		Assert.isNotNull(condition);
+		Assert.areEqual('Amount', condition.property);
+		Assert.areEqual('=', condition.operator.toString());
+	}
+
+	@IsTest
+	private static void testParseValueWithSubqueryInList() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('(SELECT Id FROM Account)');
+		Assert.areEqual('(SELECT Id FROM Account)', (String) result);
+	}
+
+	@IsTest
+	private static void testParseValueWithInvalidDate() {
+		DatabaseLayer.useMocks();
+		SoqlParser parser = new SoqlParser();
+		Object result = parser.parseValue('2025-13-45');
+		Assert.areEqual('2025-13-45', (String) result);
+	}
+
+	@IsTest
+	private static void testForReference() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account FOR REFERENCE';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -695,5 +695,4 @@ private class SoqlParserTest {
 
 		Assert.areEqual('2020-06', (String) result, 'Expected raw string for partial date');
 	}
-
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -1,3 +1,4 @@
+@SuppressWarnings('PMD.ApexUnitTestClassShouldHaveRunAs,PMD.CyclomaticComplexity')
 @IsTest
 private class SoqlParserTest {
 	@IsTest

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -141,4 +141,112 @@ private class SoqlParserTest {
 		String output = query?.toString();
 		Assert.areEqual(input, output);
 	}
+
+	@IsTest
+	private static void testAllRows() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account ALL ROWS';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testDateFiltering() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE CreatedDate > 2020-01-01';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testBindVariables() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE Name = :accountName';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testMultipleGroupByFields() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT AccountId, StageName, COUNT(Id) FROM Opportunity GROUP BY AccountId, StageName';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testComplexWhereWithNesting() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE (Name = \'test\' AND Industry = \'Tech\') OR (BillingCity = \'SF\' AND BillingState = \'CA\')';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testNotInOperator() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE Name NOT IN (\'A\', \'B\')';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testMultipleAggregations() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT COUNT(Id) count, AVG(Amount) avgAmount, MAX(Amount) maxAmount FROM Opportunity';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testDateTimeValue() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE CreatedDate > 2020-01-01T10:00:00Z';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testNullInWhere() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE BillingCity = null';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testBooleanInWhere() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Opportunity WHERE IsClosed = true';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testGreaterThanOperator() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Opportunity WHERE Amount >= 10000';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
+
+	@IsTest
+	private static void testLessThanOperator() {
+		DatabaseLayer.useMocks();
+		String input = 'SELECT Id FROM Account WHERE NumberOfEmployees <= 100';
+		Soql query = DatabaseLayer.newSoql(input);
+		String output = query?.toString();
+		Assert.areEqual(input, output);
+	}
 }

--- a/src/core/classes/SoqlParserTest.cls
+++ b/src/core/classes/SoqlParserTest.cls
@@ -422,16 +422,16 @@ private class SoqlParserTest {
 	}
 
 	@IsTest
-	private static void shouldSkipSubqueryMissingFrom() {
+	private static void shouldGracefullyIgnoreMalformedSubquery() {
+		// A subquery without a FROM clause should be silently skipped, leaving other fields intact
 		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-		Soql.Builder builder = DatabaseLayer.newSoql('SELECT Id FROM Account');
+		Soql soql = DatabaseLayer.newSoql('SELECT (SELECT Id, Name), Id FROM Account');
 
 		Test.startTest();
-		parser.parseSubquery(builder, '(SELECT Id, Name)');
+		String result = soql?.toString();
 		Test.stopTest();
 
-		Assert.isNotNull(builder?.toString(), 'Expected builder to remain valid after malformed subquery');
+		Assert.areEqual('SELECT Id FROM Account', result, 'Expected malformed subquery to be silently ignored');
 	}
 
 	@IsTest
@@ -461,54 +461,6 @@ private class SoqlParserTest {
 	}
 
 	@IsTest
-	private static void shouldParseNullLiteral() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('null');
-		Test.stopTest();
-
-		Assert.isNull(result, 'Expected null for null literal');
-	}
-
-	@IsTest
-	private static void shouldParseTrueLiteral() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('true');
-		Test.stopTest();
-
-		Assert.areEqual(true, (Boolean) result, 'Expected Boolean true');
-	}
-
-	@IsTest
-	private static void shouldParseFalseLiteral() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('false');
-		Test.stopTest();
-
-		Assert.areEqual(false, (Boolean) result, 'Expected Boolean false');
-	}
-
-	@IsTest
-	private static void shouldParseIntegerLiteral() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('12345');
-		Test.stopTest();
-
-		Assert.areEqual(12345, (Integer) result, 'Expected Integer 12345');
-	}
-
-	@IsTest
 	private static void shouldParseDecimalLiteral() {
 		DatabaseLayer.useMocks();
 		SoqlParser parser = new SoqlParser();
@@ -518,66 +470,6 @@ private class SoqlParserTest {
 		Test.stopTest();
 
 		Assert.areEqual(123.45, (Decimal) result, 'Expected Decimal 123.45');
-	}
-
-	@IsTest
-	private static void shouldParseQuotedString() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('\'test value\'');
-		Test.stopTest();
-
-		Assert.areEqual('test value', (String) result, 'Expected unquoted string value');
-	}
-
-	@IsTest
-	private static void shouldParseBindVariable() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue(':bindVar');
-		Test.stopTest();
-
-		Assert.areEqual(':bindVar', (String) result, 'Expected bind variable passed through unchanged');
-	}
-
-	@IsTest
-	private static void shouldParseListValue() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('(\'A\', \'B\', \'C\')');
-		Test.stopTest();
-
-		Assert.isNotNull(result, 'Expected non-null list result');
-	}
-
-	@IsTest
-	private static void shouldParseDateValue() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('2020-06-15');
-		Test.stopTest();
-
-		Assert.isNotNull(result, 'Expected non-null date result');
-	}
-
-	@IsTest
-	private static void shouldParseDateTimeValue() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Object result = parser.parseValue('2020-06-15T10:30:00Z');
-		Test.stopTest();
-
-		Assert.isNotNull(result, 'Expected non-null datetime result');
 	}
 
 	@IsTest
@@ -591,48 +483,6 @@ private class SoqlParserTest {
 		Test.stopTest();
 
 		Assert.areEqual('TODAY', (String) result, 'Expected unrecognized token returned as-is');
-	}
-
-	@IsTest
-	private static void shouldParseConditionFields() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Soql.Condition condition = parser.parseCondition('Amount = 5000');
-		Test.stopTest();
-
-		Assert.isNotNull(condition, 'Expected a condition to be returned');
-		Assert.areEqual('Amount', condition.property, 'Expected field name parsed correctly');
-	}
-
-	@IsTest
-	private static void shouldFindAllKeywordPositions() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-
-		Test.startTest();
-		Map<String, Integer> positions = parser.findKeywordPositions('SELECT Id FROM Account WHERE Name = \'Test\'');
-		Test.stopTest();
-
-		Assert.isTrue(positions.containsKey('SELECT'), 'Expected SELECT position');
-		Assert.isTrue(positions.containsKey('FROM'), 'Expected FROM position');
-		Assert.isTrue(positions.containsKey('WHERE'), 'Expected WHERE position');
-	}
-
-	@IsTest
-	private static void shouldExtractSelectClause() {
-		DatabaseLayer.useMocks();
-		SoqlParser parser = new SoqlParser();
-		String queryStr = 'SELECT Id, Name FROM Account WHERE Active = true';
-		Map<String, Integer> positions = parser.findKeywordPositions(queryStr);
-
-		Test.startTest();
-		String selectClause = parser.extractClause(queryStr, positions, 'SELECT', 'FROM');
-		Test.stopTest();
-
-		Assert.isTrue(selectClause.containsIgnoreCase('Id'), 'Expected Id in SELECT clause');
-		Assert.isTrue(selectClause.containsIgnoreCase('Name'), 'Expected Name in SELECT clause');
 	}
 
 	@IsTest

--- a/src/core/classes/SoqlParserTest.cls-meta.xml
+++ b/src/core/classes/SoqlParserTest.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>66.0</apiVersion>
+    <status>Active</status>
+</ApexClass>

--- a/src/core/classes/SoqlParserTest.cls-meta.xml
+++ b/src/core/classes/SoqlParserTest.cls-meta.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
     <apiVersion>66.0</apiVersion>
     <status>Active</status>

--- a/src/core/classes/SoqlTest.cls
+++ b/src/core/classes/SoqlTest.cls
@@ -1543,7 +1543,7 @@ private class SoqlTest {
 		Exception caughtError;
 		try {
 			// Can't query w/a null FROM object:
-			DatabaseLayer.Soql.newQuery(null)?.toSoql()?.query();
+			DatabaseLayer.Soql.newQuery((SObjectType) null)?.toSoql()?.query();
 			Assert.fail('Did not throw an Exception');
 		} catch (Exception error) {
 			// As expected...

--- a/wiki/The-DatabaseLayer-Class.md
+++ b/wiki/The-DatabaseLayer-Class.md
@@ -137,3 +137,22 @@ This is the default state of the application; there is no need to call it unless
 This static method is only visible in the `@IsTest` context.
 
 - `static Duplicates useRealDuplicates()`
+
+### `newSoql`
+
+Convenience method to create a new SOQL query from a raw query string. This method delegates to the current SOQL provider's `newQuery(String)` method, ensuring that the returned instance will be mock-aware when `DatabaseLayer.useMocks()` has been called.
+
+- `static Soql newSoql(String queryString)`
+
+**Parameters:**
+- `queryString` (String): The raw SOQL query string to parse
+
+**Return Value:**
+- Soql: A configured SOQL instance with parsed query state
+
+**Example Usage:**
+```apex
+// Parse an existing query string into a Soql object
+Soql query = DatabaseLayer.newSoql('SELECT Id, Name FROM Account WHERE Type != \'Internal\' LIMIT 200');
+List<Account> accounts = (List<Account>) query.query();
+```

--- a/wiki/The-DatabaseLayer.SoqlProvider-Class.md
+++ b/wiki/The-DatabaseLayer.SoqlProvider-Class.md
@@ -3,13 +3,17 @@ This class is responsible for generating new `Soql` query objects. After `Databa
 Callers access this class via the [`DatabaseLayer`](./The-DatabaseLayer-Class)'s `Soql` property:
 
 ```apex
-// Generate a real SOQL query:
+// Generate a real SOQL query from SObjectType:
 Soql query1 = DatabaseLayer.Soql.newQuery(Account.SObjectType);
 Assert.isNotInstanceofType(query1, MockSoql.class, 'Is a Mock');
+
+// Generate a real SOQL query from string:
+Soql query2 = DatabaseLayer.Soql.newQuery('SELECT Id, Name FROM Account WHERE Type != \'Internal\'');
+
 // Generate a mock SOQL query:
 DatabaseLayer.useMocks();
-Soql query2 = DatabaseLayer.Soql.newQuery(Account.SObjectType);
-Assert.isInstanceofType(query2, MockSoql.class, 'Not a Mock');
+Soql query3 = DatabaseLayer.Soql.newQuery(Account.SObjectType);
+Assert.isInstanceofType(query3, MockSoql.class, 'Not a Mock');
 ```
 
 ---
@@ -18,6 +22,7 @@ Assert.isInstanceofType(query2, MockSoql.class, 'Not a Mock');
 
 #### `newQuery`
 
-Generates a new `Soql` query using the given `SObjectType` as the FROM object.
+Generates a new `Soql` query using the given `SObjectType` as the FROM object or by parsing a raw SOQL query string.
 
 - `Soql newQuery(SObjectType objectType)`
+- `Soql newQuery(String queryString)`

--- a/wiki/The-Soql-Class.md
+++ b/wiki/The-Soql-Class.md
@@ -6,9 +6,11 @@ Use this class in place of inline SOQL to pave the way for faster, more scalable
 
 ## Constructing `Soql` Objects
 
-`Soql` objects cannot be directly constructed via the `new` keyword. Instead, use the `DatabaseLayer.Soql.newQuery(SObjectType fromSObject)` method.
+There are two ways to construct `Soql` objects:
 
-The object uses the [Soql.Builder](./The-Soql.Builder-Class) class to allow for flexible query construction. Once your query is built, call [`toSoql()`](./The-Soql.Builder-Class#toSoql) to build the query as a `Soql` object:
+### 1. Using the Factory Method (Recommended)
+
+Use the `DatabaseLayer.Soql.newQuery(SObjectType fromSObject)` method for new queries:
 
 ```apex
 Soql query = DatabaseLayer.Soql
@@ -18,7 +20,17 @@ Soql query = DatabaseLayer.Soql
   ?.toSoql();
 ```
 
-In `@IsTest` context, the `DatabaseLayer.useMocks()` method ensures that an instance of the `MockSoql` class will be returned for each subsuquent `newQuery` call:
+### 2. Using String Constructor
+
+Parse existing SOQL query strings using the `DatabaseLayer.Soql.newQuery(String queryString)` factory method:
+
+```apex
+Soql query = DatabaseLayer.Soql.newQuery('SELECT Id, Name FROM Account WHERE Type != \'Internal\' LIMIT 200');
+```
+
+The object uses the [Soql.Builder](./The-Soql.Builder-Class) class to allow for flexible query construction. Once your query is built, call [`toSoql()`](./The-Soql.Builder-Class#toSoql) to build the query as a `Soql` object.
+
+In `@IsTest` context, the `DatabaseLayer.useMocks()` method ensures that an instance of the `MockSoql` class will be returned for each subsequent `newQuery` call:
 
 ```apex
 DatabaseLayer.useMocks();

--- a/wiki/The-Soql.Builder-Class.md
+++ b/wiki/The-Soql.Builder-Class.md
@@ -69,10 +69,16 @@ Removes all fields from the SELECT clause of the query, essentially clearing any
 
 Adds fields to the ORDER BY clause of the query.
 
-- `Soql.Builder addOderBy(Soql.SortOrder sortOrder)`
-- `Soql.Builder addOderBy(String fieldName, Soql.SortDirection direction)`
-- `Soql.Builder addOderBy(SObjectField field, Soql.SortDirection direction)`
-- `Soql.Builder addOderBy(Soql.ParentField field, Soql.SortDirection direction)`
+- `Soql.Builder addOrderBy(Soql.SortOrder sortOrder)`
+- `Soql.Builder addOrderBy(String fieldName, Soql.SortDirection direction)`
+- `Soql.Builder addOrderBy(SObjectField field, Soql.SortDirection direction)`
+- `Soql.Builder addOrderBy(Soql.ParentField field, Soql.SortDirection direction)`
+
+### `addRawOrderBy`
+
+Adds a raw ORDER BY clause to the query. This method allows specifying ORDER BY clauses that may include complex expressions or syntax not directly supported by the typed methods.
+
+- `Soql.Builder addRawOrderBy(String rawClause)`
 
 ### `reset`
 
@@ -97,6 +103,7 @@ Sets the access level for the query.
 Sets the entity from which to query data. Only call this method if you need to override the SObjectType set when constructing the query, via the `DatabaseLayer.Soql.newQuery(SObjectType objectType)` method.
 
 - `Soql.Builder setFrom(SObjectType objectType)`
+- `Soql.Builder setFrom(String entityName)`
 
 ### `setOuterHavingLogic`
 
@@ -109,6 +116,18 @@ Sets the logical operator (AND/OR) for combining HAVING conditions.
 Sets the logical operator (AND/OR) for combining WHERE conditions.
 
 - `Soql.Builder setOuterWhereLogic(Soql.LogicType newLogicType)`
+
+### `setWhereCriteria`
+
+Sets the WHERE clause criteria for the query using a ConditionalLogic object. This method allows setting complex criteria structures built from multiple conditions.
+
+- `Soql.Builder setWhereCriteria(Soql.ConditionalLogic criteria)`
+
+### `setHavingCriteria`
+
+Sets the HAVING clause criteria for the query using a ConditionalLogic object. This method allows setting complex criteria structures built from multiple conditions for aggregate queries.
+
+- `Soql.Builder setHavingCriteria(Soql.ConditionalLogic criteria)`
 
 ### `setQueryIdentifier`
 


### PR DESCRIPTION
This adds a `SoqlParser` class that parses raw SOQL query strings into structured `Soql.Builder` representations. The parser handles all standard SOQL clauses — SELECT, FROM, WHERE, GROUP BY, HAVING, ORDER BY, LIMIT, OFFSET, USING SCOPE, WITH, FOR, and ALL ROWS — enabling round-trip fidelity between string queries and the builder API.

To wire this in, `Soql` gains a string-based constructor (`new Soql(queryString)`) that delegates to `SoqlParser`, and `DatabaseLayer` gets a matching factory method (`DatabaseLayer.newSoql(String)`) so callers get mock-aware behavior automatically. A handful of new `global` builder methods (`setFrom`, `setWhereCriteria`, `setHavingCriteria`, `addRawOrderBy`) were added to give the parser the surface area it needs to reconstruct query state without bypassing encapsulation.