### PR TITLE
Fix package name in sfdx-project.json

### DIFF
--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -3,7 +3,7 @@
 		{
 			"path": "src/core",
 			"default": true,
-			"package": "Apex Database Layer",
+			"package": "apex-database-layer",
 			"versionName": "v4.0.0",
 			"versionNumber": "4.0.0.NEXT"
 		},


### PR DESCRIPTION
The package name in sfdx-project.json was using spaces ('Apex Database Layer') which caused a CI failure. This updates it to use hyphens ('apex-database-layer') to match standard package naming conventions.