### PR TITLE
Fix: Use --autostash on rebase in Pull Latest Changes step

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -205,10 +205,12 @@ jobs:
         shell: bash
         run: |
           git fetch origin main
-          git rebase origin/main || {
+          git rebase --autostash origin/main || {
             echo "Rebase failed, trying merge strategy"
             git rebase --abort 2>/dev/null || true
+            git stash
             git pull --no-rebase origin main
+            git stash pop || true
           }
 
       - name: Tag & Commit Changes


### PR DESCRIPTION
The Pull Latest Changes step was failing with 'cannot rebase: You have unstaged changes' because the Update Package Version and Run Prettier steps both modify sfdx-project.json before the pull runs. Adding --autostash tells git to stash the local changes automatically before rebasing and reapply them after, so the pull succeeds without touching the pending sfdx-project.json edits. The merge fallback path gets the same treatment with an explicit stash/pop.