### PR TITLE
Fix: Correctly resolve package ID for sf package version list

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -115,8 +115,22 @@ jobs:
             VERSION_NUMBER="${INPUT_VERSION}.NEXT"
             echo "Using specified version number: $VERSION_NUMBER"
           else
-            LATEST=$(sf package version list --package "$PACKAGE" --json | \
-              jq -r '[.result[] | select(.CreatedStatus == "Success")] | sort_by(.MajorVersion, .MinorVersion, .PatchVersion, .BuildNumber) | last')
+            # Resolve the 0Ho package ID from packageAliases (required by sf package version list).
+            # packageDirectories.package may not match the alias key directly (e.g. "Apex Database
+            # Layer" vs "apex-database-layer"), so try exact match first, then normalize.
+            PACKAGE_ID=$(jq -r --arg pkg "$PACKAGE" '.packageAliases[$pkg] // empty' sfdx-project.json)
+            if [[ -z "$PACKAGE_ID" ]]; then
+              NORM=$(echo "$PACKAGE" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+              PACKAGE_ID=$(jq -r --arg key "$NORM" '.packageAliases[$key] // empty' sfdx-project.json)
+            fi
+
+            LATEST="null"
+            if [[ -n "$PACKAGE_ID" ]]; then
+              SF_RESULT=$(sf package version list --packages "$PACKAGE_ID" --json 2>&1 || true)
+              LATEST=$(echo "$SF_RESULT" | \
+                jq -r '[(.result // [])[] | .] | sort_by(.MajorVersion, .MinorVersion, .PatchVersion, .BuildNumber) | last')
+            fi
+
             if [[ -z "$LATEST" || "$LATEST" == "null" ]]; then
               VERSION_NUMBER=$(jq -r --arg pkg "$PACKAGE" \
                 '.packageDirectories[] | select(.package == $pkg) | .versionNumber' \


### PR DESCRIPTION
Two bugs in the Salesforce version query introduced in #172, verified against the live devhub before this fix was written.

**Bug 1 — wrong identifier for `sf package version list`:** The command requires a 0Ho package ID or a key from `packageAliases`, not the display name from `packageDirectories.package`. Passing `"Apex Database Layer"` (the display name) returns `InvalidPackageIdError` with no `result` key, which caused jq to crash with "Cannot iterate over null (null)" and exit code 5. The fix looks up the 0Ho ID from `packageAliases` using the package name as the key, with a normalized fallback (lowercase + hyphens) for packages like "Apex Database Layer" → "apex-database-layer".

**Bug 2 — filter on a non-existent field:** `select(.CreatedStatus == "Success")` always matched nothing because `CreatedStatus` is not a field in the `sf package version list` response. The response includes `IsReleased` (which is already used downstream to decide whether to bump the patch). The fix removes the `CreatedStatus` filter entirely and sorts all returned versions to find the latest.

Both bugs were confirmed by running the actual `sf` commands against the apex-starter-pack devhub before writing the fix.