### PR TITLE
Fix: Use Salesforce API as authoritative source for package versioning

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -111,14 +111,28 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
-          if [[ -z "$INPUT_VERSION" ]]; then
-            VERSION_NUMBER=$(jq -r --arg pkg "$PACKAGE" \
-              '.packageDirectories[] | select(.package == $pkg) | .versionNumber' \
-              sfdx-project.json)
-            echo "Using the version number defined in sfdx-project.json: $VERSION_NUMBER"
-          else
+          if [[ -n "$INPUT_VERSION" ]]; then
             VERSION_NUMBER="${INPUT_VERSION}.NEXT"
             echo "Using specified version number: $VERSION_NUMBER"
+          else
+            LATEST=$(sf package version list --package "$PACKAGE" --json | \
+              jq -r '[.result[] | select(.CreatedStatus == "Success")] | sort_by(.MajorVersion, .MinorVersion, .PatchVersion, .BuildNumber) | last')
+            if [[ -z "$LATEST" || "$LATEST" == "null" ]]; then
+              VERSION_NUMBER=$(jq -r --arg pkg "$PACKAGE" \
+                '.packageDirectories[] | select(.package == $pkg) | .versionNumber' \
+                sfdx-project.json)
+              echo "No existing versions found; using sfdx-project.json: $VERSION_NUMBER"
+            else
+              MAJOR=$(echo "$LATEST" | jq -r '.MajorVersion')
+              MINOR=$(echo "$LATEST" | jq -r '.MinorVersion')
+              PATCH=$(echo "$LATEST" | jq -r '.PatchVersion')
+              IS_RELEASED=$(echo "$LATEST" | jq -r '.IsReleased')
+              if [[ "$IS_RELEASED" == "true" ]]; then
+                PATCH=$((PATCH + 1))
+              fi
+              VERSION_NUMBER="${MAJOR}.${MINOR}.${PATCH}.NEXT"
+              echo "Computed version from Salesforce: $VERSION_NUMBER (IsReleased=${IS_RELEASED})"
+            fi
           fi
           VERSION_NAME="v${VERSION_NUMBER%.NEXT}"
           echo "version-number=$VERSION_NUMBER" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,28 +51,15 @@ jobs:
           while IFS= read -r entry; do
             PKG_ALIAS=$(echo "$entry" | jq -r '.package')
             PKG_PATH=$(echo "$entry" | jq -r '.path')
-            CURR_VERSION=$(echo "$entry" | jq -r '.versionNumber' | sed 's/\.NEXT$//')
 
             # Include package if: workflow_dispatch (run all), or files changed under its path
             if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] || \
                git diff --name-only HEAD~1 HEAD | grep -q "^${PKG_PATH}/"; then
 
-              # On push: auto-increment patch if version is unchanged from previous commit
-              if [[ "${{ github.event_name }}" == "push" ]]; then
-                PREV_VERSION=$(git show HEAD~1:sfdx-project.json | \
-                  jq -r --arg path "$PKG_PATH" \
-                  '.packageDirectories[] | select(.path == $path) | .versionNumber' | \
-                  sed 's/\.NEXT$//')
-                if [[ "$CURR_VERSION" == "$PREV_VERSION" ]]; then
-                  IFS='.' read -ra P <<< "$CURR_VERSION"
-                  CURR_VERSION="${P[0]}.${P[1]}.$((P[2] + 1))"
-                  echo "Auto-incremented $PKG_ALIAS version to $CURR_VERSION"
-                fi
-              fi
-
               PACKAGES=$(echo "$PACKAGES" | jq \
-                --arg pkg "$PKG_ALIAS" --arg ver "$CURR_VERSION" \
-                '. + [{"package": $pkg, "version": $ver}]')
+                --arg pkg "$PKG_ALIAS" \
+                '. + [{"package": $pkg}]')
+              echo "Detected changes in $PKG_ALIAS"
             fi
           done < <(jq -c '.packageDirectories[] | select(.package != null)' sfdx-project.json)
 
@@ -97,7 +84,6 @@ jobs:
     secrets: inherit
     with:
       package: ${{ matrix.pkg.package }}
-      version: ${{ matrix.pkg.version }}
       promote: ${{ inputs.promote || false }}
       create-release: ${{ inputs.create-release == true || github.event_name == 'push' }}
       skip-validation: ${{ inputs.skip-validation || false }}


### PR DESCRIPTION
The release workflow had a fragile versioning strategy that caused duplicate package versions and triggered releases for packages with no code changes. The `detect-changes` job was tracking version state by comparing `sfdx-project.json` between commits and auto-incrementing the patch when the version looked unchanged — but this approach breaks down whenever a run fails mid-flight, the file gets out of sync, or multiple packages run in parallel and race on the same state.

The fix separates concerns cleanly: `release.yml` now only answers "which packages have changed files?" and passes just the package name downstream. `packaging.yml` takes responsibility for version determination by querying Salesforce directly via `sf package version list`, sorting by semver, and checking `IsReleased` on the latest successfully-created version. If that version has been promoted, it bumps the patch; if not, it reuses the same version number. Salesforce is the authoritative system here, so querying it directly is the right source of truth rather than attempting to reconstruct state from git history.