### PR TITLE
Fix: Correct --packages flag and null guard for sf package version list

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -115,8 +115,9 @@ jobs:
             VERSION_NUMBER="${INPUT_VERSION}.NEXT"
             echo "Using specified version number: $VERSION_NUMBER"
           else
-            LATEST=$(sf package version list --package "$PACKAGE" --json | \
-              jq -r '[.result[] | select(.CreatedStatus == "Success")] | sort_by(.MajorVersion, .MinorVersion, .PatchVersion, .BuildNumber) | last')
+            SF_RESULT=$(sf package version list --packages "$PACKAGE" --json 2>&1 || true)
+            LATEST=$(echo "$SF_RESULT" | \
+              jq -r '[(.result // [])[] | select(.CreatedStatus == "Success")] | sort_by(.MajorVersion, .MinorVersion, .PatchVersion, .BuildNumber) | last')
             if [[ -z "$LATEST" || "$LATEST" == "null" ]]; then
               VERSION_NUMBER=$(jq -r --arg pkg "$PACKAGE" \
                 '.packageDirectories[] | select(.package == $pkg) | .versionNumber' \


### PR DESCRIPTION
The previous fix introduced a call to `sf package version list` but used the wrong flag name: `--package` (singular) instead of `--packages` (plural). When the flag is unrecognized, the SF CLI returns `{"result": null}` in JSON mode rather than raising a shell error. This caused jq to crash with "Cannot iterate over null (null)" and exit code 5, failing both package jobs every time.

Two changes: the flag is corrected to `--packages`, and the jq filter now uses `(.result // [])` so a null result is treated as an empty version list rather than a crash. The SF CLI call also captures its output separately with `|| true` so any future unexpected SF CLI errors degrade gracefully to the sfdx-project.json version fallback instead of aborting the job.